### PR TITLE
[Setting] 모듈 생성 및 삭제 자동화 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ Tuist/.build
 ### Copilot ###
 .github/instructions/
 .github/copilot-instructions.md
+
+### Module Scripts ###
+.module_backup/
+claude.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: module module-delete module-rollback generate clean
+
+# 모듈 생성
+module:
+	@./Scripts/create_module.sh
+
+# 모듈 삭제
+module-delete:
+	@./Scripts/delete_module.sh
+
+# 모듈 삭제 롤백
+module-rollback:
+	@./Scripts/delete_module.sh
+
+# Tuist generate
+generate:
+	@tuist generate
+
+# Tuist clean
+clean:
+	@tuist clean

--- a/Projects/User/Project.swift
+++ b/Projects/User/Project.swift
@@ -1,0 +1,35 @@
+//
+//  Project.swift
+//  Manifests
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.make(
+    project: .user,
+    targets: [
+        .make(
+            target: .user(.userData),
+            product: .framework,
+            dependencies: [
+                .user(.userDomain),
+                .core(.livithNetwork)
+            ]
+        ),
+        .make(
+            target: .user(.userDomain),
+            product: .framework
+        ),
+        .make(
+            target: .user(.userFeature),
+            product: .framework,
+            dependencies: [
+                .user(.userDomain),
+                .dsKit(),
+                .core(.diContainer),
+                .core(.livithConcurrency)
+            ]
+        )
+    ]
+)

--- a/Projects/User/UserData/Sources/Placeholder.swift
+++ b/Projects/User/UserData/Sources/Placeholder.swift
@@ -1,0 +1,6 @@
+//
+//  Placeholder.swift
+//  UserData
+//
+
+import Foundation

--- a/Projects/User/UserDomain/Sources/Placeholder.swift
+++ b/Projects/User/UserDomain/Sources/Placeholder.swift
@@ -1,0 +1,6 @@
+//
+//  Placeholder.swift
+//  UserDomain
+//
+
+import Foundation

--- a/Projects/User/UserFeature/Sources/Placeholder.swift
+++ b/Projects/User/UserFeature/Sources/Placeholder.swift
@@ -1,0 +1,6 @@
+//
+//  Placeholder.swift
+//  UserFeature
+//
+
+import Foundation

--- a/Scripts/create_module.sh
+++ b/Scripts/create_module.sh
@@ -29,7 +29,7 @@ DEPENDENCY_FILE="$HELPERS_DIR/TargetDependency+Extension.swift"
 clear
 echo ""
 echo -e "${BOLD}${CYAN}╔════════════════════════════════════════╗${NC}"
-echo -e "${BOLD}${CYAN}║     🛠️  Tuist 모듈 생성 스크립트      ║${NC}"
+echo -e "${BOLD}${CYAN}║     🛠️  Tuist 모듈 생성 스크립트            ║${NC}"
 echo -e "${BOLD}${CYAN}╚════════════════════════════════════════╝${NC}"
 echo ""
 
@@ -298,7 +298,7 @@ fi
 # 완료 메시지
 echo ""
 echo -e "${BOLD}${GREEN}╔════════════════════════════════════════╗${NC}"
-echo -e "${BOLD}${GREEN}║       ✅ 모듈 생성 완료!               ║${NC}"
+echo -e "${BOLD}${GREEN}║       ✅ 모듈 생성 완료!                   ║${NC}"
 echo -e "${BOLD}${GREEN}╚════════════════════════════════════════╝${NC}"
 echo ""
 echo -e "   ${BOLD}생성된 구조:${NC}"

