### PR TITLE
[Feat] 네트워크 모듈 구현

### DIFF
--- a/Livith-iOS/Projects/Network/Resources/Info.plist
+++ b/Livith-iOS/Projects/Network/Resources/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CURRENT_VERSION</key>
+	<string>$(CURRENT_VERSION)</string>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
 </dict>

--- a/Livith-iOS/Projects/Network/Sources/DTO/Base/BaseResponse.swift
+++ b/Livith-iOS/Projects/Network/Sources/DTO/Base/BaseResponse.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct BaseResponse<T: Decodable>: Decodable {
+public struct BaseResponse<T: Decodable>: Decodable {
     let statusCode: Int
     let message: String
     let data: T?

--- a/Livith-iOS/Projects/Network/Sources/DTO/Base/BaseResponse.swift
+++ b/Livith-iOS/Projects/Network/Sources/DTO/Base/BaseResponse.swift
@@ -1,0 +1,15 @@
+//
+//  BaseResponse.swift
+//  network
+//
+//  Created by Youjin Lee on 10/12/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+struct BaseResponse<T: Decodable>: Decodable {
+    let statusCode: Int
+    let message: String
+    let data: T?
+}

--- a/Livith-iOS/Projects/Network/Sources/DTO/Base/DTO.swift
+++ b/Livith-iOS/Projects/Network/Sources/DTO/Base/DTO.swift
@@ -1,0 +1,14 @@
+//
+//  DTO.swift
+//  network
+//
+//  Created by Youjin Lee on 10/12/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+enum DTO {
+    enum Request {}
+    enum Response {}
+}

--- a/Livith-iOS/Projects/Network/Sources/DTO/Base/DTO.swift
+++ b/Livith-iOS/Projects/Network/Sources/DTO/Base/DTO.swift
@@ -9,6 +9,6 @@
 import Foundation
 
 public enum DTO {
-    enum Request {}
-    enum Response {}
+    public enum Request {}
+    public enum Response {}
 }

