### PR TITLE
[Fix] 탭 스위칭 로직 변경

### DIFF
--- a/Projects/App/Sources/View/LivithMainTabView.swift
+++ b/Projects/App/Sources/View/LivithMainTabView.swift
@@ -58,15 +58,21 @@ public struct LivithMainTabView: View {
 
     public var body: some View {
         ZStack(alignment: .bottom) {
-            Group {
-                switch selectedTab {
-                case .home:
-                    HomeView()
-                case .search:
-                    SearchRootView(isTabBarHidden: $isTabBarHidden)
-                case .my:
-                    UserView(nickname: "유짐이", isTabBarHidden: $isTabBarHidden)
-                }
+            ZStack {
+                HomeView()
+                    .opacity(selectedTab == .home ? 1 : 0)
+                    .allowsHitTesting(selectedTab == .home)
+                    .transition(.opacity)
+                
+                SearchRootView(isTabBarHidden: $isTabBarHidden)
+                    .opacity(selectedTab == .search ? 1 : 0)
+                    .allowsHitTesting(selectedTab == .search)
+                    .transition(.opacity)
+                
+                UserView(nickname: "유짐이", isTabBarHidden: $isTabBarHidden)
+                    .opacity(selectedTab == .my ? 1 : 0)
+                    .allowsHitTesting(selectedTab == .my)
+                    .transition(.opacity)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 
@@ -77,6 +83,7 @@ public struct LivithMainTabView: View {
             }
         }
         .animation(.easeInOut(duration: 0.3), value: isTabBarHidden)
+        .animation(.easeInOut(duration: 0.3), value: selectedTab)
         .ignoresSafeArea(edges: .bottom)
     }
 }

--- a/Projects/App/Sources/View/LivithMainTabView.swift
+++ b/Projects/App/Sources/View/LivithMainTabView.swift
@@ -58,21 +58,18 @@ public struct LivithMainTabView: View {
 
     public var body: some View {
         ZStack(alignment: .bottom) {
-            ZStack {
+            TabView(selection: $selectedTab) {
                 HomeView()
-                    .opacity(selectedTab == .home ? 1 : 0)
-                    .allowsHitTesting(selectedTab == .home)
-                    .transition(.opacity)
+                    .tag(Tab.home)
+                    .toolbar(.hidden, for: .tabBar)
                 
                 SearchRootView(isTabBarHidden: $isTabBarHidden)
-                    .opacity(selectedTab == .search ? 1 : 0)
-                    .allowsHitTesting(selectedTab == .search)
-                    .transition(.opacity)
+                    .tag(Tab.search)
+                    .toolbar(.hidden, for: .tabBar)
                 
-                UserView(nickname: "유짐이", isTabBarHidden: $isTabBarHidden)
-                    .opacity(selectedTab == .my ? 1 : 0)
-                    .allowsHitTesting(selectedTab == .my)
-                    .transition(.opacity)
+                UserView(nickname: "유지미", isTabBarHidden: $isTabBarHidden)
+                    .tag(Tab.my)
+                    .toolbar(.hidden, for: .tabBar)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 기존의 탭 스위칭 로직을 변경하였습니다.

|    구현 내용    |   iPhone 17   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/4d8db980-222e-43c4-9cba-d0465c94adb4" width=250> |


## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 탭 스위칭
- 기존의 문제점은 변경된 Tab에 대해서 switch 문을 거쳐 항상 새로운 View를 반환한다는 점입니다.
    - 뷰 생성에 따른 네트워크 재수행
    - UI 초기화
- 이를 ZStack으로 변경하고, 투명도(opacity)를 조정하도록 하여 뷰인스턴스는 유지하고 탭만 스위칭되도록 하였습니다.

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 번쩍거리는듯한 효과가 무언가 맘에 들지 않지만, 빠른 진행을 위해 넘어가야 할지 고민입니다.
- 앱 진입점부터 상태 변수로 닉네임을 가지며, 하위 뷰에 바인딩으로 전달해야 할지 고민입니다.

## 🔗 연결된 이슈
- Resolved: #80 
