### PR TITLE
[Feat] 탐색 탭 루트뷰 엠티뷰 구현

### DIFF
--- a/Projects/DSKit/Sources/SwiftUIHelper/ShapeStyle+.swift
+++ b/Projects/DSKit/Sources/SwiftUIHelper/ShapeStyle+.swift
@@ -1,0 +1,26 @@
+//
+//  ShapeStyle+.swift
+//  DSKit
+//
+//  Created by 김진웅 on 12/24/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import SwiftUI
+
+public extension ShapeStyle where Self == Color {
+    /// `.foregroundStyle()` 또는 `.background()` 모디파이어에서 바로 Livith 컬러를 사용할 수 있습니다.
+    ///
+    /// 사용 예시:
+    /// ```swift
+    /// Text("Hello")
+    ///     .foregroundStyle(.livithColor(.black100))
+    ///     .background(.livithColor(.white100))
+    /// ```
+    ///
+    /// - Parameter color: LivithColor 열거형 케이스
+    /// - Returns: 해당 색상에 맞는 Color 객체
+    static func livithColor(_ color: Color.LivithColor) -> Color {
+        return color.color
+    }
+}

--- a/Projects/Search/SearchFeature/Sources/Explore/View/ExploreView.swift
+++ b/Projects/Search/SearchFeature/Sources/Explore/View/ExploreView.swift
@@ -83,6 +83,11 @@ private extension ExploreView {
         .refreshable {
             store.send(.onRefresh)
         }
+        .overlay {
+            if store.state.banners.isEmpty && store.state.concertSections.isEmpty && !store.state.isLoading {
+                ExploreEmptyView()
+            }
+        }
     }
     
     var bannerView: some View {

--- a/Projects/Search/SearchFeature/Sources/Explore/View/ExploreView.swift
+++ b/Projects/Search/SearchFeature/Sources/Explore/View/ExploreView.swift
@@ -33,15 +33,6 @@ struct ExploreView: View {
             }
         }
         .background(Color.livithColor(.black100))
-        .livithToast(
-            isPresented: Binding(
-                get: { !store.state.errorMessage.isEmpty },
-                set: { _ in store.send(.setErrorMessage("")) }
-            ),
-            type: .failure,
-            message: store.state.errorMessage,
-            duration: 2
-        )
     }
 }
 
@@ -85,7 +76,7 @@ private extension ExploreView {
         }
         .overlay {
             if store.state.banners.isEmpty && store.state.concertSections.isEmpty && !store.state.isLoading {
-                ExploreEmptyView()
+                ExploreEmptyView(message: store.state.errorMessage)
             }
         }
     }

--- a/Projects/Search/SearchFeature/Sources/Explore/View/Subview/ExploreEmptyView.swift
+++ b/Projects/Search/SearchFeature/Sources/Explore/View/Subview/ExploreEmptyView.swift
@@ -1,0 +1,31 @@
+//
+//  ExploreEmptyView.swift
+//  SearchFeature
+//
+//  Created by 김진웅 on 12/24/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import SwiftUI
+
+import DSKit
+
+struct ExploreEmptyView: View {
+    var body: some View {
+        VStack(spacing: 0) {
+            Image.livithImage(.livithEmpty)
+                .resizable()
+                .frame(width: 52, height: 40)
+            
+            Text("아직 탐색할 콘텐츠가 없어요")
+                .notosans(.body2Medium)
+                .foregroundStyle(.livithColor(.black80))
+                .padding(.top, 16)
+        }
+    }
+}
+
+#Preview {
+    ExploreEmptyView()
+        .background(.livithColor(.black100))
+}

--- a/Projects/Search/SearchFeature/Sources/Explore/View/Subview/ExploreEmptyView.swift
+++ b/Projects/Search/SearchFeature/Sources/Explore/View/Subview/ExploreEmptyView.swift
@@ -11,21 +11,32 @@ import SwiftUI
 import DSKit
 
 struct ExploreEmptyView: View {
+    let message: String
+
+    init(message: String = "") {
+        self.message = message
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             Image.livithImage(.livithEmpty)
                 .resizable()
                 .frame(width: 52, height: 40)
             
-            Text("아직 탐색할 콘텐츠가 없어요")
+            Text(message.isEmpty ? "아직 탐색할 콘텐츠가 없어요" : message)
                 .notosans(.body2Medium)
                 .foregroundStyle(.livithColor(.black80))
+                .multilineTextAlignment(.center)
                 .padding(.top, 16)
+                .padding(.horizontal, 20)
         }
     }
 }
 
 #Preview {
-    ExploreEmptyView()
-        .background(.livithColor(.black100))
+    VStack {
+        ExploreEmptyView()
+        ExploreEmptyView(message: "네트워크 오류가 발생했어요. 잠시 후 다시 시도해주세요.")
+    }
+    .background(.livithColor(.black100))
 }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 탐색 탭 루트뷰에 엠티뷰를 적용합니다.

|    구현 내용    |   iPhone 17   |
| :-------------: | :----------: |
| 스크린샷 | <img src = "https://github.com/user-attachments/assets/7b7c4e47-53f9-42a5-8853-e0ccb8312f16" width=250> |


## 🔗 연결된 이슈
- Resolved: #84 