--- a/Scripts/create_module.sh
+++ b/Scripts/create_module.sh
@@ -1,0 +1,318 @@
+#!/bin/bash
+
+# Tuist 모듈 자동 생성 스크립트 (대화형)
+# 사용법: ./Scripts/create_module.sh
+
+set -e
+
+# 색상 정의
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# 프로젝트 루트 경로
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Tuist 파일 경로
+HELPERS_DIR="$PROJECT_ROOT/Tuist/ProjectDescriptionHelpers/Module"
+CONSTANT_FILE="$HELPERS_DIR/Module+Constant.swift"
+TARGET_ID_FILE="$HELPERS_DIR/Module+TargetID.swift"
+PROJECT_ID_FILE="$HELPERS_DIR/Module+ProjectID.swift"
+DEPENDENCY_FILE="$HELPERS_DIR/TargetDependency+Extension.swift"
+
+# 헤더 출력
+clear
+echo ""
+echo -e "${BOLD}${CYAN}╔════════════════════════════════════════╗${NC}"
+echo -e "${BOLD}${CYAN}║     🛠️  Tuist 모듈 생성 스크립트      ║${NC}"
+echo -e "${BOLD}${CYAN}╚════════════════════════════════════════╝${NC}"
+echo ""
+
+# 모듈 이름 입력
+echo -e "${BOLD}${BLUE}📦 모듈 이름을 입력하세요${NC}"
+echo -e "${YELLOW}   (예: User, Concert, Ticket)${NC}"
+echo ""
+read -p "   모듈 이름: " MODULE_INPUT
+
+# 입력 검증
+if [ -z "$MODULE_INPUT" ]; then
+    echo ""
+    echo -e "${RED}❌ 모듈 이름을 입력해주세요.${NC}"
+    exit 1
+fi
+
+# 이름 정규화 (첫 글자 대문자)
+MODULE_NAME_UPPER="$(echo "${MODULE_INPUT:0:1}" | tr '[:lower:]' '[:upper:]')${MODULE_INPUT:1}"
+MODULE_NAME_LOWER="$(echo "${MODULE_INPUT:0:1}" | tr '[:upper:]' '[:lower:]')${MODULE_INPUT:1}"
+
+# 이미 존재하는지 확인
+if grep -q "case ${MODULE_NAME_LOWER} = \"${MODULE_NAME_UPPER}\"" "$PROJECT_ID_FILE" 2>/dev/null; then
+    echo ""
+    echo -e "${RED}❌ '${MODULE_NAME_UPPER}' 모듈이 이미 존재합니다.${NC}"
+    exit 1
+fi
+
+echo ""
+echo -e "${BOLD}${BLUE}📂 생성할 하위 모듈을 선택하세요${NC}"
+echo -e "${YELLOW}   (스페이스로 선택/해제, Enter로 확인)${NC}"
+echo ""
+
+# 하위 모듈 선택
+CREATE_DATA=true
+CREATE_DOMAIN=true
+CREATE_FEATURE=true
+
+echo "   기본값: Data, Domain, Feature 모두 생성"
+echo ""
+read -p "   모두 생성하시겠습니까? (Y/n): " CONFIRM_ALL
+
+if [[ "$CONFIRM_ALL" =~ ^[Nn]$ ]]; then
+    read -p "   Data 모듈 생성? (Y/n): " CREATE_DATA_INPUT
+    read -p "   Domain 모듈 생성? (Y/n): " CREATE_DOMAIN_INPUT
+    read -p "   Feature 모듈 생성? (Y/n): " CREATE_FEATURE_INPUT
+
+    [[ "$CREATE_DATA_INPUT" =~ ^[Nn]$ ]] && CREATE_DATA=false
+    [[ "$CREATE_DOMAIN_INPUT" =~ ^[Nn]$ ]] && CREATE_DOMAIN=false
+    [[ "$CREATE_FEATURE_INPUT" =~ ^[Nn]$ ]] && CREATE_FEATURE=false
+fi
+
+# 생성 요약 출력
+echo ""
+echo -e "${BOLD}${BLUE}📋 생성 요약${NC}"
+echo ""
+echo -e "   모듈 이름: ${GREEN}${MODULE_NAME_UPPER}${NC}"
+echo -e "   생성 위치: ${YELLOW}Projects/${MODULE_NAME_UPPER}/${NC}"
+echo ""
+echo "   하위 모듈:"
+$CREATE_DATA && echo -e "     ${GREEN}✓${NC} ${MODULE_NAME_UPPER}Data"
+$CREATE_DATA || echo -e "     ${RED}✗${NC} ${MODULE_NAME_UPPER}Data"
+$CREATE_DOMAIN && echo -e "     ${GREEN}✓${NC} ${MODULE_NAME_UPPER}Domain"
+$CREATE_DOMAIN || echo -e "     ${RED}✗${NC} ${MODULE_NAME_UPPER}Domain"
+$CREATE_FEATURE && echo -e "     ${GREEN}✓${NC} ${MODULE_NAME_UPPER}Feature"
+$CREATE_FEATURE || echo -e "     ${RED}✗${NC} ${MODULE_NAME_UPPER}Feature"
+echo ""
+
+# 최종 확인
+read -p "   계속 진행하시겠습니까? (Y/n): " FINAL_CONFIRM
+
+if [[ "$FINAL_CONFIRM" =~ ^[Nn]$ ]]; then
+    echo ""
+    echo -e "${YELLOW}⚠️  취소되었습니다.${NC}"
+    exit 0
+fi
+
+echo ""
+echo -e "${BOLD}${CYAN}🚀 모듈 생성 중...${NC}"
+echo ""
+
+# 1. Module+Constant.swift 수정
+echo -e "   ${YELLOW}[1/6]${NC} Module+Constant.swift 수정 중..."
+
+TEMP_FILE=$(mktemp)
+awk -v upper="$MODULE_NAME_UPPER" -v lower="$MODULE_NAME_LOWER" \
+    -v data="$CREATE_DATA" -v domain="$CREATE_DOMAIN" -v feature="$CREATE_FEATURE" '
+/\/\/ MARK: - External Dependency/ {
+    print ""
+    print "// MARK: - " upper " Module"
+    print ""
+    print "public enum " upper "Module: String {"
+    if (data == "true") print "    case " lower "Data = \"" upper "Data\""
+    if (domain == "true") print "    case " lower "Domain = \"" upper "Domain\""
+    if (feature == "true") print "    case " lower "Feature = \"" upper "Feature\""
+    print "}"
+    print ""
+}
+{ print }
+' "$CONSTANT_FILE" > "$TEMP_FILE"
+mv "$TEMP_FILE" "$CONSTANT_FILE"
+
+# 2. Module+TargetID.swift 수정
+echo -e "   ${YELLOW}[2/6]${NC} Module+TargetID.swift 수정 중..."
+
+TEMP_FILE=$(mktemp)
+awk -v upper="$MODULE_NAME_UPPER" -v lower="$MODULE_NAME_LOWER" '
+# enum case 추가
+/case search\(SearchModule\)/ {
+    print
+    print "    case " lower "(" upper "Module)"
+    next
+}
+# name switch case 추가
+/case \.search\(let module\): return module\.rawValue/ {
+    print
+    print "        case ." lower "(let module): return module.rawValue"
+    next
+}
+# sourcesPath switch case 추가 (search 다음 줄의 return 이후에 추가)
+/case \.search\(let module\):$/ {
+    print
+    getline  # return 줄 읽기
+    print
+    print "        case ." lower "(let module):"
+    print "            return [\"\\(module.rawValue)/Sources/**\"]"
+    next
+}
+{ print }
+' "$TARGET_ID_FILE" > "$TEMP_FILE"
+mv "$TEMP_FILE" "$TARGET_ID_FILE"
+
+# 3. Module+ProjectID.swift 수정
+echo -e "   ${YELLOW}[3/6]${NC} Module+ProjectID.swift 수정 중..."
+
+TEMP_FILE=$(mktemp)
+awk -v upper="$MODULE_NAME_UPPER" -v lower="$MODULE_NAME_LOWER" '
+/public var name: String \{ rawValue \}/ {
+    print "    case " lower " = \"" upper "\""
+}
+{ print }
+' "$PROJECT_ID_FILE" > "$TEMP_FILE"
+mv "$TEMP_FILE" "$PROJECT_ID_FILE"
+
+# 4. TargetDependency+Extension.swift 수정
+echo -e "   ${YELLOW}[4/6]${NC} TargetDependency+Extension.swift 수정 중..."
+
+TEMP_FILE=$(mktemp)
+awk -v upper="$MODULE_NAME_UPPER" -v lower="$MODULE_NAME_LOWER" '
+/^}$/ && !added {
+    print ""
+    print "    public static func " lower "(_ module: " upper "Module) -> TargetDependency {"
+    print "        return .project(target: module.rawValue, path: ProjectID." lower ".path)"
+    print "    }"
+    added = 1
+}
+{ print }
+' "$DEPENDENCY_FILE" > "$TEMP_FILE"
+mv "$TEMP_FILE" "$DEPENDENCY_FILE"
+
+# 5. Projects 디렉토리 생성
+echo -e "   ${YELLOW}[5/6]${NC} Projects/${MODULE_NAME_UPPER} 디렉토리 생성 중..."
+
+MODULE_DIR="$PROJECT_ROOT/Projects/${MODULE_NAME_UPPER}"
+mkdir -p "$MODULE_DIR"
+
+$CREATE_DATA && mkdir -p "$MODULE_DIR/${MODULE_NAME_UPPER}Data/Sources"
+$CREATE_DOMAIN && mkdir -p "$MODULE_DIR/${MODULE_NAME_UPPER}Domain/Sources"
+$CREATE_FEATURE && mkdir -p "$MODULE_DIR/${MODULE_NAME_UPPER}Feature/Sources"
+
+# Project.swift 생성
+TARGETS=""
+
+if $CREATE_DATA; then
+    TARGETS="${TARGETS}
+        .make(
+            target: .${MODULE_NAME_LOWER}(.${MODULE_NAME_LOWER}Data),
+            product: .framework,
+            dependencies: ["
+    $CREATE_DOMAIN && TARGETS="${TARGETS}
+                .${MODULE_NAME_LOWER}(.${MODULE_NAME_LOWER}Domain),"
+    TARGETS="${TARGETS}
+                .core(.livithNetwork)
+            ]
+        ),"
+fi
+
+if $CREATE_DOMAIN; then
+    TARGETS="${TARGETS}
+        .make(
+            target: .${MODULE_NAME_LOWER}(.${MODULE_NAME_LOWER}Domain),
+            product: .framework
+        ),"
+fi
+
+if $CREATE_FEATURE; then
+    TARGETS="${TARGETS}
+        .make(
+            target: .${MODULE_NAME_LOWER}(.${MODULE_NAME_LOWER}Feature),
+            product: .framework,
+            dependencies: ["
+    $CREATE_DOMAIN && TARGETS="${TARGETS}
+                .${MODULE_NAME_LOWER}(.${MODULE_NAME_LOWER}Domain),"
+    TARGETS="${TARGETS}
+                .dsKit(),
+                .core(.diContainer),
+                .core(.livithConcurrency)
+            ]
+        ),"
+fi
+
+# 마지막 콤마 제거
+TARGETS=$(echo "$TARGETS" | sed '$ s/,$//')
+
+cat > "$MODULE_DIR/Project.swift" << EOF
+//
+//  Project.swift
+//  Manifests
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.make(
+    project: .${MODULE_NAME_LOWER},
+    targets: [${TARGETS}
+    ]
+)
+EOF
+
+# 6. Placeholder 파일 생성
+echo -e "   ${YELLOW}[6/6]${NC} Placeholder 파일 생성 중..."
+
+if $CREATE_DATA; then
+    cat > "$MODULE_DIR/${MODULE_NAME_UPPER}Data/Sources/Placeholder.swift" << EOF
+//
+//  Placeholder.swift
+//  ${MODULE_NAME_UPPER}Data
+//
+
+import Foundation
+EOF
+fi
+
+if $CREATE_DOMAIN; then
+    cat > "$MODULE_DIR/${MODULE_NAME_UPPER}Domain/Sources/Placeholder.swift" << EOF
+//
+//  Placeholder.swift
+//  ${MODULE_NAME_UPPER}Domain
+//
+
+import Foundation
+EOF
+fi
+
+if $CREATE_FEATURE; then
+    cat > "$MODULE_DIR/${MODULE_NAME_UPPER}Feature/Sources/Placeholder.swift" << EOF
+//
+//  Placeholder.swift
+//  ${MODULE_NAME_UPPER}Feature
+//
+
+import Foundation
+EOF
+fi
+
+# 완료 메시지
+echo ""
+echo -e "${BOLD}${GREEN}╔════════════════════════════════════════╗${NC}"
+echo -e "${BOLD}${GREEN}║       ✅ 모듈 생성 완료!               ║${NC}"
+echo -e "${BOLD}${GREEN}╚════════════════════════════════════════╝${NC}"
+echo ""
+echo -e "   ${BOLD}생성된 구조:${NC}"
+echo -e "   ${YELLOW}Projects/${MODULE_NAME_UPPER}/${NC}"
+echo "   ├── Project.swift"
+$CREATE_DATA && echo "   ├── ${MODULE_NAME_UPPER}Data/Sources/"
+$CREATE_DOMAIN && echo "   ├── ${MODULE_NAME_UPPER}Domain/Sources/"
+$CREATE_FEATURE && echo "   └── ${MODULE_NAME_UPPER}Feature/Sources/"
+echo ""
+echo -e "   ${BOLD}의존성 사용법:${NC}"
+$CREATE_DATA && echo -e "   ${CYAN}.${MODULE_NAME_LOWER}(.${MODULE_NAME_LOWER}Data)${NC}"
+$CREATE_DOMAIN && echo -e "   ${CYAN}.${MODULE_NAME_LOWER}(.${MODULE_NAME_LOWER}Domain)${NC}"
+$CREATE_FEATURE && echo -e "   ${CYAN}.${MODULE_NAME_LOWER}(.${MODULE_NAME_LOWER}Feature)${NC}"
+echo ""
+echo -e "   ${BOLD}다음 단계:${NC}"
+echo -e "   ${YELLOW}tuist generate${NC}"
+echo ""

