### PR TITLE
[Feat] 메인 탭바 UI 구현

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -20,8 +20,12 @@ let project = Project.make(
             dependencies: [
                 .dsKit(),
                 .login(.loginFeature),
+                .home(.homeFeature),
+                .home(.homeData),
                 .search(.searchFeature),
                 .search(.searchData),
+                .user(.userFeature),
+                .user(.userData),
                 .core(.diContainer)
             ]
         )

--- a/Projects/App/Sources/LivithApp.swift
+++ b/Projects/App/Sources/LivithApp.swift
@@ -1,7 +1,5 @@
 import SwiftUI
 
-import LoginFeature
-import SearchFeature
 import DSKit
 
 @main
@@ -15,8 +13,7 @@ struct LivithApp: App {
 
     var body: some Scene {
         WindowGroup {
-            SearchView(store: SearchStore())
-                .background(Color.livithColor(.black100))
+            LivithMainTabView()
         }
     }
 }

--- a/Projects/App/Sources/View/LivithMainTabView.swift
+++ b/Projects/App/Sources/View/LivithMainTabView.swift
@@ -48,6 +48,10 @@ public struct LivithMainTabView: View {
     // MARK: - Property
 
     @State private var selectedTab: Tab = .home
+    
+    // MARK: - LifeCycle
+
+    public init() { }
 
     // MARK: - Body
 
@@ -69,10 +73,12 @@ public struct LivithMainTabView: View {
         }
         .ignoresSafeArea(edges: .bottom)
     }
+}
 
-    // MARK: - Custom TabBar
+// MARK: - Components Extension
 
