### PR TITLE
[Refactor] 에러 표현 방식 토스트로 변경

### DIFF
--- a/Projects/Login/LoginFeature/Sources/Login/Store/LoginStore.swift
+++ b/Projects/Login/LoginFeature/Sources/Login/Store/LoginStore.swift
@@ -15,6 +15,7 @@ enum LoginIntent {
     case onAppear
     case kakaoLogin
     case appleLogin
+    case setErrorMessage(String)
     case _loginResult(Result<LoginStatus, Error>)
     case _setLastLoginPlatform(SocialLoginProvider?)
 }
@@ -22,7 +23,7 @@ enum LoginIntent {
 struct LoginState {
     var status: LoginStatus?
     var lastLoginPlatform: SocialLoginProvider?
-    var errorMessage: String?
+    var errorMessage: String = ""
 }
 
 final class LoginStore: ObservableObject {
@@ -34,7 +35,7 @@ final class LoginStore: ObservableObject {
         switch intent {
         case .onAppear:
             state.status = nil
-            state.errorMessage = nil
+            state.errorMessage = ""
             performFetchLastLoginPlatform()
             
         case .kakaoLogin:
@@ -42,6 +43,9 @@ final class LoginStore: ObservableObject {
             
         case .appleLogin:
             performLogin(for: .apple)
+            
+        case .setErrorMessage(let message):
+            state.errorMessage = message
             
         case ._loginResult(let result):
             switch result {
@@ -79,12 +83,12 @@ private extension LoginStore {
         }
     }
     
-    func formatErrorMessage(from error: Error) -> String? {
+    func formatErrorMessage(from error: Error) -> String {
         guard let loginError = error as? LoginError else { return LoginError.unknown.errorDescription }
         
         switch loginError {
         case .canceled, .forbidden:
-            return nil
+            return ""
         case .noConnection, .serverError, .notFound:
             return loginError.errorDescription
         case .noData, .unknown:

--- a/Projects/Login/LoginFeature/Sources/Login/Store/LoginStore.swift
+++ b/Projects/Login/LoginFeature/Sources/Login/Store/LoginStore.swift
@@ -31,6 +31,7 @@ final class LoginStore: ObservableObject {
     
     @Injected private var useCase: LoginUseCase
     
+    @MainActor
     func send(_ intent: LoginIntent) {
         switch intent {
         case .onAppear:
@@ -69,9 +70,9 @@ private extension LoginStore {
         Task {
             do {
                 let loginResult = try await useCase.execute(for: socialProvider)
-                await MainActor.run { send(._loginResult(.success(loginResult))) }
+                await send(._loginResult(.success(loginResult)))
             } catch {
-                await MainActor.run { send(._loginResult(.failure(error))) }
+                await send(._loginResult(.failure(error)))
             }
         }
     }
@@ -79,7 +80,7 @@ private extension LoginStore {
     func performFetchLastLoginPlatform() {
         Task {
             let platform = try? await useCase.lastLoginPlatform()
-            await MainActor.run { send(._setLastLoginPlatform(platform)) }
+            await send(._setLastLoginPlatform(platform))
         }
     }
     

--- a/Projects/Login/LoginFeature/Sources/Login/Store/LoginStore.swift
+++ b/Projects/Login/LoginFeature/Sources/Login/Store/LoginStore.swift
@@ -53,7 +53,7 @@ final class LoginStore: ObservableObject {
                 state.status = loginResult
             case .failure(let error):
                 // TODO: LoginError 중 forbidden 처리 -> 탈퇴 후 7일 이내 로그인 불가 알림
-                state.errorMessage = formatErrorMessage(from: error)
+                state.errorMessage = getErrorMessage(from: error)
             }
             
         case ._setLastLoginPlatform(let value):
@@ -83,16 +83,17 @@ private extension LoginStore {
         }
     }
     
-    func formatErrorMessage(from error: Error) -> String {
-        guard let loginError = error as? LoginError else { return LoginError.unknown.errorDescription }
-        
+    func getErrorMessage(from error: Error) -> String {
+        let unknownMessage = LoginError.unknown.errorDescription ?? ""
+        guard let loginError = error as? LoginError else { return unknownMessage }
+
         switch loginError {
         case .canceled, .forbidden:
             return ""
         case .noConnection, .serverError, .notFound:
-            return loginError.errorDescription
+            return loginError.errorDescription ?? unknownMessage
         case .noData, .unknown:
-            return LoginError.unknown.errorDescription
+            return unknownMessage
         }
     }
 }

--- a/Projects/Login/LoginFeature/Sources/Login/View/LoginView.swift
+++ b/Projects/Login/LoginFeature/Sources/Login/View/LoginView.swift
@@ -31,17 +31,15 @@ struct LoginView: View {
         .onAppear {
             store.send(.onAppear)
         }
-        .alert(
-            Literals.errorAlertTitle,
-            isPresented: .constant(store.state.errorMessage != nil),
-            presenting: store.state.errorMessage
-        ) { _ in
-            Button(Literals.confirmButtonTitle) {
-                store.send(.onAppear)
-            }
-        } message: { errorMessage in
-            Text(errorMessage)
-        }
+        .livithToast(
+            isPresented: Binding(
+                get: { !store.state.errorMessage.isEmpty },
+                set: { _ in store.send(.setErrorMessage("")) }
+            ),
+            type: .failure,
+            message: store.state.errorMessage,
+            duration: 2
+        )
         .onChange(of: store.state.status) { oldValue, newValue in
             guard let loginStatus = newValue else { return }
             handleLoginSuccess(loginStatus)

--- a/Projects/Login/LoginFeature/Sources/Onboarding/Store/NicknameSettingStore.swift
+++ b/Projects/Login/LoginFeature/Sources/Onboarding/Store/NicknameSettingStore.swift
@@ -78,7 +78,7 @@ final class NicknameSettingStore: ObservableObject {
                     state.nicknameValidationStatus = .duplicate
                 } else {
                     state.nicknameValidationStatus = .valid
-                    state.errorMessage = formatErrorMessage(error)
+                    state.errorMessage = getErrorMessage(from: error)
                 }
             }
             
@@ -92,7 +92,7 @@ final class NicknameSettingStore: ObservableObject {
                 let isRecoverableError = onboardingError == .invalidNicknameFormat || onboardingError == .nicknameDuplicated
                 
                 if isRecoverableError {
-                    state.errorMessage = formatErrorMessage(error)
+                    state.errorMessage = getErrorMessage(from: error)
                 } else {
                     state.signupStatus = .failure
                 }
@@ -146,10 +146,11 @@ private extension NicknameSettingStore {
         }
     }
     
-    func formatErrorMessage(_ error: Error) -> String {
+    func getErrorMessage(from error: Error) -> String {
+        let unknownMessage = OnboardingError.unknown.errorDescription ?? ""
         guard let onboardingError = error as? OnboardingError else {
-            return OnboardingError.unknown.errorDescription
+            return unknownMessage
         }
-        return onboardingError.errorDescription
+        return onboardingError.errorDescription ?? unknownMessage
     }
 }

--- a/Projects/Login/LoginFeature/Sources/Onboarding/Store/NicknameSettingStore.swift
+++ b/Projects/Login/LoginFeature/Sources/Onboarding/Store/NicknameSettingStore.swift
@@ -41,6 +41,7 @@ final class NicknameSettingStore: ObservableObject {
         self.tempUser = tempUser
     }
     
+    @MainActor
     func send(_ intent: NicknameSettingIntent) {
         switch intent {
         case .updateNickname(let nickname):
@@ -113,9 +114,9 @@ private extension NicknameSettingStore {
         Task {
             do {
                 try onboardingUseCase.validateNicknameFormat(state.nickname)
-                await MainActor.run { send(._validationResult(.success(()))) }
+                await send(._validationResult(.success(())))
             } catch {
-                await MainActor.run { send(._validationResult(.failure(error))) }
+                await send(._validationResult(.failure(error)))
             }
         }
     }
@@ -124,9 +125,9 @@ private extension NicknameSettingStore {
         Task {
             do {
                 try await onboardingUseCase.checkNicknameDuplicate(state.nickname)
-                await MainActor.run { send(._duplicateCheckResult(.success(()))) }
+                await send(._duplicateCheckResult(.success(())))
             } catch {
-                await MainActor.run { send(._duplicateCheckResult(.failure(error))) }
+                await send(._duplicateCheckResult(.failure(error)))
             }
         }
     }
@@ -139,9 +140,9 @@ private extension NicknameSettingStore {
                     nickname: state.nickname,
                     tempUser: tempUser
                 )
-                await MainActor.run { send(._signupResult(.success(()))) }
+                await send(._signupResult(.success(())))
             } catch {
-                await MainActor.run { send(._signupResult(.failure(error))) }
+                await send(._signupResult(.failure(error)))
             }
         }
     }

--- a/Projects/Login/LoginFeature/Sources/Onboarding/Store/NicknameSettingStore.swift
+++ b/Projects/Login/LoginFeature/Sources/Onboarding/Store/NicknameSettingStore.swift
@@ -15,14 +15,14 @@ struct NicknameSettingState {
     var nickname: String = ""
     var nicknameValidationStatus: NicknameValidationStatus = .idle
     var signupStatus: SignupStatus = .idle
-    var errorMessage: String?
+    var errorMessage: String = ""
 }
 
 enum NicknameSettingIntent {
     case updateNickname(String)
     case checkNicknameDuplicate
     case signup
-    case confirmAlert
+    case setErrorMessage(String)
     case _validationResult(Result<Void, Error>)
     case _duplicateCheckResult(Result<Void, Error>)
     case _signupResult(Result<Void, Error>)
@@ -55,9 +55,8 @@ final class NicknameSettingStore: ObservableObject {
             state.signupStatus = .loading
             performSignup()
             
-        case .confirmAlert:
-            state.errorMessage = nil
-            state.signupStatus = .idle
+        case .setErrorMessage(let message):
+            state.errorMessage = message
             
         case ._validationResult(let result):
             switch result {
@@ -147,7 +146,7 @@ private extension NicknameSettingStore {
         }
     }
     
-    func formatErrorMessage(_ error: Error) -> String? {
+    func formatErrorMessage(_ error: Error) -> String {
         guard let onboardingError = error as? OnboardingError else {
             return OnboardingError.unknown.errorDescription
         }

--- a/Projects/Login/LoginFeature/Sources/Onboarding/View/NicknameSettingView.swift
+++ b/Projects/Login/LoginFeature/Sources/Onboarding/View/NicknameSettingView.swift
@@ -52,17 +52,15 @@ struct NicknameSettingView: View {
             }
             .padding(.horizontal, 16)
         }
-        .alert(
-            Literals.errorAlertTitle,
-            isPresented: .constant(store.state.errorMessage != nil),
-            presenting: store.state.errorMessage
-        ) { _ in
-            Button(Literals.confirmButtonTitle) {
-                store.send(.confirmAlert)
-            }
-        } message: { errorMessage in
-            Text(errorMessage)
-        }
+        .livithToast(
+            isPresented: Binding(
+                get: { !store.state.errorMessage.isEmpty },
+                set: { _ in store.send(.setErrorMessage("")) }
+            ),
+            type: .failure,
+            message: store.state.errorMessage,
+            duration: 2
+        )
         .ignoresSafeArea(.all, edges: .bottom)
         .onChange(of: store.state.signupStatus) { oldValue, newValue in
             switch newValue {

--- a/Projects/Search/SearchFeature/Sources/Explore/Store/ExploreStore.swift
+++ b/Projects/Search/SearchFeature/Sources/Explore/Store/ExploreStore.swift
@@ -14,7 +14,7 @@ import DIContainer
 enum ExploreIntent {
     case onRefresh
     case setCurrentPage(Int)
-    case setErrorMessage(String?)
+    case setErrorMessage(String)
     case _fetchBannersResult(Result<[Banner], Error>)
     case _fetchSectionsResult(Result<[ConcertSection], Error>)
 } 
@@ -24,7 +24,7 @@ struct ExploreState {
     var banners: [Banner] = []
     var concertSections: [ConcertSection] = []
     var isLoading: Bool = false
-    var errorMessage: String? = nil
+    var errorMessage: String = ""
 }
 
 final class ExploreStore: ObservableObject {
@@ -46,7 +46,7 @@ final class ExploreStore: ObservableObject {
             state.banners = []
             state.concertSections = []
             state.isLoading = true
-            state.errorMessage = nil
+            state.errorMessage = ""
             
             performFetchExploreData()
         
@@ -107,7 +107,7 @@ private extension ExploreStore {
         }
     }
 
-    func getErrorMessage(from error: Error) -> String? {
+    func getErrorMessage(from error: Error) -> String {
         guard let searchError = error as? SearchError else {
             return SearchError.unknown.errorDescription
         }

--- a/Projects/Search/SearchFeature/Sources/Explore/Store/ExploreStore.swift
+++ b/Projects/Search/SearchFeature/Sources/Explore/Store/ExploreStore.swift
@@ -14,7 +14,7 @@ import DIContainer
 enum ExploreIntent {
     case onRefresh
     case setCurrentPage(Int)
-    case onAlertConfirm
+    case setErrorMessage(String?)
     case _fetchBannersResult(Result<[Banner], Error>)
     case _fetchSectionsResult(Result<[ConcertSection], Error>)
 } 
@@ -53,8 +53,8 @@ final class ExploreStore: ObservableObject {
         case .setCurrentPage(let page):
             state.currentPage = page
             
-        case .onAlertConfirm:
-            state.errorMessage = nil
+        case .setErrorMessage(let message):
+            state.errorMessage = message
             
         case ._fetchBannersResult(let result):
             state.isLoading = false

--- a/Projects/Search/SearchFeature/Sources/Explore/Store/ExploreStore.swift
+++ b/Projects/Search/SearchFeature/Sources/Explore/Store/ExploreStore.swift
@@ -108,15 +108,16 @@ private extension ExploreStore {
     }
 
     func getErrorMessage(from error: Error) -> String {
+        let unknownMessage = SearchError.unknown.errorDescription ?? ""
         guard let searchError = error as? SearchError else {
-            return SearchError.unknown.errorDescription
+            return unknownMessage
         }
 
         switch searchError {
         case .networkError, .serverError:
-            return searchError.errorDescription
+            return searchError.errorDescription ?? unknownMessage
         case .noSearchResult, .invalidResponse, .unknown:
-            return SearchError.unknown.errorDescription
+            return unknownMessage
         }
     }
 }

--- a/Projects/Search/SearchFeature/Sources/Explore/View/ExploreView.swift
+++ b/Projects/Search/SearchFeature/Sources/Explore/View/ExploreView.swift
@@ -35,11 +35,11 @@ struct ExploreView: View {
         .background(Color.livithColor(.black100))
         .livithToast(
             isPresented: Binding(
-                get: { store.state.errorMessage != nil },
-                set: { _ in store.send(.setErrorMessage(nil)) }
+                get: { !store.state.errorMessage.isEmpty },
+                set: { _ in store.send(.setErrorMessage("")) }
             ),
             type: .failure,
-            message: store.state.errorMessage ?? "",
+            message: store.state.errorMessage,
             duration: 2
         )
     }

--- a/Projects/Search/SearchFeature/Sources/Explore/View/ExploreView.swift
+++ b/Projects/Search/SearchFeature/Sources/Explore/View/ExploreView.swift
@@ -33,17 +33,15 @@ struct ExploreView: View {
             }
         }
         .background(Color.livithColor(.black100))
-        .alert(
-            "알림",
-            isPresented: .constant(store.state.errorMessage != nil),
-            presenting: store.state.errorMessage
-        ) { _ in
-            Button("확인") {
-                store.send(.onAlertConfirm)
-            }
-        } message: { errorMessage in
-            Text(errorMessage)
-        }
+        .livithToast(
+            isPresented: Binding(
+                get: { store.state.errorMessage != nil },
+                set: { _ in store.send(.setErrorMessage(nil)) }
+            ),
+            type: .failure,
+            message: store.state.errorMessage ?? "",
+            duration: 2
+        )
     }
 }
 


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 기존의 에러를 Alert로 보여주던 방식을 토스트로 적용하였습니다.
- 상태 업데이트 로직을 간소화하였습니다.
- 에러 메세지를 논옵셔널로 다루도록 하였습니다.

|    구현 내용    |   IPhone 17   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/4ee4d344-41e7-4b95-a4b5-1dfe31207e12" width=250> |

## 🔗 연결된 이슈
- Resolved: #74