--- a/Scripts/delete_module.sh
+++ b/Scripts/delete_module.sh
@@ -1,0 +1,287 @@
+#!/bin/bash
+
+# Tuist 모듈 삭제 스크립트 (대화형 + 롤백 지원)
+# 사용법: ./Scripts/delete_module.sh
+
+set -e
+
+# 색상 정의
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# 프로젝트 루트 경로
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Tuist 파일 경로
+HELPERS_DIR="$PROJECT_ROOT/Tuist/ProjectDescriptionHelpers/Module"
+CONSTANT_FILE="$HELPERS_DIR/Module+Constant.swift"
+TARGET_ID_FILE="$HELPERS_DIR/Module+TargetID.swift"
+PROJECT_ID_FILE="$HELPERS_DIR/Module+ProjectID.swift"
+DEPENDENCY_FILE="$HELPERS_DIR/TargetDependency+Extension.swift"
+
+# 백업 디렉토리
+BACKUP_DIR="$PROJECT_ROOT/.module_backup"
+
+# 롤백 함수
+rollback() {
+    echo ""
+    echo -e "${YELLOW}⏪ 롤백 중...${NC}"
+
+    if [ -d "$BACKUP_DIR" ]; then
+        cp "$BACKUP_DIR/Module+Constant.swift" "$CONSTANT_FILE"
+        cp "$BACKUP_DIR/Module+TargetID.swift" "$TARGET_ID_FILE"
+        cp "$BACKUP_DIR/Module+ProjectID.swift" "$PROJECT_ID_FILE"
+        cp "$BACKUP_DIR/TargetDependency+Extension.swift" "$DEPENDENCY_FILE"
+
+        # Projects 디렉토리 복원
+        if [ -f "$BACKUP_DIR/module_name.txt" ]; then
+            MODULE_NAME=$(cat "$BACKUP_DIR/module_name.txt")
+            if [ -d "$BACKUP_DIR/Projects_$MODULE_NAME" ]; then
+                cp -r "$BACKUP_DIR/Projects_$MODULE_NAME" "$PROJECT_ROOT/Projects/$MODULE_NAME"
+            fi
+        fi
+
+        rm -rf "$BACKUP_DIR"
+        echo -e "${GREEN}✅ 롤백 완료!${NC}"
+    else
+        echo -e "${RED}❌ 백업 파일을 찾을 수 없습니다.${NC}"
+    fi
+    exit 0
+}
+
+# 헤더 출력
+clear
+echo ""
+echo -e "${BOLD}${RED}╔════════════════════════════════════════╗${NC}"
+echo -e "${BOLD}${RED}║     🗑️  Tuist 모듈 삭제 스크립트      ║${NC}"
+echo -e "${BOLD}${RED}╚════════════════════════════════════════╝${NC}"
+echo ""
+
+# 롤백 옵션 확인
+if [ -d "$BACKUP_DIR" ]; then
+    echo -e "${YELLOW}⚠️  이전 삭제 작업의 백업이 발견되었습니다.${NC}"
+    echo ""
+    read -p "   롤백하시겠습니까? (y/N): " ROLLBACK_CONFIRM
+    if [[ "$ROLLBACK_CONFIRM" =~ ^[Yy]$ ]]; then
+        rollback
+    else
+        rm -rf "$BACKUP_DIR"
+        echo ""
+    fi
+fi
+
+# 현재 존재하는 모듈 목록 표시
+echo -e "${BOLD}${BLUE}📦 현재 존재하는 모듈 목록${NC}"
+echo ""
+
+# ProjectID에서 모듈 목록 추출 (app, core, dsKit 제외)
+MODULES=$(grep -E "case .+ = " "$PROJECT_ID_FILE" | grep -vE "(app|core|dsKit)" | sed 's/.*case \([^ ]*\) = .*/\1/' | tr '\n' ' ')
+
+if [ -z "$MODULES" ]; then
+    echo -e "   ${YELLOW}삭제 가능한 모듈이 없습니다.${NC}"
+    exit 0
+fi
+
+# 모듈 목록 출력
+INDEX=1
+declare -a MODULE_ARRAY
+for MODULE in $MODULES; do
+    MODULE_ARRAY+=("$MODULE")
+    MODULE_DISPLAY="$(echo "${MODULE:0:1}" | tr '[:lower:]' '[:upper:]')${MODULE:1}"
+    echo -e "   ${CYAN}[$INDEX]${NC} $MODULE_DISPLAY"
+    ((INDEX++))
+done
+
+echo ""
+echo -e "${BOLD}${BLUE}🗑️  삭제할 모듈을 선택하세요${NC}"
+echo -e "${YELLOW}   (번호 또는 모듈 이름 입력)${NC}"
+echo ""
+read -p "   선택: " MODULE_INPUT
+
+# 입력 검증
+if [ -z "$MODULE_INPUT" ]; then
+    echo ""
+    echo -e "${RED}❌ 모듈을 선택해주세요.${NC}"
+    exit 1
+fi
+
+# 번호로 입력한 경우
+if [[ "$MODULE_INPUT" =~ ^[0-9]+$ ]]; then
+    INDEX=$((MODULE_INPUT - 1))
+    if [ $INDEX -lt 0 ] || [ $INDEX -ge ${#MODULE_ARRAY[@]} ]; then
+        echo ""
+        echo -e "${RED}❌ 잘못된 번호입니다.${NC}"
+        exit 1
+    fi
+    MODULE_NAME_LOWER="${MODULE_ARRAY[$INDEX]}"
+else
+    MODULE_NAME_LOWER="$(echo "${MODULE_INPUT:0:1}" | tr '[:upper:]' '[:lower:]')${MODULE_INPUT:1}"
+fi
+
+MODULE_NAME_UPPER="$(echo "${MODULE_NAME_LOWER:0:1}" | tr '[:lower:]' '[:upper:]')${MODULE_NAME_LOWER:1}"
+
+# 모듈 존재 확인
+if ! grep -q "case ${MODULE_NAME_LOWER} = \"${MODULE_NAME_UPPER}\"" "$PROJECT_ID_FILE" 2>/dev/null; then
+    echo ""
+    echo -e "${RED}❌ '${MODULE_NAME_UPPER}' 모듈을 찾을 수 없습니다.${NC}"
+    exit 1
+fi
+
+# 삭제 확인
+echo ""
+echo -e "${BOLD}${RED}⚠️  경고${NC}"
+echo ""
+echo -e "   다음 항목들이 삭제됩니다:"
+echo -e "   ${YELLOW}• Projects/${MODULE_NAME_UPPER}/ 디렉토리${NC}"
+echo -e "   ${YELLOW}• ${MODULE_NAME_UPPER}Module enum (Module+Constant.swift)${NC}"
+echo -e "   ${YELLOW}• TargetID.${MODULE_NAME_LOWER} case (Module+TargetID.swift)${NC}"
+echo -e "   ${YELLOW}• ProjectID.${MODULE_NAME_LOWER} case (Module+ProjectID.swift)${NC}"
+echo -e "   ${YELLOW}• .${MODULE_NAME_LOWER}() 함수 (TargetDependency+Extension.swift)${NC}"
+echo ""
+echo -e "   ${GREEN}💾 백업이 생성되며, 문제 발생 시 롤백 가능합니다.${NC}"
+echo ""
+read -p "   정말 삭제하시겠습니까? (yes를 입력): " CONFIRM
+
+if [ "$CONFIRM" != "yes" ]; then
+    echo ""
+    echo -e "${YELLOW}⚠️  취소되었습니다.${NC}"
+    exit 0
+fi
+
+echo ""
+echo -e "${BOLD}${CYAN}🗑️  모듈 삭제 중...${NC}"
+echo ""
+
+# 백업 생성
+echo -e "   ${YELLOW}[0/5]${NC} 백업 생성 중..."
+mkdir -p "$BACKUP_DIR"
+cp "$CONSTANT_FILE" "$BACKUP_DIR/"
+cp "$TARGET_ID_FILE" "$BACKUP_DIR/"
+cp "$PROJECT_ID_FILE" "$BACKUP_DIR/"
+cp "$DEPENDENCY_FILE" "$BACKUP_DIR/"
+echo "$MODULE_NAME_UPPER" > "$BACKUP_DIR/module_name.txt"
+
+MODULE_DIR="$PROJECT_ROOT/Projects/${MODULE_NAME_UPPER}"
+if [ -d "$MODULE_DIR" ]; then
+    cp -r "$MODULE_DIR" "$BACKUP_DIR/Projects_${MODULE_NAME_UPPER}"
+fi
+
+# 1. Module+Constant.swift에서 enum 삭제
+echo -e "   ${YELLOW}[1/5]${NC} Module+Constant.swift 수정 중..."
+
+TEMP_FILE=$(mktemp)
+awk -v module="${MODULE_NAME_UPPER}" '
+BEGIN { skip = 0; blank_count = 0 }
+/^$/ { blank_count++; next }
+{
+    # 빈 줄 출력 (최대 1개)
+    if (blank_count > 0 && !skip) {
+        print ""
+        blank_count = 0
+    }
+
+    # MARK 주석 발견
+    if ($0 ~ "// MARK: - " module " Module") {
+        skip = 1
+        next
+    }
+
+    # enum 시작
+    if ($0 ~ "public enum " module "Module") {
+        skip = 1
+        next
+    }
+
+    # enum 끝
+    if (/^}$/ && skip) {
+        skip = 0
+        next
+    }
+
+    if (!skip) print
+}
+' "$CONSTANT_FILE" > "$TEMP_FILE"
+mv "$TEMP_FILE" "$CONSTANT_FILE"
+
+# 2. Module+TargetID.swift 수정
+echo -e "   ${YELLOW}[2/5]${NC} Module+TargetID.swift 수정 중..."
+
+TEMP_FILE=$(mktemp)
+awk -v module="${MODULE_NAME_LOWER}" -v Module="${MODULE_NAME_UPPER}" '
+BEGIN { skip_next = 0 }
+{
+    # enum case 삭제
+    if ($0 ~ "case " module "\\(" Module "Module\\)") next
+
+    # name switch case 삭제
+    if ($0 ~ "case \\." module "\\(let module\\): return module\\.rawValue") next
+
+    # sourcesPath case 삭제 (2줄)
+    if ($0 ~ "case \\." module "\\(let module\\):$") {
+        skip_next = 1
+        next
+    }
+    if (skip_next) {
+        skip_next = 0
+        next
+    }
+
+    print
+}
+' "$TARGET_ID_FILE" > "$TEMP_FILE"
+mv "$TEMP_FILE" "$TARGET_ID_FILE"
+
+# 3. Module+ProjectID.swift 수정
+echo -e "   ${YELLOW}[3/5]${NC} Module+ProjectID.swift 수정 중..."
+
+TEMP_FILE=$(mktemp)
+grep -v "case ${MODULE_NAME_LOWER} = \"${MODULE_NAME_UPPER}\"" "$PROJECT_ID_FILE" > "$TEMP_FILE"
+mv "$TEMP_FILE" "$PROJECT_ID_FILE"
+
+# 4. TargetDependency+Extension.swift 수정
+echo -e "   ${YELLOW}[4/5]${NC} TargetDependency+Extension.swift 수정 중..."
+
+TEMP_FILE=$(mktemp)
+awk -v module="${MODULE_NAME_LOWER}" -v Module="${MODULE_NAME_UPPER}" '
+BEGIN { skip = 0 }
+{
+    if ($0 ~ "public static func " module "\\(_ module: " Module "Module\\)") {
+        skip = 1
+        next
+    }
+    if (skip && /^    }$/) {
+        skip = 0
+        next
+    }
+    if (!skip) print
+}
+' "$DEPENDENCY_FILE" > "$TEMP_FILE"
+mv "$TEMP_FILE" "$DEPENDENCY_FILE"
+
+# 5. Projects 디렉토리 삭제
+echo -e "   ${YELLOW}[5/5]${NC} Projects/${MODULE_NAME_UPPER} 디렉토리 삭제 중..."
+
+if [ -d "$MODULE_DIR" ]; then
+    rm -rf "$MODULE_DIR"
+fi
+
+# 완료 메시지
+echo ""
+echo -e "${BOLD}${GREEN}╔════════════════════════════════════════╗${NC}"
+echo -e "${BOLD}${GREEN}║       ✅ 모듈 삭제 완료!               ║${NC}"
+echo -e "${BOLD}${GREEN}╚════════════════════════════════════════╝${NC}"
+echo ""
+echo -e "   ${BOLD}삭제된 모듈:${NC} ${RED}${MODULE_NAME_UPPER}${NC}"
+echo ""
+echo -e "   ${BOLD}다음 단계:${NC}"
+echo -e "   ${YELLOW}tuist generate${NC}"
+echo ""
+echo -e "   ${BOLD}문제 발생 시:${NC}"
+echo -e "   ${CYAN}make module-delete${NC} 실행 후 롤백 선택"
+echo ""

