### PR TITLE
[Refactor] 토큰 관리 시스템 에러 처리 개선

### DIFF
--- a/Projects/Core/LivithNetwork/Sources/Foundation/NetworkService.swift
+++ b/Projects/Core/LivithNetwork/Sources/Foundation/NetworkService.swift
@@ -81,6 +81,8 @@ public extension NetworkService {
                 interceptor: interceptor(for: endPoint)
             )
         }
+        
+        dataRequest.validate()
 
         do {
             let data = try await dataRequest.serializingData().value

--- a/Projects/Core/LivithNetwork/Sources/Token/Refresher/TokenRefresher.swift
+++ b/Projects/Core/LivithNetwork/Sources/Token/Refresher/TokenRefresher.swift
@@ -24,45 +24,59 @@ struct TokenRefresher {
     }
     
     func refresh(with refreshToken: String) async throws(TokenError) -> DTO.Response.UpdateToken {
+        print("[TokenRefresher] 🔵 refresh(with:) 시작")
         do {
             let request = try buildRequest(refreshToken: refreshToken)
+            print("[TokenRefresher] 🟡 HTTP 요청 전송")
             let (data, response) = try await urlSession.data(for: request)
             
             guard let httpResponse = response as? HTTPURLResponse else {
+                print("[TokenRefresher] ❌ refresh(with:) 실패: 유효하지 않은 HTTP 응답")
                 throw TokenError.unknown
             }
             
-            guard (200...299).contains(httpResponse.statusCode) else {
-                if httpResponse.statusCode == 401 {
-                    throw TokenError.refreshTokenExpired
-                } else {
-                    throw TokenError.networkError
-                }
+            if let dataString = String(data: data, encoding: .utf8) {
+                print("[TokenRefresher] 🔍 원본 데이터: \(dataString)")
             }
             
-            let result = try decoder.decode(BaseResponse<DTO.Response.UpdateToken>.self, from: data)
+            guard (200...299).contains(httpResponse.statusCode) else {
+                throw mapStatusCodeToError(httpResponse.statusCode)
+            }
+            
+            let result: BaseResponse<DTO.Response.UpdateToken>
+            do {
+                result = try decoder.decode(BaseResponse<DTO.Response.UpdateToken>.self, from: data)
+            } catch {
+                print("[TokenRefresher] ❌ refresh(with:) 실패: 응답 디코딩 실패 - \(error)")
+                throw TokenError.refresh(.decodingFailed)
+            }
             
             guard let data = result.data else {
-                throw TokenError.noData
+                print("[TokenRefresher] ❌ refresh(with:) 실패: 응답 데이터 없음")
+                throw TokenError.refresh(.emptyResponse)
             }
+            print("[TokenRefresher] ✅ refresh(with:) 완료")
             return data
         } catch let error as TokenError {
             throw error
         } catch {
-            throw .networkError
+            throw TokenError.refresh(.noConnection)
         }
     }
     
     private func buildRequest(refreshToken: String) throws -> URLRequest {
+        print("[TokenRefresher] 🟡 buildRequest(refreshToken:) 시작, refreshToken: \(refreshToken)")
         var components = URLComponents(
             url: Bundle.baseURL.appendingPathComponent(Literals.tokenRefreshPath),
             resolvingAgainstBaseURL: false
         )
         components?.queryItems = [URLQueryItem(name: Literals.clientQueryKey, value: Literals.clientQueryValue)]
         guard let url = components?.url else {
+            print("[TokenRefresher] ❌ buildRequest(refreshToken:) 실패: URL 생성 실패")
             throw TokenError.unknown
         }
         
+        print("[TokenRefresher] 🟡 URL 생성 완료: \(url.absoluteString)")
         var request = URLRequest(url: url)
         request.httpMethod = Literals.postMethod
         request.setValue(Literals.contentTypeValue, forHTTPHeaderField: Literals.contentTypeKey)
@@ -71,6 +85,27 @@ struct TokenRefresher {
         request.httpBody = try encoder.encode(requestBody)
         
         return request
+    }
+
+    private func mapStatusCodeToError(_ statusCode: Int) -> TokenError {
+        let error = switch statusCode {
+        case 400:
+            TokenError.refresh(.badRequest)
+        case 401:
+            TokenError.refresh(.unauthorized)
+        case 403:
+            TokenError.refresh(.forbidden)
+        case 404:
+            TokenError.refresh(.notFound)
+        case 400...499:
+            TokenError.refresh(.unauthorized)
+        case 500...599:
+            TokenError.refresh(.serverError)
+        default:
+            TokenError.unknown
+        }
+        print("[TokenRefresher] ❌ HTTP 오류 발생: 상태 코드 \(statusCode), 오류: \(error)")
+        return error
     }
 }
 

--- a/Projects/Core/LivithNetwork/Sources/Token/Service/TokenService.swift
+++ b/Projects/Core/LivithNetwork/Sources/Token/Service/TokenService.swift
@@ -29,9 +29,10 @@ public actor TokenServiceImpl: TokenService {
         do {
             let token = try storage.fetch()
             return token.accessToken
-        } catch TokenError.refreshTokenExpired {
-            handleRefreshTokenExpired()
-            throw .refreshTokenExpired
+        } catch {
+            try await refresh()
+            let token = try storage.fetch()
+            return token.accessToken
         }
     }
     
@@ -39,40 +40,28 @@ public actor TokenServiceImpl: TokenService {
         do {
             let token = try storage.fetch()
             return token.refreshToken
-        } catch TokenError.refreshTokenExpired {
+        } catch {
             handleRefreshTokenExpired()
-            throw .refreshTokenExpired
+            throw error
         }
     }
     
     public func saveToken(accessToken: String, refreshToken: String) async throws(TokenError) {
-        do {
-            let token = Token(accessToken: accessToken, refreshToken: refreshToken, refreshTokenIssuedAt: .now)
-            try storage.save(token)
-        } catch {
-            throw TokenError.saveFailed
-        }
+        let token = Token(accessToken: accessToken, refreshToken: refreshToken, refreshTokenIssuedAt: .now)
+        try storage.save(token)
     }
 
     public func refresh() async throws(TokenError) {
         do {
             try await performRefresh()
-        } catch TokenError.refreshTokenExpired {
-            handleRefreshTokenExpired()
-            throw .refreshTokenExpired
-        } catch let error as TokenError {
-            throw error
         } catch {
-            throw TokenError.unknown
+            handleRefreshTokenExpired()
+            throw error as? TokenError ?? TokenError.unknown
         }
     }
     
     public func removeToken() async throws(TokenError) {
-        do {
-            try storage.remove()
-        } catch {
-            throw TokenError.deleteFailed
-        }
+        try storage.remove()
     }
     
     public func isRefreshTokenExpired() async -> Bool {
@@ -90,7 +79,6 @@ private extension TokenServiceImpl {
         
         let task = Task<Void, Error> {
             let token = try self.storage.fetch()
-            print(">>> 토큰이 키체인에 있다. [\(#file) \(#line)] - \(token)")
             let response = try await self.refresher.refresh(with: token.refreshToken)
             
             let newToken = Token(
@@ -109,6 +97,7 @@ private extension TokenServiceImpl {
     }
     
     func handleRefreshTokenExpired() {
+        print("[TokenService] 🟡 handleRefreshTokenExpired() - 토큰 삭제 및 재로그인 알림 전송")
         try? storage.remove()
         notifyReloginRequired()
     }

--- a/Projects/Core/LivithNetwork/Sources/Token/Storage/TokenStorage.swift
+++ b/Projects/Core/LivithNetwork/Sources/Token/Storage/TokenStorage.swift
@@ -17,6 +17,7 @@ struct TokenStorage {
     }
     
     func save(_ token: Token) throws(TokenError) {
+        print("[TokenStorage] 🔵 save() 시작")
         try? remove()
         
         do {
@@ -25,39 +26,48 @@ struct TokenStorage {
             
             let issuedAtString = String(token.refreshTokenIssuedAt.timeIntervalSince1970)
             try add(key: .issuedAt, value: issuedAtString)
+            print("[TokenStorage] ✅ save() 완료")
         } catch {
-            throw TokenError.saveFailed
+            print("[TokenStorage] ❌ save() 실패: \(error)")
+            throw TokenError.storage(.saveFailed)
         }
     }
     
     func fetch() throws(TokenError) -> Token {
+        print("[TokenStorage] 🔵 fetch() 시작")
         let accessToken = try fetch(key: .accessToken)
         let refreshToken = try fetch(key: .refreshToken)
         let issuedAtString = try fetch(key: .issuedAt)
         
         guard let timeInterval = TimeInterval(issuedAtString) else {
-            throw TokenError.noData
+            print("[TokenStorage] ❌ fetch() 실패: 유효하지 않은 issuedAt 형식")
+            throw TokenError.storage(.noData)
         }
         let issuedAt = Date(timeIntervalSince1970: timeInterval)
 
         let token = Token(accessToken: accessToken, refreshToken: refreshToken, refreshTokenIssuedAt: issuedAt)
 
         if token.refreshTokenIsExpired {
-            throw .refreshTokenExpired
+            print("[TokenStorage] ❌ fetch() 실패: refreshToken 만료됨")
+            throw .storage(.refreshTokenExpired)
         }
         
+        print("[TokenStorage] ✅ fetch() 완료")
         return token
     }
     
     func remove() throws(TokenError) {
+        print("[TokenStorage] 🔵 remove() 시작")
         let keysToDelete: [Keys] = [.accessToken, .refreshToken, .issuedAt]
         
         for key in keysToDelete {
             let status = delete(key: key)
             if status != errSecSuccess && status != errSecItemNotFound {
-                throw TokenError.deleteFailed
+                print("[TokenStorage] ❌ remove() 실패: \(key.description) 삭제 중 에러")
+                throw TokenError.storage(.deleteFailed)
             }
         }
+        print("[TokenStorage] ✅ remove() 완료")
     }
 }
 
@@ -80,7 +90,7 @@ private extension TokenStorage {
     
     func add(key: Keys, value: String) throws(TokenError) {
         guard let valueData = value.data(using: .utf8) else {
-            throw TokenError.saveFailed
+            throw TokenError.storage(.saveFailed)
         }
         
         var query = keychainQuery(for: key)
@@ -89,7 +99,7 @@ private extension TokenStorage {
         
         let status = SecItemAdd(query as CFDictionary, nil)
         guard status == errSecSuccess else {
-            throw TokenError.saveFailed
+            throw TokenError.storage(.saveFailed)
         }
     }
     
@@ -102,7 +112,7 @@ private extension TokenStorage {
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         
         guard status != errSecItemNotFound else {
-            throw TokenError.noData
+            throw TokenError.storage(.noData)
         }
         
         guard status == errSecSuccess else {
@@ -112,16 +122,17 @@ private extension TokenStorage {
         guard let data = result as? Data,
               let value = String(data: data, encoding: .utf8)
         else {
-            throw TokenError.noData
+            throw TokenError.storage(.noData)
         }
-        
+
         return value
     }
     
     @discardableResult
     func delete(key: Keys) -> OSStatus {
         let query = keychainQuery(for: key)
-        return SecItemDelete(query as CFDictionary)
+        let status = SecItemDelete(query as CFDictionary)
+        return status
     }
     
     func keychainQuery(for key: Keys) -> [String: Any] {

--- a/Projects/Core/LivithNetwork/Sources/Token/TokenError.swift
+++ b/Projects/Core/LivithNetwork/Sources/Token/TokenError.swift
@@ -9,25 +9,74 @@
 import Foundation
 
 public enum TokenError: Error, LocalizedError {
-    case saveFailed
-    case deleteFailed
-    case noData
-    case refreshTokenExpired
-    case networkError
+    case storage(StorageError)
+    case refresh(RefreshError)
     case unknown
+    
+    // MARK: - Storage Error
+    
+    public enum StorageError: Error, LocalizedError {
+        case saveFailed
+        case deleteFailed
+        case noData
+        case refreshTokenExpired
+        
+        public var errorDescription: String? {
+            switch self {
+            case .saveFailed:
+                return "토큰 저장에 실패했습니다."
+            case .deleteFailed:
+                return "토큰 삭제에 실패했습니다."
+            case .noData:
+                return "토큰 데이터가 없습니다."
+            case .refreshTokenExpired:
+                return "리프레시 토큰이 만료되었습니다."
+            }
+        }
+    }
+    
+    // MARK: - Refresh Error
+    
+    public enum RefreshError: Error, LocalizedError {
+        case badRequest
+        case unauthorized
+        case forbidden
+        case notFound
+        case serverError
+        case noConnection
+        case decodingFailed
+        case emptyResponse
+        
+        public var errorDescription: String? {
+            switch self {
+            case .badRequest:
+                return "잘못된 요청입니다. 요청 형식을 확인해주세요."
+            case .unauthorized:
+                return "인증에 실패했습니다."
+            case .forbidden:
+                return "해당 작업에 대한 권한이 없습니다."
+            case .notFound:
+                return "요청한 리소스를 찾을 수 없습니다."
+            case .serverError:
+                return "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
+            case .noConnection:
+                return "네트워크 연결에 실패했습니다. 인터넷 연결을 확인해주세요."
+            case .decodingFailed:
+                return "서버 응답을 처리하는 데 실패했습니다."
+            case .emptyResponse:
+                return "서버에서 빈 응답을 받았습니다."
+            }
+        }
+    }
+    
+    // MARK: - Error Description
     
     public var errorDescription: String? {
         switch self {
-        case .saveFailed:
-            return "토큰 저장에 실패했습니다."
-        case .deleteFailed:
-            return "토큰 삭제에 실패했습니다."
-        case .noData:
-            return "토큰 데이터가 없습니다."
-        case .refreshTokenExpired:
-            return "리프레시 토큰이 만료되었습니다."
-        case .networkError:
-            return "네트워크 오류로 인해 토큰 작업에 실패했습니다."
+        case .storage(let error):
+            return error.errorDescription
+        case .refresh(let error):
+            return error.errorDescription
         case .unknown:
             return "알 수 없는 토큰 오류가 발생했습니다."
         }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 토큰 재발급 과정에서 어떠한 오류라도 발생 시에 재로그인 하도록 수정하였습니다.
- 리퀘스트 인터셉터가 동작하도록 validate 메서드를 호출했습니다.
- 에러 케이스를 구체화하였습니다.
- 토큰의 전반적인 로직 흐름 상에 print 문을 두어 흐름을 원할히 파악할 수 있도록 하였습니다.


## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 아직 어떠한 오류인지 구체적으로 파악이 되지는 않았지만, iOS 오류는 아닌 것 같아 로직 수정 후 원할한 개발 진행을 위해 PR 작성하였습니다.

## 🔗 연결된 이슈
- Resolved: #96
