### PR TITLE
[Feat] 로그인/회원가입 성공 후, 닉네임 하위뷰로 전달

### DIFF
--- a/Projects/App/Sources/View/AppRootView.swift
+++ b/Projects/App/Sources/View/AppRootView.swift
@@ -57,7 +57,7 @@ private extension AppRootView {
                 }
 
             case .main:
-                LivithMainTabView()
+                LivithMainTabView(nickname: $nickname)
             }
         } else {
             Color.clear

--- a/Projects/App/Sources/View/AppRootView.swift
+++ b/Projects/App/Sources/View/AppRootView.swift
@@ -34,7 +34,7 @@ struct AppRootView: View {
         .animation(.easeInOut(duration: Constants.animationDuration), value: currentRoute)
         .animation(.easeInOut(duration: Constants.animationDuration), value: isWelcomeSheetVisible)
         .onReceive(NotificationCenter.default.publisher(for: Notification.Name.reloginRequired)) { _ in
-            currentRoute = .login
+            transition(to: .login)
         }
         .onAppear {
             handleOnAppear()
@@ -87,18 +87,11 @@ private extension AppRootView {
     }
     
     func handleLoginCompleted(nickname: String) {
-        withAnimation(.easeInOut(duration: Constants.animationDuration)) {
-            currentRoute = .main
-        }
-        self.nickname = nickname
+        transition(to: .main, nickname: nickname)
     }
     
     func handleSignupCompleted(nickname: String) {
-        withAnimation(.easeInOut(duration: Constants.animationDuration)) {
-            currentRoute = .main
-        }
-        self.nickname = nickname
-        isWelcomeSheetVisible = true
+        transition(to: .main, nickname: nickname, showWelcome: true)
     }
 
     func handleOnAppear() {
@@ -118,6 +111,18 @@ private extension AppRootView {
             currentRoute = .main
         } catch {
             currentRoute = .login
+        }
+    }
+
+    func transition(to route: AppRoute, nickname: String? = nil, showWelcome: Bool = false) {
+        withAnimation(.easeInOut(duration: Constants.animationDuration)) {
+            currentRoute = route
+
+            if let nickname = nickname {
+                self.nickname = nickname
+            }
+
+            isWelcomeSheetVisible = showWelcome
         }
     }
 }

--- a/Projects/App/Sources/View/AppRootView.swift
+++ b/Projects/App/Sources/View/AppRootView.swift
@@ -15,7 +15,8 @@ import Persistence
 struct AppRootView: View {
     @State private var currentRoute: AppRoute?
     @State private var isLaunchScreenVisible: Bool = true
-    @State private var welcomeNickname: String?
+    @State private var nickname: String = ""
+    @State private var isWelcomeSheetVisible: Bool = false
     
     private let localKeyValueStorage: LocalKeyValueStorage
     
@@ -31,7 +32,7 @@ struct AppRootView: View {
         }
         .animation(.easeInOut(duration: Constants.animationDuration), value: isLaunchScreenVisible)
         .animation(.easeInOut(duration: Constants.animationDuration), value: currentRoute)
-        .animation(.easeInOut(duration: Constants.animationDuration), value: welcomeNickname)
+        .animation(.easeInOut(duration: Constants.animationDuration), value: isWelcomeSheetVisible)
         .onReceive(NotificationCenter.default.publisher(for: Notification.Name.reloginRequired)) { _ in
             currentRoute = .login
         }
@@ -49,10 +50,8 @@ private extension AppRootView {
         if let route = currentRoute {
             switch route {
             case .login:
-                LoginRootView {
-                    withAnimation(.easeInOut(duration: Constants.animationDuration)) {
-                        currentRoute = .main
-                    }
+                LoginRootView { nickname in
+                    handleLoginCompleted(nickname: nickname)
                 } onSignupCompleted: { nickname in
                     handleSignupCompleted(nickname: nickname)
                 }
@@ -76,10 +75,10 @@ private extension AppRootView {
 
     @ViewBuilder
     func welcomeSheetOverlay() -> some View {
-        if let nickname = welcomeNickname {
+        if isWelcomeSheetVisible {
             WelcomeSheetView(nickname: nickname) {
                 withAnimation(.easeInOut(duration: Constants.animationDuration)) {
-                    welcomeNickname = nil
+                    isWelcomeSheetVisible = false
                 }
             }
             .transition(.opacity)
@@ -87,11 +86,19 @@ private extension AppRootView {
         }
     }
     
+    func handleLoginCompleted(nickname: String) {
+        withAnimation(.easeInOut(duration: Constants.animationDuration)) {
+            currentRoute = .main
+        }
+        self.nickname = nickname
+    }
+    
     func handleSignupCompleted(nickname: String) {
         withAnimation(.easeInOut(duration: Constants.animationDuration)) {
             currentRoute = .main
         }
-        welcomeNickname = nickname
+        self.nickname = nickname
+        isWelcomeSheetVisible = true
     }
 
     func handleOnAppear() {
@@ -106,7 +113,8 @@ private extension AppRootView {
 
     func checkInitialRoute() {
         do {
-            let _: DTO.Response.FetchUserInfo = try localKeyValueStorage.fetch(for: "currentUser")
+            let user: DTO.Response.FetchUserInfo = try localKeyValueStorage.fetch(for: "currentUser")
+            self.nickname = user.nickname
             currentRoute = .main
         } catch {
             currentRoute = .login

--- a/Projects/App/Sources/View/LivithMainTabView.swift
+++ b/Projects/App/Sources/View/LivithMainTabView.swift
@@ -13,7 +13,7 @@ import HomeFeature
 import UserFeature
 import SearchFeature
 
-public struct LivithMainTabView: View {
+struct LivithMainTabView: View {
 
     // MARK: - Enum
 
@@ -47,16 +47,19 @@ public struct LivithMainTabView: View {
 
     // MARK: - Property
     
+    @Binding private var nickname: String
     @State private var selectedTab: Tab = .home
     @State private var isTabBarHidden: Bool = false
     
     // MARK: - LifeCycle
 
-    public init() { }
+    init(nickname: Binding<String>) {
+        self._nickname = nickname
+    }
 
     // MARK: - Body
 
-    public var body: some View {
+    var body: some View {
         ZStack(alignment: .bottom) {
             TabView(selection: $selectedTab) {
                 HomeView()
@@ -67,7 +70,7 @@ public struct LivithMainTabView: View {
                     .tag(Tab.search)
                     .toolbar(.hidden, for: .tabBar)
                 
-                UserView(nickname: "유지미", isTabBarHidden: $isTabBarHidden)
+                UserView(nickname: $nickname, isTabBarHidden: $isTabBarHidden)
                     .tag(Tab.my)
                     .toolbar(.hidden, for: .tabBar)
             }

--- a/Projects/Login/LoginData/Sources/Login/LoginRepositoryImpl.swift
+++ b/Projects/Login/LoginData/Sources/Login/LoginRepositoryImpl.swift
@@ -123,9 +123,10 @@ private extension LoginRepositoryImpl {
         }
     }
     
-    func fetchAndStoreCurrentUser() async throws {
+    func fetchAndStoreCurrentUser() async throws -> String {
         let userInfo: DTO.Response.FetchUserInfo = try await loginService.request(.fetchUserInfo)
         try localStorage.save(userInfo, for: LocalStorageKeys.currentUser)
+        return userInfo.nickname
     }
     
     func finalizeExistingUser(
@@ -138,7 +139,7 @@ private extension LoginRepositoryImpl {
         }
         try await tokenService.saveToken(accessToken: accessToken, refreshToken: refreshToken)
         try? localStorage.save(provider.description, for: LocalStorageKeys.lastLoginPlatform)
-        try await fetchAndStoreCurrentUser()
-        return .existingUser
+        let nickname = try await fetchAndStoreCurrentUser()
+        return .existingUser(nickname: nickname)
     }
 }

--- a/Projects/Login/LoginDomain/Sources/Login/Model/LoginStatus.swift
+++ b/Projects/Login/LoginDomain/Sources/Login/Model/LoginStatus.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public enum LoginStatus: Equatable {
-    case existingUser
+    case existingUser(nickname: String)
     case newUser(tempUser: TempUser)
     case forbidden
 }

--- a/Projects/Login/LoginFeature/Sources/Login/View/LoginView.swift
+++ b/Projects/Login/LoginFeature/Sources/Login/View/LoginView.swift
@@ -45,8 +45,8 @@ struct LoginView: View {
     
     private func handleLoginSuccess(_ status: LoginStatus) {
         switch status {
-        case .existingUser:
-            router.completeLogin()
+        case .existingUser(let nickname):
+            router.completeLogin(nickname: nickname)
         case .newUser(let tempUser):
             router.push(.terms(tempUser))
         case .forbidden:

--- a/Projects/Login/LoginFeature/Sources/Route/LoginRootView.swift
+++ b/Projects/Login/LoginFeature/Sources/Route/LoginRootView.swift
@@ -15,7 +15,7 @@ public struct LoginRootView: View {
     @StateObject private var router: LoginRouter
 
     public init(
-        onLoginCompleted: @escaping () -> Void,
+        onLoginCompleted: @escaping (String) -> Void,
         onSignupCompleted: @escaping (String) -> Void
     ) {
         _router = StateObject(

--- a/Projects/Login/LoginFeature/Sources/Route/LoginRouter.swift
+++ b/Projects/Login/LoginFeature/Sources/Route/LoginRouter.swift
@@ -21,11 +21,11 @@ final class LoginRouter: Router {
     @Published var sheet: Route?
     @Published var fullScreenCover: Route?
     
-    private let onLoginCompleted: () -> Void
+    private let onLoginCompleted: (String) -> Void
     private let onSignupCompleted: (String) -> Void
 
     init(
-        onLoginCompleted: @escaping () -> Void = {},
+        onLoginCompleted: @escaping (String) -> Void = { _ in },
         onSignupCompleted: @escaping (String) -> Void = { _ in }
     ) {
         self.onLoginCompleted = onLoginCompleted
@@ -84,8 +84,8 @@ final class LoginRouter: Router {
         }
     }
 
-    func completeLogin() {
-        onLoginCompleted()
+    func completeLogin(nickname: String) {
+        onLoginCompleted(nickname)
     }
 
     func completeSignup(nickname: String) {

--- a/Projects/User/UserFeature/Sources/View/UserView.swift
+++ b/Projects/User/UserFeature/Sources/View/UserView.swift
@@ -37,7 +37,7 @@ public struct UserView: View {
 
     // MARK: - Property
 
-    private let nickname: String
+    @Binding private var nickname: String
 
     @State private var path = NavigationPath()
     @State private var overlayType: OverlayType = .none
@@ -47,8 +47,8 @@ public struct UserView: View {
     
     // MARK: - LifeCycle
     
-    public init(nickname: String, isTabBarHidden: Binding<Bool>) {
-        self.nickname = nickname
+    public init(nickname: Binding<String>, isTabBarHidden: Binding<Bool>) {
+        self._nickname = nickname
         self._isTabBarHidden = isTabBarHidden
     }
     


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 로그인/회원가입 성공 후, 닉네임을 하위뷰로 전달합니다.

|    구현 내용    |   iPhone 17   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/bf0ae208-eb24-46f1-ae55-8e652f0a8d73" width=250> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 로그인/회원가입 성공 후, 닉네임을 하위 뷰까지 전달하는 방법
- 로그인/회원가입 성공 후, 다시 앱 루트뷰로 돌아옵니다. (클로저 콜백으로 닉네임 전달)
- 전달 받은 닉네임을 상태 변수로 설정
- 상태 변수인 닉네임을 `Binding`으로 메인 탭 뷰로 전달
- 메인 탭 뷰에서 유저뷰로 `Binding`을 전달

## 🔗 연결된 이슈
- Resolved: #82 