--- a/Tuist/ProjectDescriptionHelpers/Module/Module+Constant.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module/Module+Constant.swift
@@ -46,6 +46,15 @@ public enum SearchModule: String {
     case searchFeature = "SearchFeature"
 }
 
+
+// MARK: - User Module
+
+public enum UserModule: String {
+    case userData = "UserData"
+    case userDomain = "UserDomain"
+    case userFeature = "UserFeature"
+}
+
 // MARK: - External Dependency
 
 public enum ExternalDependency: String {

--- a/Tuist/ProjectDescriptionHelpers/Module/Module+ProjectID.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module/Module+ProjectID.swift
@@ -17,6 +17,7 @@ public enum ProjectID: String, CaseIterable {
     case login = "Login"
     case onboarding = "Onboarding"
     
+    case user = "User"
     public var name: String { rawValue }
     
     public var path: Path {

--- a/Tuist/ProjectDescriptionHelpers/Module/Module+TargetID.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module/Module+TargetID.swift
@@ -16,6 +16,7 @@ public enum TargetID {
     case dsKit
     case onboarding(OnboardingModule)
     case search(SearchModule)
+    case user(UserModule)
 
     public var name: String {
         switch self {
@@ -25,6 +26,7 @@ public enum TargetID {
         case .login(let module): return module.rawValue
         case .onboarding(let module): return module.rawValue
         case .search(let module): return module.rawValue
+        case .user(let module): return module.rawValue
         }
     }
     
@@ -50,6 +52,8 @@ public enum TargetID {
         case .onboarding(let module):
             return ["\(module.rawValue)/Sources/**"]
         case .search(let module):
+            return ["\(module.rawValue)/Sources/**"]
+        case .user(let module):
             return ["\(module.rawValue)/Sources/**"]
         }
     }

--- a/Tuist/ProjectDescriptionHelpers/Module/TargetDependency+Extension.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module/TargetDependency+Extension.swift
@@ -33,4 +33,8 @@ extension TargetDependency {
     public static func onboarding(_ module: OnboardingModule) -> TargetDependency {
         return .project(target: module.rawValue, path: ProjectID.onboarding.path)
     }
+
+    public static func user(_ module: UserModule) -> TargetDependency {
+        return .project(target: module.rawValue, path: ProjectID.user.path)
+    }
 }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- Tuist 모듈을 자동으로 생성하는 대화형 스크립트를 구현해 모듈 생성 로직을 자동화했어요.
- Tuist 모듈 삭제 스크립트를 구현하고 문제 시 롤백 가능한 기능을 추가했어요.
- Makefile을 도입해 `make module`, `make module-delete` 등 간편한 명령어로 스크립트를 실행할 수 있도록 구현했어요.

<img alt="스크린샷 2025-12-03 오후 7 08 10" src="https://github.com/user-attachments/assets/fa97f63b-dca2-4fd7-ae70-b86b76639e60" />

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 대화형 모듈 생성 스크립트 구현
- 기존에는 새 모듈을 추가할 때 4개의 Tuist 설정 파일을 수동으로 수정해야 했습니다.
- `Module+Constant.swift`, `Module+TargetID.swift`, `Module+ProjectID.swift`, `TargetDependency+Extension.swift`를 일일이 편집해야 해서 휴먼 에러가 발생하기 쉬운 환경이었습니다.
- 이를 해결하기 위해 `Scripts/create_module.sh`를 통해 모듈 이름만 입력하면 필요한 모든 파일이 자동 생성되도록 개선했습니다.
  - Data/Domain/Feature 하위 모듈을 선택적으로 생성할 수 있도록 해 유연성을 확보했습니다.

```bash
make module
# 모듈 이름: User
# → UserData, UserDomain, UserFeature 자동 생성
```

### 모듈 삭제 시 롤백 기능 추가

- 모듈 삭제 스크립트가 Tuist 설정 파일을 잘못 수정할 경우, 프로젝트 빌드가 깨지는 문제가 있었습니다.
- 삭제 전 `.module_backup/` 폴더에 원본 파일을 백업하고, 문제 발생 시 즉시 복원할 수 있도록 구현했습니다.
- `make module-rollback` 명령으로 이전 상태로 되돌릴 수 있습니다.

```bash
make module-delete  # 삭제 진행 (자동 백업)
tuist generate      # 에러 발생 시
make module-rollback  # 이전 상태로 복원
```

### Makefile을 통한 명령어 단순화

- Makefile을 도입해 루트 디렉토리에서 간단한 명령어로 실행할 수 있게 개선했습니다.

| 명령어 | 설명 |
|--------|------|
| `make module` | 모듈 생성 |
| `make module-delete` | 모듈 삭제 |
| `make module-rollback` | 삭제 롤백 |

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 모듈 생성하는데 번거로운 점이 약간 있어.. 빠르게 구현해보았습니다.
- 쓰시다 불편하신 점이 있으시면 연락 주세요 ~!

## 🔗 연결된 이슈
n/a