--- a/Livith-iOS/Projects/Network/Sources/DTO/Base/DTO.swift
+++ b/Livith-iOS/Projects/Network/Sources/DTO/Base/DTO.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum DTO {
+public enum DTO {
     enum Request {}
     enum Response {}
 }

--- a/Livith-iOS/Projects/Network/Sources/DTO/Base/EmptyResponse.swift
+++ b/Livith-iOS/Projects/Network/Sources/DTO/Base/EmptyResponse.swift
@@ -1,0 +1,11 @@
+//
+//  EmptyResponse.swift
+//  network
+//
+//  Created by Youjin Lee on 10/12/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+public struct EmptyResponse: Decodable {}

--- a/Livith-iOS/Projects/Network/Sources/DTO/Base/ErrorResponse.swift
+++ b/Livith-iOS/Projects/Network/Sources/DTO/Base/ErrorResponse.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct ErrorResponse: Decodable {
+public struct ErrorResponse: Decodable {
     let statusCode: Int
     let message: String
     let error: String?

--- a/Livith-iOS/Projects/Network/Sources/DTO/Base/ErrorResponse.swift
+++ b/Livith-iOS/Projects/Network/Sources/DTO/Base/ErrorResponse.swift
@@ -1,0 +1,15 @@
+//
+//  ErrorResponse.swift
+//  network
+//
+//  Created by Youjin Lee on 10/12/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+struct ErrorResponse: Decodable {
+    let statusCode: Int
+    let message: String
+    let error: String?
+}

--- a/Livith-iOS/Projects/Network/Sources/MultipartData.swift
+++ b/Livith-iOS/Projects/Network/Sources/MultipartData.swift
@@ -1,0 +1,29 @@
+//
+//  MultipartData.swift
+//  network
+//
+//  Created by Youjin Lee on 10/12/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+/// Multipart 업로드에 사용할 데이터 구조체
+public struct MultipartData {
+    public let data: Data
+    public let name: String
+    public let fileName: String
+    public let mimeType: String
+
+    public init(
+        data: Data,
+        name: String,
+        fileName: String,
+        mimeType: String
+    ) {
+        self.data = data
+        self.name = name
+        self.fileName = fileName
+        self.mimeType = mimeType
+    }
+}

--- a/Livith-iOS/Projects/Network/Sources/NetworkEndpoint.swift
+++ b/Livith-iOS/Projects/Network/Sources/NetworkEndpoint.swift
@@ -13,11 +13,13 @@ import Alamofire
 public protocol NetworkEndpoint {
     var endPoint: String? { get }
     var method: HTTPMethod { get }
+    var headers: HTTPHeaders? { get }
     var query: [String: Any]? { get }
     var body: Encodable? { get }
 }
 
 public extension NetworkEndpoint {
+    var headers: HTTPHeaders? { .none }
     var query: [String: Any]? { .none }
     var body: Encodable? { .none }
 }

--- a/Livith-iOS/Projects/Network/Sources/NetworkEndpoint.swift
+++ b/Livith-iOS/Projects/Network/Sources/NetworkEndpoint.swift
@@ -1,0 +1,23 @@
+//
+//  RequestDescription.swift
+//  network
+//
+//  Created by Youjin Lee on 10/12/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+import Alamofire
+
+public protocol NetworkEndpoint {
+    var endPoint: String? { get }
+    var method: HTTPMethod { get }
+    var query: [String: Any]? { get }
+    var body: Encodable? { get }
+}
+
+public extension NetworkEndpoint {
+    var query: [String: Any]? { .none }
+    var body: Encodable? { .none }
+}

--- a/Livith-iOS/Projects/Network/Sources/NetworkExtension/Bundle+.swift
+++ b/Livith-iOS/Projects/Network/Sources/NetworkExtension/Bundle+.swift
@@ -1,0 +1,34 @@
+//
+//  Bundle+.swift
+//  network
+//
+//  Created by Youjin Lee on 10/12/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+public extension Bundle {
+    static let versionedBaseURL: URL = {
+        guard let url = URL(string: baseURL + version) else {
+            fatalError("BASE_URL에서 추출한 문자열을 URL로 변환할 수 없습니다.")
+        }
+        
+        return url
+    }()
+}
+
+private extension Bundle {
+    static func object(dictionaryKey: String) -> String {
+        guard let object = main.object(forInfoDictionaryKey: dictionaryKey) as? String else {
+            fatalError("\(dictionaryKey)을 찾을 수 없습니다.")
+        }
+        
+        return object
+    }
+}
+
+private extension Bundle {
+    static let baseURL: String = object(dictionaryKey: "BASE_URL")
+    static let version: String = object(dictionaryKey: "CURRENT_VERSION")
+}

--- a/Livith-iOS/Projects/Network/Sources/NetworkHelper/ErrorMapper.swift
+++ b/Livith-iOS/Projects/Network/Sources/NetworkHelper/ErrorMapper.swift
@@ -1,0 +1,38 @@
+//
+//  ErrorMapper.swift
+//  network
+//
+//  Created by Youjin Lee on 10/12/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+import Alamofire
+
+public protocol ErrorMapperProtocol {
+    func map(_ error: Error) -> NetworkError
+}
+
+public final class ErrorMapper: ErrorMapperProtocol {
+    public init() {}
+
+    public func map(_ error: Error) -> NetworkError {
+        if let networkError = error as? NetworkError {
+            return networkError
+        }
+
+        if let afError = error as? AFError {
+            switch afError {
+            case .invalidURL:
+                return .invalidURL
+            case .responseValidationFailed:
+                return .invalidResponse
+            default:
+                return .unknown(afError)
+            }
+        }
+
+        return .unknown(error)
+    }
+}

--- a/Livith-iOS/Projects/Network/Sources/NetworkHelper/NetworkError.swift
+++ b/Livith-iOS/Projects/Network/Sources/NetworkHelper/NetworkError.swift
@@ -1,0 +1,90 @@
+//
+//  NetworkError.swift
+//  network
+//
+//  Created by Youjin Lee on 10/12/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+public enum NetworkError: Error {
+    
+    // MARK: Request Error
+    
+    case invalidURL
+    case invalidRequest
+
+    // MARK: Response Error
+    
+    case noData
+    case invalidResponse
+    case decodingFailed(Error)
+
+    // MARK: HTTP Error
+    
+    case badRequest(message: String?)
+    case unauthorized(message: String?)
+    case forbidden(message: String?)
+    case notFound(message: String?)
+    case serverError(message: String?)
+    case clientError(statusCode: Int, message: String?)
+
+    // MARK: Unknown Error
+    
+    case unknown(Error)
+}
+
+extension NetworkError {
+    static func from(statusCode: Int, message: String? = nil) -> NetworkError {
+        switch statusCode {
+        case 400:
+            return .badRequest(message: message)
+        case 401:
+            return .unauthorized(message: message)
+        case 403:
+            return .forbidden(message: message)
+        case 404:
+            return .notFound(message: message)
+        case 400 ..< 500:
+            return .clientError(statusCode: statusCode, message: message)
+        case 500 ..< 600:
+            return .serverError(message: message)
+        default:
+            return .invalidResponse
+        }
+    }
+}
+
+extension NetworkError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "유효하지 않은 URL입니다."
+        case .invalidRequest:
+            return "잘못된 요청입니다."
+        case .invalidResponse:
+            return "서버 응답이 유효하지 않습니다."
+        case .noData:
+            return "응답 데이터가 없습니다."
+
+        case .badRequest(let message):
+            return "잘못된 요청입니다 (400): \(message ?? "")"
+        case .unauthorized(let message):
+            return "인증이 필요합니다 (401): \(message ?? "")"
+        case .forbidden(let message):
+            return "접근 권한이 없습니다 (403): \(message ?? "")"
+        case .notFound(let message):
+            return "요청한 리소스를 찾을 수 없습니다 (404): \(message ?? "")"
+        case .serverError(let message):
+            return "서버 에러가 발생했습니다 (5xx): \(message ?? "")"
+        case .clientError(let statusCode, let message):
+            return "클라이언트 에러입니다 (\(statusCode)): \(message ?? "")"
+
+        case .decodingFailed(let error):
+            return "데이터 디코딩에 실패했습니다: \(error.localizedDescription)"
+        case .unknown(let error):
+            return "알 수 없는 에러입니다: \(error.localizedDescription)"
+        }
+    }
+}