-    private var customTabBar: some View {
+private extension LivithMainTabView {
+    var customTabBar: some View {
         HStack(spacing: 73) {
             ForEach(Tab.allCases, id: \.self) { tab in
                 Button {

--- a/Projects/App/Sources/View/LivithMainTabView.swift
+++ b/Projects/App/Sources/View/LivithMainTabView.swift
@@ -1,0 +1,100 @@
+//
+//  LivithMainTabView.swift
+//  Livith-iOS
+//
+//  Created by Youjin Lee on 12/3/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import SwiftUI
+
+import DSKit
+import HomeFeature
+import UserFeature
+import SearchFeature
+
+public struct LivithMainTabView: View {
+
+    // MARK: - Enum
+
+    enum Tab: Int, CaseIterable {
+        case home, search, my
+
+        var title: String {
+            switch self {
+            case .home: return "홈"
+            case .search: return "탐색"
+            case .my: return "마이"
+            }
+        }
+
+        var defaultIcon: Image {
+            switch self {
+            case .home: return Image.livithIcon(.homeDisabled)
+            case .search: return Image.livithIcon(.ticketDisabled)
+            case .my: return Image.livithIcon(.myDisabled)
+            }
+        }
+
+        var selectedIcon: Image {
+            switch self {
+            case .home: return Image.livithIcon(.homeEnabled)
+            case .search: return Image.livithIcon(.ticketEnabled)
+            case .my: return Image.livithIcon(.myEnabled)
+            }
+        }
+    }
+
+    // MARK: - Property
+
+    @State private var selectedTab: Tab = .home
+
+    // MARK: - Body
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            Group {
+                switch selectedTab {
+                case .home:
+                    HomeView()
+                case .search:
+                    SearchView(store: SearchStore())
+                case .my:
+                    UserView()
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            customTabBar
+        }
+        .ignoresSafeArea(edges: .bottom)
+    }
+
+    // MARK: - Custom TabBar
+
+    private var customTabBar: some View {
+        HStack(spacing: 73) {
+            ForEach(Tab.allCases, id: \.self) { tab in
+                Button {
+                    withAnimation(.easeInOut(duration: 0.1)) {
+                        selectedTab = tab
+                    }
+                } label: {
+                    VStack(spacing: 0) {
+                        (selectedTab == tab ? tab.selectedIcon : tab.defaultIcon)
+                            .resizable()
+                            .frame(width: 38, height: 38)
+
+                        Text(tab.title)
+                            .notosans(.caption2Semibold)
+                            .foregroundStyle(Color.livithColor(selectedTab == tab ? .yellow60 : .black50))
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 12)
+        .padding(.bottom, 24)
+        .background(Color.livithColor(.black100))
+    }
+}

--- a/Projects/Home/HomeData/Sources/Placeholder.swift
+++ b/Projects/Home/HomeData/Sources/Placeholder.swift
@@ -1,0 +1,6 @@
+//
+//  Placeholder.swift
+//  HomeData
+//
+
+import Foundation

--- a/Projects/Home/HomeDomain/Sources/Placeholder.swift
+++ b/Projects/Home/HomeDomain/Sources/Placeholder.swift
@@ -1,0 +1,6 @@
+//
+//  Placeholder.swift
+//  HomeDomain
+//
+
+import Foundation

--- a/Projects/Home/HomeFeature/Sources/HomeView.swift
+++ b/Projects/Home/HomeFeature/Sources/HomeView.swift
@@ -1,0 +1,22 @@
+//
+//  HomeView.swift
+//  Home
+//
+//  Created by Youjin Lee on 12/3/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import SwiftUI
+
+public struct HomeView: View {
+    
+    // MARK: - LifeCycle
+
+    public init() { }
+    
+    // MARK: - Body
+
+    public var body: some View {
+        Text("Hello, World!")
+    }
+}

--- a/Projects/Home/Project.swift
+++ b/Projects/Home/Project.swift
@@ -1,0 +1,35 @@
+//
+//  Project.swift
+//  Manifests
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.make(
+    project: .home,
+    targets: [
+        .make(
+            target: .home(.homeData),
+            product: .framework,
+            dependencies: [
+                .home(.homeDomain),
+                .core(.livithNetwork)
+            ]
+        ),
+        .make(
+            target: .home(.homeDomain),
+            product: .framework
+        ),
+        .make(
+            target: .home(.homeFeature),
+            product: .framework,
+            dependencies: [
+                .home(.homeDomain),
+                .dsKit(),
+                .core(.diContainer),
+                .core(.livithConcurrency)
+            ]
+        )
+    ]
+)

--- a/Projects/User/UserFeature/Sources/Placeholder.swift
+++ b/Projects/User/UserFeature/Sources/Placeholder.swift
@@ -1,6 +1,0 @@
-//
-//  Placeholder.swift
-//  UserFeature
-//
-
-import Foundation

--- a/Projects/User/UserFeature/Sources/View/UserView.swift
+++ b/Projects/User/UserFeature/Sources/View/UserView.swift
@@ -1,0 +1,27 @@
+//
+//  UserView.swift
+//  User
+//
+//  Created by Youjin Lee on 12/2/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import SwiftUI
+
+public struct UserView: View {
+    
+    // MARK: - Property
+    
+    
+    // MARK: - LifeCycle
+    
+    public init () { }
+    
+    // MARK: - Body
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            
+        }
+    }
+}

--- a/Tuist/ProjectDescriptionHelpers/Module/Module+Constant.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module/Module+Constant.swift
@@ -55,6 +55,15 @@ public enum UserModule: String {
     case userFeature = "UserFeature"
 }
 
+
+// MARK: - Home Module
+
+public enum HomeModule: String {
+    case homeData = "HomeData"
+    case homeDomain = "HomeDomain"
+    case homeFeature = "HomeFeature"
+}
+
 // MARK: - External Dependency
 
 public enum ExternalDependency: String {

--- a/Tuist/ProjectDescriptionHelpers/Module/Module+ProjectID.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module/Module+ProjectID.swift
@@ -18,6 +18,7 @@ public enum ProjectID: String, CaseIterable {
     case onboarding = "Onboarding"
     
     case user = "User"
+    case home = "Home"
     public var name: String { rawValue }
     
     public var path: Path {

--- a/Tuist/ProjectDescriptionHelpers/Module/Module+TargetID.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module/Module+TargetID.swift
@@ -16,6 +16,7 @@ public enum TargetID {
     case dsKit
     case onboarding(OnboardingModule)
     case search(SearchModule)
+    case home(HomeModule)
     case user(UserModule)
 
     public var name: String {
@@ -26,6 +27,7 @@ public enum TargetID {
         case .login(let module): return module.rawValue
         case .onboarding(let module): return module.rawValue
         case .search(let module): return module.rawValue
+        case .home(let module): return module.rawValue
         case .user(let module): return module.rawValue
         }
     }
@@ -52,6 +54,8 @@ public enum TargetID {
         case .onboarding(let module):
             return ["\(module.rawValue)/Sources/**"]
         case .search(let module):
+            return ["\(module.rawValue)/Sources/**"]
+        case .home(let module):
             return ["\(module.rawValue)/Sources/**"]
         case .user(let module):
             return ["\(module.rawValue)/Sources/**"]

--- a/Tuist/ProjectDescriptionHelpers/Module/TargetDependency+Extension.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module/TargetDependency+Extension.swift
@@ -37,4 +37,8 @@ extension TargetDependency {
     public static func user(_ module: UserModule) -> TargetDependency {
         return .project(target: module.rawValue, path: ProjectID.user.path)
     }
+
+    public static func home(_ module: HomeModule) -> TargetDependency {
+        return .project(target: module.rawValue, path: ProjectID.home.path)
+    }
 }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 홈, 탐색, 마이로 나뉘는 메인 탭바를 구현하고 진입점을 설정했어요.

|    구현 내용    |   IPhone 13 mini   |   IPhone 17   |
| :-------------: | :----------: | :----------: |
| 메인 탭바 | <img width="250" src= "https://github.com/user-attachments/assets/603aa1c8-2186-4d68-8fd3-45f07a76f51d"> | <img width="250" src="https://github.com/user-attachments/assets/e6e8dfc9-f607-4ada-82bf-0b795eb4611a"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### Enum 기반 커스텀 탭바 구현
- 기존 SwiftUI의 `TabView`는 커스터마이징에 제약이 있어 디자인 명세를 적용하기 어렵다는 문제가 있었습니다.
- 이를 해결하기 위해 `Tab` enum과 커스텀 뷰를 조합한 탭바를 직접 구현했습니다.
- `CaseIterable`을 채택해 `ForEach`에서 모든 탭을 순회하여 렌더링할 수 있도록 구현했습니다.

```swift
enum Tab: Int, CaseIterable {
    case home, search, my

    var title: String {
        switch self {
        case .home: return "홈"
        case .search: return "탐색"
        case .my: return "마이"
        }
    }

    var defaultIcon: Image {
        switch self {
        case .home: return Image.livithIcon(.homeDisabled)
        case .search: return Image.livithIcon(.ticketDisabled)
        case .my: return Image.livithIcon(.myDisabled)
        }
    }

    var selectedIcon: Image {
        switch self {
        case .home: return Image.livithIcon(.homeEnabled)
        case .search: return Image.livithIcon(.ticketEnabled)
        case .my: return Image.livithIcon(.myEnabled)
        }
    }
}
```

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 탐색 탭바의 경우 진입점을 검색 화면으로 설정해두었습니다. 이후 탐색 화면 구현 시 바꿔서 구현해주시면 감사하겠습니다 ~!

## 🔗 연결된 이슈
- Resolved: #이슈번호
