### PR TITLE
[Feat] 로그인 로직 구성 (도메인, 데이터 영역

### DIFF
--- a/Projects/Core/Auth/Sources/AuthError.swift
+++ b/Projects/Core/Auth/Sources/AuthError.swift
@@ -9,14 +9,14 @@
 import Foundation
 
 public enum AuthError: Error, LocalizedError {
-    case cancelled
+    case canceled
     case networkError
     case missingToken
     case unknown
     
     public var errorDescription: String? {
         switch self {
-        case .cancelled:
+        case .canceled:
             return "로그인 과정이 취소되었습니다."
         case .networkError:
             return "네트워크 오류로 로그인에 실패했습니다."

--- a/Projects/Core/Auth/Sources/AuthService/AppleLoginService.swift
+++ b/Projects/Core/Auth/Sources/AuthService/AppleLoginService.swift
@@ -19,7 +19,7 @@ public final class AppleLoginService: NSObject, AuthService {
         do {
             return try await withCheckedThrowingContinuation { continuation in
                 if let oldContinuation = activeContinuation {
-                    oldContinuation.resume(throwing: AuthError.cancelled)
+                    oldContinuation.resume(throwing: AuthError.canceled)
                 }
                 
                 activeContinuation = continuation
@@ -72,7 +72,7 @@ extension AppleLoginService: ASAuthorizationControllerDelegate {
         
         switch authorizationError.code {
         case .canceled:
-            return .cancelled
+            return .canceled
         default:
             return .unknown
         }

--- a/Projects/Core/Auth/Sources/AuthService/AppleLoginService.swift
+++ b/Projects/Core/Auth/Sources/AuthService/AppleLoginService.swift
@@ -9,12 +9,12 @@
 import Foundation
 import AuthenticationServices
 
-@MainActor
 public final class AppleLoginService: NSObject, AuthService {
     private var activeContinuation: CheckedContinuation<AuthCredential, Error>?
     
     public override init() {}
     
+    @MainActor
     public func login() async throws(AuthError) -> AuthCredential {
         do {
             return try await withCheckedThrowingContinuation { continuation in

--- a/Projects/Core/Auth/Sources/AuthService/KakaoLoginService.swift
+++ b/Projects/Core/Auth/Sources/AuthService/KakaoLoginService.swift
@@ -78,7 +78,7 @@ private extension KakaoLoginService {
         }
         
         if case .ClientFailed(let reason, _) = sdkError, reason == .Cancelled {
-            return .cancelled
+            return .canceled
         }
         
         return .unknown

--- a/Projects/Login/LoginData/Sources/Assembler/LoginAssembler.swift
+++ b/Projects/Login/LoginData/Sources/Assembler/LoginAssembler.swift
@@ -15,9 +15,12 @@ public struct LoginAssembler: DependencyAssembler {
     public init() {}
     
     public func assemble(to container: DependencyContainer) {
-        let onboardingRepository = OnboardingRepositoryImpl()
-        let useCase = OnboardingUseCaseImpl(onboardingRepository: onboardingRepository)
-
-        container.register({ useCase }, for: OnboardingUseCase.self)
+        container.register({
+            LoginUseCaseImpl(repository: LoginRepositoryImpl())
+        }, for: LoginUseCase.self)
+        
+        container.register({
+            OnboardingUseCaseImpl(onboardingRepository: OnboardingRepositoryImpl())
+        }, for: OnboardingUseCase.self)
     }
 }

--- a/Projects/Login/LoginData/Sources/Login/DTO/AppleLogin.swift
+++ b/Projects/Login/LoginData/Sources/Login/DTO/AppleLogin.swift
@@ -1,0 +1,62 @@
+//
+//  AppleLogin.swift
+//  LoginData
+//
+//  Created by 김진웅 on 12/5/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+import LivithNetwork
+
+// MARK: - 34. iOS 애플 로그인
+
+extension DTO.Request {
+    struct AppleLogin: Encodable {
+        let identityToken: String
+    }
+}
+
+extension DTO.Response {
+    struct AppleLogin: Decodable {
+        let isNewUser: Bool
+        let accessToken: String?
+        let refreshToken: String?
+        let tempUser: TempUser?
+        
+        enum CodingKeys: String, CodingKey {
+            case isNewUser, accessToken, refreshToken
+            case tempUser = "tempUserData"
+        }
+        
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: DTO.Response.AppleLogin.CodingKeys.self)
+            
+            isNewUser = try container.decode(Bool.self, forKey: .isNewUser)
+            
+            if isNewUser {
+                tempUser = try container.decode(DTO.Response.AppleLogin.TempUser.self, forKey: .tempUser)
+                accessToken = nil
+                refreshToken = nil
+            } else {
+                accessToken = try container.decode(String.self, forKey: .accessToken)
+                refreshToken = try container.decode(String.self, forKey: .refreshToken)
+                tempUser = nil
+            }
+        }
+    }
+}
+
+extension DTO.Response.AppleLogin {
+    struct TempUser: Decodable {
+        let provider: String
+        let providerID: String
+        let email: String
+        
+        enum CodingKeys: String, CodingKey {
+            case provider, email
+            case providerID = "providerId"
+        }
+    }
+}

--- a/Projects/Login/LoginData/Sources/Login/DTO/KakaoLogin.swift
+++ b/Projects/Login/LoginData/Sources/Login/DTO/KakaoLogin.swift
@@ -1,0 +1,61 @@
+//
+//  KakaoLogin.swift
+//  LoginData
+//
+//  Created by 김진웅 on 12/5/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+import LivithNetwork
+
+// MARK: - 28. iOS 카카오 로그인
+
+extension DTO.Request {
+    struct KakaoLogin: Encodable {
+        let accessToken: String
+    }
+}
+
+extension DTO.Response {
+    struct KakaoLogin: Decodable {
+        let isNewUser: Bool
+        let accessToken: String?
+        let refreshToken: String?
+        let tempUser: TempUser?
+        
+        enum CodingKeys: String, CodingKey {
+            case isNewUser, accessToken, refreshToken
+            case tempUser = "tempUserData"
+        }
+        
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: DTO.Response.KakaoLogin.CodingKeys.self)
+            
+            isNewUser = try container.decode(Bool.self, forKey: .isNewUser)
+            
+            if isNewUser {
+                tempUser = try container.decode(DTO.Response.KakaoLogin.TempUser.self, forKey: .tempUser)
+                accessToken = nil
+                refreshToken = nil
+            } else {
+                accessToken = try container.decode(String.self, forKey: .accessToken)
+                refreshToken = try container.decode(String.self, forKey: .refreshToken)
+                tempUser = nil
+            }
+        }
+    }
+}
+
+extension DTO.Response.KakaoLogin {
+    struct TempUser: Decodable {
+        let providerID: String
+        let provider: String
+        
+        enum CodingKeys: String, CodingKey {
+            case providerID = "providerId"
+            case provider
+        }
+    }
+}

--- a/Projects/Login/LoginData/Sources/Login/LoginEndpoint.swift
+++ b/Projects/Login/LoginData/Sources/Login/LoginEndpoint.swift
@@ -1,0 +1,43 @@
+//
+//  LoginEndpoint.swift
+//  LoginData
+//
+//  Created by 김진웅 on 12/5/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+import LivithNetwork
+
+enum LoginEndpoint {
+    case appleLogin(identityToken: String)
+    case kakaoLogin(accessToken: String)
+}
+
+extension LoginEndpoint: NetworkEndpoint {
+    var path: String? {
+        switch self {
+        case .appleLogin:
+            return "/api/v4/auth/apple/mobile"
+        case .kakaoLogin:
+            return "/api/v4/auth/kakao/mobile"
+        }
+    }
+    
+    var method: HTTPMethod {
+        switch self {
+        case .appleLogin, .kakaoLogin:
+            return .post
+        }
+    }
+    
+    var body: (any Encodable)? {
+        switch self {
+        case .appleLogin(let identityToken):
+            return DTO.Request.AppleLogin(identityToken: identityToken)
+        case .kakaoLogin(let accessToken):
+            return DTO.Request.KakaoLogin(accessToken: accessToken)
+        }
+    }
+}

--- a/Projects/Login/LoginData/Sources/Login/LoginRepositoryImpl.swift
+++ b/Projects/Login/LoginData/Sources/Login/LoginRepositoryImpl.swift
@@ -10,21 +10,110 @@ import Foundation
 
 import Auth
 import LivithNetwork
+import LoginDomain
+
+typealias LoginService = NetworkService<LoginEndpoint>
 
 final class LoginRepositoryImpl {
-    typealias LoginService = NetworkService<LoginEndpoint>
-    
     private let appleLoginService: AppleLoginService
     private let kakaoLoginService: KakaoLoginService
     private let loginService: LoginService
+    private let errorMapper: LoginErrorMapper
     
     init(
         appleLoginService: AppleLoginService = .init(),
         kakaoLoginService: KakaoLoginService = .init(),
-        loginService: LoginService = .init()
+        loginService: LoginService = .init(),
+        errorMapper: LoginErrorMapper = .init()
     ) {
         self.appleLoginService = appleLoginService
         self.kakaoLoginService = kakaoLoginService
         self.loginService = loginService
+        self.errorMapper = errorMapper
+    }
+}
+
+extension LoginRepositoryImpl: LoginRepository {
+    func login(for provider: SocialLoginProvider) async throws(LoginError) -> LoginResult {
+        do {
+            let credential = try await getCredential(for: provider)
+            return try await performBackendLogin(with: credential, for: provider)
+        } catch {
+            throw mapToDomainError(from: error)
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private extension LoginRepositoryImpl {
+    func getCredential(for provider: SocialLoginProvider) async throws -> AuthCredential {
+        switch provider {
+        case .apple:
+            return try await appleLoginService.login()
+        case .kakao:
+            return try await kakaoLoginService.login()
+        }
+    }
+    
+    func performBackendLogin(with credential: AuthCredential, for provider: SocialLoginProvider) async throws -> LoginResult {
+        switch provider {
+        case .apple:
+            let endpoint = LoginEndpoint.appleLogin(identityToken: credential.token)
+            let response: BaseResponse<DTO.Response.AppleLogin> = try await loginService.request(endpoint)
+            
+            guard let data = response.data else {
+                throw LoginError.noData
+            }
+            
+            if data.isNewUser {
+                guard let tempUserData = data.tempUser else {
+                    throw LoginError.noData
+                }
+                let tempUser = TempUser(
+                    provider: .apple,
+                    providerID: tempUserData.providerID,
+                    email: tempUserData.email
+                )
+                return .newUser(tempUser: tempUser)
+            } else {
+                return .existingUser
+            }
+            
+        case .kakao:
+            let endpoint = LoginEndpoint.kakaoLogin(accessToken: credential.token)
+            let response: BaseResponse<DTO.Response.KakaoLogin> = try await loginService.request(endpoint)
+            
+            guard let data = response.data else {
+                throw LoginError.noData
+            }
+            
+            if data.isNewUser {
+                guard let tempUserData = data.tempUser else {
+                    throw LoginError.noData
+                }
+                let tempUser = TempUser(
+                    provider: .kakao,
+                    providerID: tempUserData.providerID,
+                    email: nil
+                )
+                return .newUser(tempUser: tempUser)
+            } else {
+                return .existingUser
+            }
+        }
+    }
+    
+    func mapToDomainError(from error: Error) -> LoginError {
+        if let loginError = error as? LoginError {
+            return loginError
+        }
+        if let authError = error as? AuthError {
+            return errorMapper.mapToDomainError(authError)
+        }
+        if let networkError = error as? NetworkError {
+            return errorMapper.mapToDomainError(networkError)
+        }
+        return .unknown
     }
 }

--- a/Projects/Login/LoginData/Sources/Login/LoginRepositoryImpl.swift
+++ b/Projects/Login/LoginData/Sources/Login/LoginRepositoryImpl.swift
@@ -1,0 +1,30 @@
+//
+//  LoginRepositoryImpl.swift
+//  LoginData
+//
+//  Created by 김진웅 on 12/5/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+import Auth
+import LivithNetwork
+
+final class LoginRepositoryImpl {
+    typealias LoginService = NetworkService<LoginEndpoint>
+    
+    private let appleLoginService: AppleLoginService
+    private let kakaoLoginService: KakaoLoginService
+    private let loginService: LoginService
+    
+    init(
+        appleLoginService: AppleLoginService = .init(),
+        kakaoLoginService: KakaoLoginService = .init(),
+        loginService: LoginService = .init()
+    ) {
+        self.appleLoginService = appleLoginService
+        self.kakaoLoginService = kakaoLoginService
+        self.loginService = loginService
+    }
+}

--- a/Projects/Login/LoginData/Sources/Login/Mapper/LoginErrorMapper.swift
+++ b/Projects/Login/LoginData/Sources/Login/Mapper/LoginErrorMapper.swift
@@ -1,0 +1,35 @@
+//
+//  LoginErrorMapper.swift
+//  LoginData
+//
+//  Created by 김진웅 on 12/5/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+import Auth
+import LivithNetwork
+import LoginDomain
+
+struct LoginErrorMapper {
+    func mapToDomainError(_ error: AuthError) -> LoginError {
+        switch error {
+        case .canceled: .canceled
+        case .networkError: .noConnection
+        case .missingToken: .loginFailed
+        case .unknown: .unknown
+        }
+    }
+    
+    func mapToDomainError(_ error: NetworkError) -> LoginError {
+        switch error {
+        case .noConnection: .noConnection
+        case .badRequest, .unauthorized, .forbidden: .loginFailed
+        case .serverError: .serverError
+        case .noData: .noData
+        case .invalidURL, .invalidRequest, .invalidResponse, .decodingFailed, .notFound,
+                .clientError, .unknown: .unknown
+        }
+    }
+}

--- a/Projects/Login/LoginDomain/Sources/Login/Error/LoginError.swift
+++ b/Projects/Login/LoginDomain/Sources/Login/Error/LoginError.swift
@@ -1,0 +1,26 @@
+//
+//  LoginError.swift
+//  LoginDomain
+//
+//  Created by 김진웅 on 12/5/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+public enum LoginError: Error, LocalizedError {
+    case canceled
+    case noConnection
+    case unknown
+    
+    public var errorDescription: String? {
+        switch self {
+        case .canceled:
+            return "로그인이 취소되었습니다."
+        case .noConnection:
+            return "네트워크 연결을 확인해주세요."
+        case .unknown:
+            return "알 수 없는 오류가 발생했습니다."
+        }
+    }
+}

--- a/Projects/Login/LoginDomain/Sources/Login/Error/LoginError.swift
+++ b/Projects/Login/LoginDomain/Sources/Login/Error/LoginError.swift
@@ -11,6 +11,9 @@ import Foundation
 public enum LoginError: Error, LocalizedError {
     case canceled
     case noConnection
+    case loginFailed
+    case serverError
+    case noData
     case unknown
     
     public var errorDescription: String? {
@@ -19,6 +22,12 @@ public enum LoginError: Error, LocalizedError {
             return "로그인이 취소되었습니다."
         case .noConnection:
             return "네트워크 연결을 확인해주세요."
+        case .loginFailed:
+            return "로그인에 실패했습니다. 다시 시도해주세요."
+        case .serverError:
+            return "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요."
+        case .noData:
+            return "데이터를 불러올 수 없습니다."
         case .unknown:
             return "알 수 없는 오류가 발생했습니다."
         }

--- a/Projects/Login/LoginDomain/Sources/Login/Model/LoginResult.swift
+++ b/Projects/Login/LoginDomain/Sources/Login/Model/LoginResult.swift
@@ -1,0 +1,14 @@
+//
+//  LoginResult.swift
+//  LoginDomain
+//
+//  Created by 김진웅 on 12/5/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+public enum LoginResult {
+    case existingUser
+    case newUser(tempUser: TempUser)
+}

--- a/Projects/Login/LoginDomain/Sources/Login/Model/SocialLoginProvider.swift
+++ b/Projects/Login/LoginDomain/Sources/Login/Model/SocialLoginProvider.swift
@@ -1,0 +1,23 @@
+//
+//  SocialLoginProvider.swift
+//  LoginDomain
+//
+//  Created by 김진웅 on 12/5/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+public enum SocialLoginProvider: CustomStringConvertible {
+    case apple
+    case kakao
+    
+    public var description: String {
+        switch self {
+        case .apple:
+            return "apple"
+        case .kakao:
+            return "kakao"
+        }
+    }
+}

--- a/Projects/Login/LoginDomain/Sources/Login/Model/TempUser.swift
+++ b/Projects/Login/LoginDomain/Sources/Login/Model/TempUser.swift
@@ -1,0 +1,15 @@
+//
+//  TempUser.swift
+//  LoginDomain
+//
+//  Created by 김진웅 on 12/5/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+public struct TempUser {
+    let provider: SocialLoginProvider
+    let providerID: String
+    let email: String?
+}

--- a/Projects/Login/LoginDomain/Sources/Login/Model/TempUser.swift
+++ b/Projects/Login/LoginDomain/Sources/Login/Model/TempUser.swift
@@ -12,4 +12,10 @@ public struct TempUser {
     let provider: SocialLoginProvider
     let providerID: String
     let email: String?
+    
+    public init(provider: SocialLoginProvider, providerID: String, email: String?) {
+        self.provider = provider
+        self.providerID = providerID
+        self.email = email
+    }
 }

--- a/Projects/Login/LoginDomain/Sources/Login/Model/TempUser.swift
+++ b/Projects/Login/LoginDomain/Sources/Login/Model/TempUser.swift
@@ -9,9 +9,9 @@
 import Foundation
 
 public struct TempUser {
-    let provider: SocialLoginProvider
-    let providerID: String
-    let email: String?
+    public let provider: SocialLoginProvider
+    public let providerID: String
+    public let email: String?
     
     public init(provider: SocialLoginProvider, providerID: String, email: String?) {
         self.provider = provider

--- a/Projects/Login/LoginDomain/Sources/Login/RepositoryInterface/LoginRepository.swift
+++ b/Projects/Login/LoginDomain/Sources/Login/RepositoryInterface/LoginRepository.swift
@@ -1,0 +1,13 @@
+//
+//  LoginRepository.swift
+//  LoginDomain
+//
+//  Created by 김진웅 on 12/5/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+public protocol LoginRepository {
+    func login(for provider: SocialLoginProvider) async throws(LoginError) -> LoginResult
+}

--- a/Projects/Login/LoginDomain/Sources/Login/UseCase/LoginUseCase.swift
+++ b/Projects/Login/LoginDomain/Sources/Login/UseCase/LoginUseCase.swift
@@ -15,7 +15,7 @@ public protocol LoginUseCase {
 public final class LoginUseCaseImpl: LoginUseCase {
     private let repository: LoginRepository
     
-    init(repository: LoginRepository) {
+    public init(repository: LoginRepository) {
         self.repository = repository
     }
     

--- a/Projects/Login/LoginDomain/Sources/Login/UseCase/LoginUseCase.swift
+++ b/Projects/Login/LoginDomain/Sources/Login/UseCase/LoginUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  LoginUseCase.swift
+//  LoginDomain
+//
+//  Created by 김진웅 on 12/5/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+public protocol LoginUseCase {
+    func execute(for provider: SocialLoginProvider) async throws(LoginError) -> LoginResult
+}
+
+public final class LoginUseCaseImpl: LoginUseCase {
+    private let repository: LoginRepository
+    
+    init(repository: LoginRepository) {
+        self.repository = repository
+    }
+    
+    public func execute(for provider: SocialLoginProvider) async throws(LoginError) -> LoginResult {
+        return try await repository.login(for: provider)
+    }
+}

--- a/Projects/Login/Project.swift
+++ b/Projects/Login/Project.swift
@@ -17,7 +17,8 @@ let project = Project.make(
             dependencies: [
                 .login(.loginDomain),
                 .core(.diContainer),
-                .core(.livithNetwork)
+                .core(.livithNetwork),
+                .core(.auth)
             ]
         ),
         .make(


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 로그인 도메인 영역의 로직을 구성했습니다.
    - 에러 타입 정의
    - 유즈케이스 선언
    - 객체 정의 (Model)
- 로그인 데이터 영역의 로직을 구성했습니다.
    - 에러 매핑
    - 레포지토리 구현
    - DTO 선언

<img width="811" height="580" alt="image" src="https://github.com/user-attachments/assets/e6e90bb4-323f-40e4-bfde-3633f2a8aa9b" />

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 매 PR마다 draw.io 기반의 다이어그램을 첨부할 생각입니다. AI를 이용해서 만들고 있는데 추후 의견을 모아, 다이어그램을 생성하는 프롬프트를 만들어, 어떠한 내용이 들어가기를 바라는지 정하면 일관된 다이어그램이 만들어질 것 같습니다.
- `NetworkService`에서 `Endpoint`를 제네릭 타입으로 받지만, 메서드에서는 이를 사용하지 않아 다시 `Endpoint` 타입을 명시해야 하는 불편이 존재합니다. 추후 수정이 필요합니다.
- git branch rule을 제대로 따르기 위해, `feat/#29-login`(현재 `develop`과 같음)에 머지하기 위한 PR을 작성하였습니다.
## 🔗 연결된 이슈
- Resolved: #40 
