### PR TITLE
[Fix] 변경된 서버 명세에 따른 DTO 옵셔널 여부 수정

### DIFF
--- a/Projects/Core/LivithNetwork/Sources/DTO/CommentFeature/CreateCommentReport.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/CommentFeature/CreateCommentReport.swift
@@ -22,7 +22,7 @@ public extension DTO.Response {
         public let commentID: Int
         public let commentUserID: Int
         public let commentContent: String
-        public let reportReason: String
+        public let reportReason: String?
         public let createdAt: String
 
         enum CodingKeys: String, CodingKey {

--- a/Projects/Core/LivithNetwork/Sources/DTO/CommentFeature/FetchConcertCommentList.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/CommentFeature/FetchConcertCommentList.swift
@@ -13,7 +13,7 @@ import Foundation
 public extension DTO.Response {
     struct FetchConcertCommentList: Decodable {
         public let data: [Comment]
-        public let cursor: Cursor
+        public let cursor: Cursor?
         public let totalCount: Int
 
         public struct Comment: Decodable {

--- a/Projects/Core/LivithNetwork/Sources/DTO/ConcertFeature/FetchConcertArtistInfo.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/ConcertFeature/FetchConcertArtistInfo.swift
@@ -17,9 +17,9 @@ public extension DTO.Response {
         public let debutDate: String
         public let category: String
         public let detail: String
-        public let instagramURL: String
+        public let instagramURL: String?
         public let keywords: [String]
-        public let imageURL: String
+        public let imageURL: String?
 
         enum CodingKeys: String, CodingKey {
             case id

--- a/Projects/Core/LivithNetwork/Sources/DTO/ConcertFeature/FetchConcertInfo.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/ConcertFeature/FetchConcertInfo.swift
@@ -20,12 +20,12 @@ public extension DTO.Response {
         public let status: String
         public let posterURL: String
         public let artist: String
-        public let daysLeft: Int?
-        public let ticketSite: String
-        public let ticketURL: String
+        public let daysLeft: Int
+        public let ticketSite: String?
+        public let ticketURL: String?
         public let venue: String
         public let introduction: String
-        public let label: String
+        public let label: String?
 
         enum CodingKeys: String, CodingKey {
             case id

--- a/Projects/Core/LivithNetwork/Sources/DTO/ConcertFeature/FetchConcertMDList.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/ConcertFeature/FetchConcertMDList.swift
@@ -16,8 +16,8 @@ public extension DTO.Response {
     struct ConcertMD: Decodable {
         public let id: Int
         public let name: String
-        public let price: String
-        public let imageURL: String
+        public let price: String?
+        public let imageURL: String?
 
         enum CodingKeys: String, CodingKey {
             case id

--- a/Projects/Core/LivithNetwork/Sources/DTO/ConcertFeature/FetchConcertSetlistList.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/ConcertFeature/FetchConcertSetlistList.swift
@@ -16,7 +16,7 @@ public extension DTO.Response {
     struct ConcertSetlist: Decodable {
         public let id: Int
         public let title: String
-        public let imageURL: String
+        public let imageURL: String?
         public let type: String
         public let startDate: String
         public let endDate: String

--- a/Projects/Core/LivithNetwork/Sources/DTO/HomeFeature/FetchConcertMainSetlist.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/HomeFeature/FetchConcertMainSetlist.swift
@@ -14,11 +14,11 @@ public extension DTO.Response {
     struct FetchConcertMainSetlist: Decodable {
         public let id: Int
         public let title: String
-        public let imageURL: String
+        public let imageURL: String?
         public let type: String
         public let startDate: String
         public let endDate: String
-        public let status: String
+        public let status: String?
         public let venue: String
         public let artist: String
 

--- a/Projects/Core/LivithNetwork/Sources/DTO/HomeFeature/FetchHomeSectionList.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/HomeFeature/FetchHomeSectionList.swift
@@ -30,9 +30,9 @@ public extension DTO.Response {
         public let artist: String
         public let createdAt: String
         public let updatedAt: String
-        public let artistId: Int
-        public let ticketSite: String
-        public let ticketURL: String
+        public let artistID: Int
+        public let ticketSite: String?
+        public let ticketURL: String?
         public let venue: String
         public let introduction: String
         public let label: String?
@@ -50,7 +50,7 @@ public extension DTO.Response {
             case artist
             case createdAt
             case updatedAt
-            case artistId
+            case artistID = "artistId"
             case ticketSite
             case ticketURL = "ticketUrl"
             case venue

--- a/Projects/Core/LivithNetwork/Sources/DTO/HomeFeature/FetchUserInterestConcert.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/HomeFeature/FetchUserInterestConcert.swift
@@ -21,11 +21,11 @@ public extension DTO.Response {
         public let posterURL: String
         public let artist: String
         public let daysLeft: Int
-        public let ticketSite: String
-        public let ticketURL: String
+        public let ticketSite: String?
+        public let ticketURL: String?
         public let venue: String
         public let introduction: String
-        public let label: String
+        public let label: String?
 
         enum CodingKeys: String, CodingKey {
             case id

--- a/Projects/Core/LivithNetwork/Sources/DTO/HomeFeature/UpdateUserInterestConcert.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/HomeFeature/UpdateUserInterestConcert.swift
@@ -30,11 +30,11 @@ public extension DTO.Response {
         public let status: String
         public let posterURL: String
         public let artist: String
-        public let ticketSite: String
-        public let ticketURL: String
+        public let ticketSite: String?
+        public let ticketURL: String?
         public let venue: String
         public let introduction: String
-        public let label: String
+        public let label: String?
 
         enum CodingKeys: String, CodingKey {
             case id

--- a/Projects/Core/LivithNetwork/Sources/DTO/OnboardingFeature/FetchUserInfo.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/OnboardingFeature/FetchUserInfo.swift
@@ -19,7 +19,17 @@ public extension DTO.Response {
     
     struct User: Decodable {
         public let id: String
+        public let interestConcertID: Int?
+        public let provider: String
+        public let providerID: String
+        public let email: String?
         public let nickname: String
-        public let email: String
+        public let marketingConsent: Bool
+        
+        enum CodingKeys: String, CodingKey {
+            case id
+            case interestConcertID = "interestConcertId"
+            case provider, providerID, email, nickname, marketingConsent
+        }
     }
 }

--- a/Projects/Core/LivithNetwork/Sources/DTO/SearchFeature/FetchBannerList.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/SearchFeature/FetchBannerList.swift
@@ -18,12 +18,14 @@ public extension DTO.Response {
         public let title: String
         public let category: String
         public let imageURL: String
+        public let content: String
 
         enum CodingKeys: String, CodingKey {
             case id
             case title
             case category
             case imageURL = "imgUrl"
+            case content
         }
     }
 }

--- a/Projects/Core/LivithNetwork/Sources/DTO/SearchFeature/FetchConcertList.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/SearchFeature/FetchConcertList.swift
@@ -25,11 +25,11 @@ public extension DTO.Response {
             public let posterURL: String
             public let artist: String
             public let daysLeft: Int
-            public let ticketSite: String
-            public let ticketURL: String
+            public let ticketSite: String?
+            public let ticketURL: String?
             public let venue: String
             public let introduction: String
-            public let label: String
+            public let label: String?
 
             enum CodingKeys: String, CodingKey {
                 case id

--- a/Projects/Core/LivithNetwork/Sources/DTO/SetlistFeature/FetchConcertSetlist.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/SetlistFeature/FetchConcertSetlist.swift
@@ -14,11 +14,11 @@ public extension DTO.Response {
     struct FetchConcertSetlist: Decodable {
         public let id: Int
         public let title: String
-        public let imageURL: String
+        public let imageURL: String?
         public let type: String
         public let startDate: String
         public let endDate: String
-        public let status: String
+        public let status: String?
         public let venue: String
         public let artist: String
 

--- a/Projects/Core/LivithNetwork/Sources/DTO/SongFeature/FetchSongFanchant.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/SongFeature/FetchSongFanchant.swift
@@ -16,7 +16,7 @@ public extension DTO.Response {
         public let setlistID: Int
         public let songID: Int
         public let fanchant: [String]
-        public let fanchantPoint: String
+        public let fanchantPoint: String?
 
         enum CodingKeys: String, CodingKey {
             case id

--- a/Projects/Core/LivithNetwork/Sources/DTO/SongFeature/FetchSongLyrics.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/SongFeature/FetchSongLyrics.swift
@@ -18,7 +18,7 @@ public extension DTO.Response {
         public let lyrics: [String]
         public let pronunciation: [String]
         public let translation: [String]
-        public let youtubeID: String
+        public let youtubeID: String?
 
         enum CodingKeys: String, CodingKey {
             case id

--- a/Projects/Core/LivithNetwork/Sources/DTO/UserFeature/DeleteUser.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/UserFeature/DeleteUser.swift
@@ -7,3 +7,15 @@
 //
 
 // MARK: - 35. 회원탈퇴
+
+public extension DTO.Request {
+    struct DeleteUser: Encodable {
+        public let reason: String
+    }
+}
+
+public extension DTO.Response {
+    struct DeleteUser: Decodable {
+        public let message: String
+    }
+}

--- a/Projects/Core/LivithNetwork/Sources/DTO/UserFeature/RequestLogout.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/UserFeature/RequestLogout.swift
@@ -7,3 +7,15 @@
 //
 
 // MARK: - 34. 로그아웃
+
+public extension DTO.Request {
+    struct RequestLogout: Encodable {
+        public let refreshToken: String
+    }
+}
+
+public extension DTO.Response {
+    struct RequestLogout: Encodable {
+        public let message: String
+    }
+}

--- a/Projects/Core/LivithNetwork/Sources/DTO/UserFeature/UpdateUserNickname.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/UserFeature/UpdateUserNickname.swift
@@ -7,3 +7,27 @@
 //
 
 // MARK: - 33. 닉네임 수정
+
+public extension DTO.Request {
+    struct UpdateUserNickname: Encodable {
+        public let nickname: String
+    }
+}
+
+public extension DTO.Response {
+    struct UpdateUserNickname: Decodable {
+        public let id: String
+        public let interestConcertID: Int?
+        public let provider: String
+        public let providerID: String
+        public let email: String?
+        public let nickname: String
+        public let marketingConsent: Bool
+        
+        enum CodingKeys: String, CodingKey {
+            case id
+            case interestConcertID = "interestConcertId"
+            case provider, providerID, email, nickname, marketingConsent
+        }
+    }
+}

--- a/Projects/Search/SearchData/Sources/DTO/Response/FetchFilterSearchResult.swift
+++ b/Projects/Search/SearchData/Sources/DTO/Response/FetchFilterSearchResult.swift
@@ -27,12 +27,12 @@ public extension DTO.Response {
             public let status: String
             public let posterURL: String
             public let artist: String
-            public let daysLeft: Int?
-            public let ticketSite: String
-            public let ticketURL: String
+            public let daysLeft: Int
+            public let ticketSite: String?
+            public let ticketURL: String?
             public let venue: String
             public let introduction: String
-            public let label: String
+            public let label: String?
 
             enum CodingKeys: String, CodingKey {
                 case id

--- a/Projects/Search/SearchData/Sources/Mapper/SearchMapper.swift
+++ b/Projects/Search/SearchData/Sources/Mapper/SearchMapper.swift
@@ -15,8 +15,7 @@ public class SearchMapper {
     func toDomain(from response: DTO.Response.FetchFilterSearchResult) -> SearchResultEntity {
         let concerts = response.data.compactMap { concert -> ConcertEntity? in
             guard let status = ConcertStatus(rawValue: concert.status),
-                  let posterURL = URL(string: concert.posterURL),
-                  let ticketURL = URL(string: concert.ticketURL) else {
+                  let posterURL = URL(string: concert.posterURL) else {
                 return nil
             }
 
@@ -25,13 +24,13 @@ public class SearchMapper {
                 title: concert.title,
                 artist: concert.artist,
                 status: status,
-                daysLeft: concert.daysLeft ?? 0,
+                daysLeft: concert.daysLeft,
                 startDate: concert.startDate,
                 endDate: concert.endDate,
                 posterURL: posterURL,
                 venue: concert.venue,
                 ticketSite: concert.ticketSite,
-                ticketURL: ticketURL,
+                ticketURL: URL(string: concert.ticketURL ?? ""),
                 introduction: concert.introduction,
                 label: concert.label
             )

--- a/Projects/Search/SearchDomain/Sources/Entity/ConcertEntity.swift
+++ b/Projects/Search/SearchDomain/Sources/Entity/ConcertEntity.swift
@@ -18,10 +18,10 @@ public struct ConcertEntity: Hashable, Identifiable {
     public let endDate: String
     public let posterURL: URL
     public let venue: String
-    public let ticketingOffice: String
-    public let ticketingOfficeURL: URL
+    public let ticketingOffice: String?
+    public let ticketingOfficeURL: URL?
     public let introduction: String
-    public let label: String
+    public let label: String?
     
     public init(
         id: Int,
@@ -33,10 +33,10 @@ public struct ConcertEntity: Hashable, Identifiable {
         endDate: String,
         posterURL: URL,
         venue: String,
-        ticketSite: String,
-        ticketURL: URL,
+        ticketSite: String?,
+        ticketURL: URL?,
         introduction: String,
-        label: String
+        label: String?
     ) {
         self.id = id
         self.title = title


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 회의에서 업데이트된 서버 명세에 따라 응답값 옵셔널 여부를 업데이트했어요.
- 기존에 미구현되어 구현해두지 않았던 DTO의 경우 토큰 관련 DTO를 제외하고 업데이트했어요.
- Search 모듈의 DTO 명세 변경에 따라 Entity를 수정했어요.

## 🔗 연결된 이슈
- Resolved: #48 