--- a/Livith-iOS/Projects/Network/Sources/NetworkHelper/NetworkError.swift
+++ b/Livith-iOS/Projects/Network/Sources/NetworkHelper/NetworkError.swift
@@ -35,7 +35,7 @@ public enum NetworkError: Error {
     case unknown(Error)
 }
 
-extension NetworkError {
+public extension NetworkError {
     static func from(statusCode: Int, message: String? = nil) -> NetworkError {
         switch statusCode {
         case 400:
@@ -56,7 +56,7 @@ extension NetworkError {
     }
 }
 
-extension NetworkError: LocalizedError {
+public extension NetworkError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .invalidURL:

--- a/Livith-iOS/Projects/Network/Sources/NetworkHelper/NetworkError.swift
+++ b/Livith-iOS/Projects/Network/Sources/NetworkHelper/NetworkError.swift
@@ -56,7 +56,7 @@ public extension NetworkError {
     }
 }
 
-public extension NetworkError: LocalizedError {
+extension NetworkError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .invalidURL:

--- a/Livith-iOS/Projects/Network/Sources/NetworkHelper/ResponseHandler.swift
+++ b/Livith-iOS/Projects/Network/Sources/NetworkHelper/ResponseHandler.swift
@@ -30,7 +30,7 @@ public final class ResponseHandler: ResponseHandlerProtocol {
             let statusCode = httpResponse.statusCode
 
             guard (200..<300).contains(statusCode) else {
-                let errorMessage = try? JSONDecoder().decode(ErrorResponse.self, from: data).message
+                let errorMessage = try? decoder.decode(ErrorResponse.self, from: data).message
                 throw NetworkError.from(statusCode: statusCode, message: errorMessage)
             }
         }

--- a/Livith-iOS/Projects/Network/Sources/NetworkHelper/ResponseHandler.swift
+++ b/Livith-iOS/Projects/Network/Sources/NetworkHelper/ResponseHandler.swift
@@ -1,0 +1,47 @@
+//
+//  ResponseHandler.swift
+//  network
+//
+//  Created by Youjin Lee on 10/12/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+import Alamofire
+
+public protocol ResponseHandlerProtocol {
+    func handle<T: Decodable>(_ response: DataResponse<T, AFError>) throws -> T
+}
+
+public final class ResponseHandler: ResponseHandlerProtocol {
+    private let decoder: JSONDecoder
+
+    public init(decoder: JSONDecoder = JSONDecoder()) {
+        self.decoder = decoder
+    }
+
+    public func handle<T: Decodable>(_ response: DataResponse<T, AFError>) throws -> T {
+        guard let data = response.data else {
+            throw NetworkError.noData
+        }
+
+        if let httpResponse = response.response {
+            let statusCode = httpResponse.statusCode
+
+            guard (200..<300).contains(statusCode) else {
+                let errorMessage = try? JSONDecoder().decode(ErrorResponse.self, from: data).message
+                throw NetworkError.from(statusCode: statusCode, message: errorMessage)
+            }
+        }
+
+        guard let value = response.value else {
+            if let error = response.error {
+                throw NetworkError.decodingFailed(error)
+            }
+            throw NetworkError.invalidResponse
+        }
+
+        return value
+    }
+}

--- a/Livith-iOS/Projects/Network/Sources/NetworkService.swift
+++ b/Livith-iOS/Projects/Network/Sources/NetworkService.swift
@@ -1,0 +1,81 @@
+//
+//  NetworkService.swift
+//  network
+//
+//  Created by Youjin Lee on 10/12/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+import Alamofire
+
+public protocol NetworkServiceProtocol {
+    func request<T: Decodable>(_ endPoint: NetworkEndpoint) -> AnyPublisher<T, NetworkError>
+}
+
+public final class NetworkService: NetworkServiceProtocol {
+    private let responseHandler: ResponseHandlerProtocol
+    private let errorMapper: ErrorMapperProtocol
+
+    public init(
+        responseHandler: ResponseHandlerProtocol = ResponseHandler(),
+        errorMapper: ErrorMapperProtocol = ErrorMapper()
+    ) {
+        self.responseHandler = responseHandler
+        self.errorMapper = errorMapper
+    }
+}
+
+// MARK: - Request Method
+
+public extension NetworkService {
+    func request<T: Decodable>(_ endPoint: NetworkEndpoint) -> AnyPublisher<T, NetworkError> {
+        guard let endpoint = endPoint.endPoint else {
+            return Fail(error: NetworkError.invalidURL)
+                .eraseToAnyPublisher()
+        }
+
+        let url = Bundle.versionedBaseURL.appendingPathComponent(endpoint)
+        let dataRequest: DataRequest
+        
+        switch (endPoint.body, endPoint.query) {
+        case (let body?, _):
+            dataRequest = AF.request(
+                url,
+                method: endPoint.method,
+                parameters: body,
+                encoder: JSONParameterEncoder.default
+            )
+        case (_, let query?):
+            dataRequest = AF.request(
+                url,
+                method: endPoint.method,
+                parameters: query,
+                encoding: URLEncoding.queryString
+            )
+        default:
+            dataRequest = AF.request(url, method: endPoint.method)
+        }
+
+        return handleResponse(dataRequest)
+    }
+}
+
+
+// MARK: - Response Handling Extension
+
+private extension NetworkService {
+    func handleResponse<T: Decodable>(_ dataRequest: DataRequest) -> AnyPublisher<T, NetworkError> {
+        return dataRequest
+            .publishDecodable(type: T.self)
+            .tryMap { [responseHandler] response in
+                try responseHandler.handle(response)
+            }
+            .mapError { [errorMapper] error in
+                errorMapper.map(error)
+            }
+            .eraseToAnyPublisher()
+    }
+}

--- a/Livith-iOS/Projects/Network/Sources/NetworkService.swift
+++ b/Livith-iOS/Projects/Network/Sources/NetworkService.swift
@@ -46,17 +46,23 @@ public extension NetworkService {
                 url,
                 method: endPoint.method,
                 parameters: body,
-                encoder: JSONParameterEncoder.default
+                encoder: JSONParameterEncoder.default,
+                headers: endPoint.headers
             )
         case (_, let query?):
             dataRequest = AF.request(
                 url,
                 method: endPoint.method,
                 parameters: query,
-                encoding: URLEncoding.queryString
+                encoding: URLEncoding.queryString,
+                headers: endPoint.headers
             )
         default:
-            dataRequest = AF.request(url, method: endPoint.method)
+            dataRequest = AF.request(
+                url,
+                method: endPoint.method,
+                headers: endPoint.headers
+            )
         }
 
         return handleResponse(dataRequest)

--- a/Livith-iOS/Projects/Network/Sources/source.swift
+++ b/Livith-iOS/Projects/Network/Sources/source.swift
@@ -1,7 +1,0 @@
-//
-//  source.swift
-//  
-//
-//  Created by YOUJIM on 9/28/25.
-//
-


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
- Alamofire와 Combine을 활용해 Network 모듈을 구현했어요.
- HTTP 상태 코드별 에러 타입을 정의하고 및 ErrorMapper를 분리했어요.
- DTO 기본 구조를 구축했어요. (EmptyResponse, BaseResponse)

## 💻 주요 코드 설명

### NetworkEndpoint 프로토콜 구현
```swift
public protocol NetworkEndpoint {
    var endPoint: String? { get }
    var method: HTTPMethod { get }
    var query: [String: Any]? { get }
    var body: Encodable? { get }
}
```
- Moya의 TargetType 기반으로 구현했으나 baseURL은 Bundle extension으로 분리해 NetworkService의 request에서 직접 사용할 수 있도록 구현했습니다.
-  query와 body는 optional로 기본값을 제공하고, API 명세에 따라 선택적으로 넣어줄 수 있도록 구현했습니다. 아무것도 넣지 않을 경우 requestPlain 방식으로 request를 진행합니다.

### 네트워크 통신을 위한 NetworkService 구현
```swift
public final class NetworkService: NetworkServiceProtocol {
    private let responseHandler: ResponseHandlerProtocol
    private let errorMapper: ErrorMapperProtocol

    public init(
        responseHandler: ResponseHandlerProtocol = ResponseHandler(),
        errorMapper: ErrorMapperProtocol = ErrorMapper()
    )
}
```
- 응답 처리와 에러 매핑 로직을 분리해 SOLID 원칙 중 단일 책임 원칙을 준수하고자 했습니다.

### 서버 에러 메시지 파싱을 위한 ResponseHandler 구현
```swift
public func handle<T: Decodable>(_ response: DataResponse<T, AFError>) throws -> T {
    guard let data = response.data else { throw NetworkError.noData }

    if let httpResponse = response.response {
        let statusCode = httpResponse.statusCode
        guard (200..<300).contains(statusCode) else {
            let errorMessage = try? JSONDecoder().decode(ErrorResponse.self, from: data).message
            throw NetworkError.from(statusCode: statusCode, message: errorMessage)
        }
    }

    return value
}
```
- Alamofire에서 기본적으로 제공하는 `.validate()`를 사용하지 않고 커스텀 메서드를 구현해 에러 응답의 data에 접근하여 서버 에러 메시지를 파싱 가능하도록 했습니다.
- 서버 응답 시 들어오는 HTTP 상태 코드에 따라 적절한 NetworkError를 생성합니다.

### ErrorMapper를 이용한 AFError → NetworkError 변환
```swift
public protocol ErrorMapperProtocol {
    func map(_ error: Error) -> NetworkError
}
```
- Alamofire의 AFError를 앱 전용 NetworkError로 변환합니다.
- 네트워크 레이어와 도메인 레이어의 의존성을 분리할 수 있습니다.

### Request 자동 분기 처리
```swift
switch (endPoint.body, endPoint.query) {
case (let body?, _):
    dataRequest = AF.request(url, method: method, parameters: body, encoder: JSONParameterEncoder.default)
case (_, let query?):
    dataRequest = AF.request(url, method: method, parameters: query, encoding: URLEncoding.queryString)
default:
    dataRequest = AF.request(url, method: method)
}
```
- body와 query 존재 여부에 따라 자동으로 적절한 request를 생성합니다.
- 별도의 Task enum이나 중복 메서드 없이 간결하게 처리할 수 있도록 구현했습니다.

## 👀 기타 더 이야기해볼 점
- 토큰 관련은 일단 구현하지 않은 상태로 두었는데 회의 때 이야기해보면 좋을 것 같습니닷.

## 🔗 연결된 이슈
- Resolved: #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Versioned base URL configuration for API requests.
  - Unified network service with standardized request/response handling and Combine support.
  - Structured error mapping with localized messages.
  - Response handling and decoding utilities with uniform envelopes (base/empty/error DTOs).
  - Network endpoint abstraction and support for multipart file uploads.

- **Chores**
  - Added app configuration key for the current API version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->