### PR TITLE
[Fix] 카카오 로그인 리다이렉트 오류 해결

### DIFF
--- a/Projects/App/Resources/App-Info.plist
+++ b/Projects/App/Resources/App-Info.plist
@@ -47,5 +47,16 @@
 	</array>
 	<key>NATIVE_APP_KEY</key>
 	<string>$(NATIVE_APP_KEY)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao$(NATIVE_APP_KEY)</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Projects/App/Sources/LivithApp.swift
+++ b/Projects/App/Sources/LivithApp.swift
@@ -18,6 +18,9 @@ struct LivithApp: App {
     var body: some Scene {
         WindowGroup {
             AppRootView()
+                .onOpenURL { url in
+                    openKakaoLoginURL(url)
+                }
         }
     }
 }

--- a/Projects/Core/Auth/Sources/AuthService/KakaoLoginService.swift
+++ b/Projects/Core/Auth/Sources/AuthService/KakaoLoginService.swift
@@ -40,7 +40,7 @@ private extension KakaoLoginService {
         let completion = self.handleLoginResult(continuation: continuation)
         
         if KakaoUserAPI.isKakaoTalkLoginAvailable() {
-            KakaoUserAPI.shared.loginWithKakao(completion: completion)
+            KakaoUserAPI.shared.loginWithKakaoTalk(completion: completion)
         } else {
             KakaoUserAPI.shared.loginWithKakaoAccount(completion: completion)
         }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 카카오톡 로그인 시 앱으로 리다이렉트 되지 않는 문제를 해결했어요.
- `App-Info.plist`에 카카오톡 로그인을 위한 `CFBundleURLSchemes`를 추가했어요.

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
[카카오 로그인 iOS 문서](https://developers.kakao.com/docs/latest/ko/kakaologin/ios#before-you-begin-setting-for-kakaotalk)

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 핫픽스라 상세 브랜치에서 작업했습니다 ㅎㅎ

## 🔗 연결된 이슈
- Resolved: #66 
