### PR TITLE
[Feat] 콘서트 상세 화면 셋리스트 탭 구현

### DIFF
--- a/Projects/Concert/ConcertData/Sources/Mapper/ConcertMapper.swift
+++ b/Projects/Concert/ConcertData/Sources/Mapper/ConcertMapper.swift
@@ -27,6 +27,13 @@ struct ConcertMapper {
         return formatter
     }()
 
+    private static let dotDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy.MM.dd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter
+    }()
+
     // MARK: - Concert
 
     func toDomain(from response: DTO.Response.FetchConcertInfo) -> Concert? {
@@ -114,8 +121,8 @@ struct ConcertMapper {
 
     func toDomain(from response: DTO.Response.FetchConcertSetlistList) -> [ConcertSetlist] {
         response.compactMap { setlist in
-            guard let startDate = Self.iso8601Formatter.date(from: setlist.startDate),
-                  let endDate = Self.iso8601Formatter.date(from: setlist.endDate),
+            guard let startDate = Self.dotDateFormatter.date(from: setlist.startDate),
+                  let endDate = Self.dotDateFormatter.date(from: setlist.endDate),
                   let type = ConcertStatus(rawValue: setlist.type) else {
                 return nil
             }
@@ -191,8 +198,8 @@ struct ConcertMapper {
     // MARK: - Setlist Detail
 
     func toDomain(from response: DTO.Response.FetchConcertSetlist) -> ConcertSetlist? {
-        guard let startDate = Self.iso8601Formatter.date(from: response.startDate),
-              let endDate = Self.iso8601Formatter.date(from: response.endDate),
+        guard let startDate = Self.dotDateFormatter.date(from: response.startDate),
+              let endDate = Self.dotDateFormatter.date(from: response.endDate),
               let type = ConcertStatus(rawValue: response.type) else {
             return nil
         }

--- a/Projects/Concert/ConcertDomain/Sources/Enum/ConcertStatus.swift
+++ b/Projects/Concert/ConcertDomain/Sources/Enum/ConcertStatus.swift
@@ -13,6 +13,7 @@ public enum ConcertStatus: String, CaseIterable {
     case upcoming = "UPCOMING"
     case completed = "COMPLETED"
     case canceled = "CANCELED"
+    case past = "PAST"
 }
 
 public extension ConcertStatus {
@@ -22,7 +23,7 @@ public extension ConcertStatus {
             return "진행중"
         case .upcoming:
             return "D-"
-        case .completed:
+        case .completed, .past:
             return "종료"
         case .canceled:
             return "공연취소"
@@ -35,7 +36,7 @@ public extension ConcertStatus {
             return "진행중"
         case .upcoming:
             return "진행예정"
-        case .completed:
+        case .completed, .past:
             return "진행완료"
         case .canceled:
             return "공연취소"

--- a/Projects/Concert/ConcertFeature/Sources/Extension/DateFormatter+DateRange.swift
+++ b/Projects/Concert/ConcertFeature/Sources/Extension/DateFormatter+DateRange.swift
@@ -22,14 +22,13 @@ extension DateFormatter {
     }()
 
     static func formatDateRange(from startDate: Date, to endDate: Date) -> String {
+        let calendar = Calendar.current
         let startDateString = fullDate.string(from: startDate)
-        let endDateString = fullDate.string(from: endDate)
 
-        if startDateString == endDateString {
+        if calendar.isDate(startDate, inSameDayAs: endDate) {
             return startDateString
         }
 
-        let calendar = Calendar.current
         let startYear = calendar.component(.year, from: startDate)
         let endYear = calendar.component(.year, from: endDate)
 
@@ -37,6 +36,7 @@ extension DateFormatter {
             let endShortString = shortDate.string(from: endDate)
             return "\(startDateString)~\(endShortString)"
         } else {
+            let endDateString = fullDate.string(from: endDate)
             return "\(startDateString)~\(endDateString)"
         }
     }

--- a/Projects/Concert/ConcertFeature/Sources/Extension/DateFormatter+DateRange.swift
+++ b/Projects/Concert/ConcertFeature/Sources/Extension/DateFormatter+DateRange.swift
@@ -1,0 +1,43 @@
+//
+//  DateFormatter+DateRange.swift
+//  ConcertFeature
+//
+//  Created by Youjin Lee on 12/31/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+extension DateFormatter {
+    static let fullDate: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy.MM.dd"
+        return formatter
+    }()
+
+    static let shortDate: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MM.dd"
+        return formatter
+    }()
+
+    static func formatDateRange(from startDate: Date, to endDate: Date) -> String {
+        let startDateString = fullDate.string(from: startDate)
+        let endDateString = fullDate.string(from: endDate)
+
+        if startDateString == endDateString {
+            return startDateString
+        }
+
+        let calendar = Calendar.current
+        let startYear = calendar.component(.year, from: startDate)
+        let endYear = calendar.component(.year, from: endDate)
+
+        if startYear == endYear {
+            let endShortString = shortDate.string(from: endDate)
+            return "\(startDateString)~\(endShortString)"
+        } else {
+            return "\(startDateString)~\(endDateString)"
+        }
+    }
+}

--- a/Projects/Concert/ConcertFeature/Sources/Store/ConcertStore.swift
+++ b/Projects/Concert/ConcertFeature/Sources/Store/ConcertStore.swift
@@ -143,21 +143,6 @@ public final class ConcertStore: ObservableObject {
     }
 }
 
-// MARK: - Date Formatter
-
-private extension ConcertStore {
-    static let fullDateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy.MM.dd"
-        return formatter
-    }()
-
-    static let shortDateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MM.dd"
-        return formatter
-    }()
-}
 
 // MARK: - Private Methods
 
@@ -206,21 +191,7 @@ private extension ConcertStore {
     }
 
     func formatDateRange(from concert: Concert) -> String {
-        let calendar = Calendar.current
-        let startYear = calendar.component(.year, from: concert.startDate)
-        let endYear = calendar.component(.year, from: concert.endDate)
-
-        let startDateString = Self.fullDateFormatter.string(from: concert.startDate)
-        let endDateString = Self.fullDateFormatter.string(from: concert.endDate)
-
-        if startDateString == endDateString {
-            return startDateString
-        } else if startYear == endYear {
-            let endShortString = Self.shortDateFormatter.string(from: concert.endDate)
-            return "\(startDateString)~\(endShortString)"
-        } else {
-            return "\(startDateString)~\(endDateString)"
-        }
+        DateFormatter.formatDateRange(from: concert.startDate, to: concert.endDate)
     }
 
     func setInterestConcert() {

--- a/Projects/Concert/ConcertFeature/Sources/Store/ConcertStore.swift
+++ b/Projects/Concert/ConcertFeature/Sources/Store/ConcertStore.swift
@@ -57,6 +57,7 @@ public struct ConcertState {
     public var concertInfoList: [ConcertInfo] = []
     public var selectedTab: ConcertTab = .artistDetail
     public var merchandiseList: [ConcertMerchandise] = []
+    public var setlistList: [ConcertSetlist] = []
     public var interestStatus: InterestSettingStatus = .idle
     public var showTicketReturnBanner: Bool = false
 
@@ -78,6 +79,7 @@ public enum ConcertIntent {
     case _setSchedules([ConcertSchedule])
     case _setConcertInfoList([ConcertInfo])
     case _setMerchandiseList([ConcertMerchandise])
+    case _setSetlistList([ConcertSetlist])
     case _setConcert(Concert, formattedDateRange: String)
     case _setInterestStatus(InterestSettingStatus)
     case _setFetchError(String?)
@@ -129,6 +131,8 @@ public final class ConcertStore: ObservableObject {
             state.concertInfoList = concertInfoList
         case ._setMerchandiseList(let merchandiseList):
             state.merchandiseList = merchandiseList
+        case ._setSetlistList(let setlistList):
+            state.setlistList = setlistList
         case ._setLoading(let isLoading):
             state.isLoading = isLoading
         case ._setInterestStatus(let status):
@@ -171,14 +175,16 @@ private extension ConcertStore {
                 async let scheduleResult = repository.fetchConcertSchedule(concertID: concertID)
                 async let concertInfoResult = repository.fetchConcertInfoList(concertID: concertID)
                 async let merchandiseResult = repository.fetchConcertMerchandiseList(concertID: concertID)
+                async let setlistResult = repository.fetchConcertSetlistList(concertID: concertID)
 
-                let (concert, artist, cultures, schedules, concertInfoList, merchandiseList) = try await (
+                let (concert, artist, cultures, schedules, concertInfoList, merchandiseList, setlistList) = try await (
                     concertResult,
                     artistResult,
                     cultureResult,
                     scheduleResult,
                     concertInfoResult,
-                    merchandiseResult
+                    merchandiseResult,
+                    setlistResult
                 )
 
                 guard await Task.wait() else { return }
@@ -189,6 +195,7 @@ private extension ConcertStore {
                 send(._setSchedules(schedules))
                 send(._setConcertInfoList(concertInfoList))
                 send(._setMerchandiseList(merchandiseList))
+                send(._setSetlistList(setlistList))
             } catch {
                 guard !Task.isCancelled else { return }
                 send(._setFetchError("데이터를 불러오는데 실패했어요"))

--- a/Projects/Concert/ConcertFeature/Sources/View/ConcertView.swift
+++ b/Projects/Concert/ConcertFeature/Sources/View/ConcertView.swift
@@ -209,7 +209,9 @@ private extension ConcertView {
             .frame(maxWidth: UIScreen.main.bounds.width)
             .background(.livithColor(.black100))
         case .setlist:
-            SetlistTabView()
+            SetlistTabView(setlistList: store.state.setlistList)
+                .frame(maxWidth: UIScreen.main.bounds.width)
+                .background(.livithColor(.black100))
         case .community:
             CommunityTabView()
         }

--- a/Projects/Concert/ConcertFeature/Sources/View/Subview/SetlistTagView.swift
+++ b/Projects/Concert/ConcertFeature/Sources/View/Subview/SetlistTagView.swift
@@ -1,0 +1,58 @@
+//
+//  SetlistTagView.swift
+//  ConcertFeature
+//
+//  Created by Youjin Lee on 12/31/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import SwiftUI
+
+import ConcertDomain
+import DSKit
+
+struct SetlistTagView: View {
+
+    // MARK: - Property
+
+    let type: SetlistType
+
+    private var backgroundColor: Color {
+        switch type {
+        case .expected, .recent:
+            return Color.livithColor(.black90)
+        case .none:
+            return .clear
+        }
+    }
+
+    private var textColor: Color {
+        switch type {
+        case .expected, .recent:
+            return Color.livithColor(.white100)
+        case .none:
+            return .clear
+        }
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Text(type.displayText)
+            .notosans(.caption1Bold)
+            .foregroundStyle(textColor)
+            .padding(.horizontal, 13)
+            .padding(.vertical, 7)
+            .background(backgroundColor)
+            .clipShape(RoundedRectangle(cornerRadius: 24))
+    }
+}
+
+#Preview {
+    VStack(spacing: 10) {
+        SetlistTagView(type: .expected)
+        SetlistTagView(type: .recent)
+    }
+    .padding()
+    .background(Color.livithColor(.black100))
+}

--- a/Projects/Concert/ConcertFeature/Sources/View/TabContent/SetlistTabView.swift
+++ b/Projects/Concert/ConcertFeature/Sources/View/TabContent/SetlistTabView.swift
@@ -8,22 +8,162 @@
 
 import SwiftUI
 
+import ConcertDomain
 import DSKit
 
 struct SetlistTabView: View {
 
+    // MARK: - Property
+
+    @Environment(\.concertCoordinator) private var coordinator
+
+    let setlistList: [ConcertSetlist]
+
+    private let columns = Array(
+        repeating: GridItem(.flexible(), spacing: 10, alignment: .top),
+        count: 3
+    )
+
     // MARK: - Body
 
     var body: some View {
-        // TODO: 셋리스트 콘텐츠 구현
-        Text("셋리스트 콘텐츠")
-            .foregroundStyle(Color.livithColor(.white100))
+        if setlistList.isEmpty {
+            emptyView
+        } else {
+            setlistContent
+        }
+    }
+}
+
+// MARK: - Empty View
+
+private extension SetlistTabView {
+    var emptyView: some View {
+        LivithEmptyView(text: "셋리스트가 없어요")
             .frame(maxWidth: .infinity)
             .frame(height: 300)
     }
 }
 
+// MARK: - Setlist Content
+
+private extension SetlistTabView {
+    var setlistContent: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            SectionHeaderView(
+                firstLine: "셋리스트를",
+                secondLine: "확인해 보세요"
+            ) {
+                coordinator?.present(to: .safari(ConcertConstant.reportFormURL))
+            }
+
+            LazyVGrid(columns: columns, spacing: 16) {
+                ForEach(setlistList) { setlist in
+                    setlistCard(for: setlist)
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 30)
+        .padding(.bottom, 40)
+    }
+
+    func setlistCard(for setlist: ConcertSetlist) -> some View {
+        ThumbnailCard(
+            imageURL: setlist.imageURL.flatMap { URL(string: $0) },
+            title: setlist.title,
+            subtitle: formatDate(setlist),
+            flexible: true,
+            titleLineLimit: 2
+        )
+        .overlay(alignment: .topLeading) {
+            if setlist.status != .none {
+                SetlistTagView(type: setlist.status)
+                    .padding(10)
+            }
+        }
+    }
+
+    func formatDate(_ setlist: ConcertSetlist) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy.MM.dd"
+        let startDateString = formatter.string(from: setlist.startDate)
+
+        if setlist.startDate == setlist.endDate {
+            return startDateString
+        }
+
+        let calendar = Calendar.current
+        let startYear = calendar.component(.year, from: setlist.startDate)
+        let endYear = calendar.component(.year, from: setlist.endDate)
+
+        if startYear == endYear {
+            let shortFormatter = DateFormatter()
+            shortFormatter.dateFormat = "MM.dd"
+            let endShortString = shortFormatter.string(from: setlist.endDate)
+            return "\(startDateString)~\(endShortString)"
+        } else {
+            let endDateString = formatter.string(from: setlist.endDate)
+            return "\(startDateString)~\(endDateString)"
+        }
+    }
+}
+
 #Preview {
-    SetlistTabView()
+    ScrollView {
+        SetlistTabView(
+            setlistList: [
+                ConcertSetlist(
+                    id: 1,
+                    title: "Gen Hoshino presents MAD HOPE 202",
+                    imageURL: nil,
+                    type: .upcoming,
+                    startDate: Date(),
+                    endDate: Date(),
+                    status: .expected,
+                    venue: "올림픽공원 올림픽홀",
+                    artist: "호시노 겐"
+                ),
+                ConcertSetlist(
+                    id: 2,
+                    title: "World Tour [ LIVE FULL E...",
+                    imageURL: nil,
+                    type: .upcoming,
+                    startDate: Date(),
+                    endDate: Date().addingTimeInterval(86400),
+                    status: .recent,
+                    venue: "올림픽공원 올림픽홀",
+                    artist: "호시노 겐"
+                ),
+                ConcertSetlist(
+                    id: 3,
+                    title: "World Tour [ LIVE FULL E...",
+                    imageURL: nil,
+                    type: .upcoming,
+                    startDate: Date(),
+                    endDate: Date().addingTimeInterval(86400),
+                    status: .recent,
+                    venue: "올림픽공원 올림픽홀",
+                    artist: "호시노 겐"
+                ),
+                ConcertSetlist(
+                    id: 4,
+                    title: "World Tour [ LIVE FULL E...",
+                    imageURL: nil,
+                    type: .upcoming,
+                    startDate: Date(),
+                    endDate: Date().addingTimeInterval(86400),
+                    status: .none,
+                    venue: "올림픽공원 올림픽홀",
+                    artist: "호시노 겐"
+                )
+            ]
+        )
+    }
+    .background(Color.livithColor(.black100))
+}
+
+#Preview("Empty") {
+    SetlistTabView(setlistList: [])
         .background(Color.livithColor(.black100))
 }

--- a/Projects/Concert/ConcertFeature/Sources/View/TabContent/SetlistTabView.swift
+++ b/Projects/Concert/ConcertFeature/Sources/View/TabContent/SetlistTabView.swift
@@ -85,27 +85,7 @@ private extension SetlistTabView {
     }
 
     func formatDate(_ setlist: ConcertSetlist) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy.MM.dd"
-        let startDateString = formatter.string(from: setlist.startDate)
-
-        if setlist.startDate == setlist.endDate {
-            return startDateString
-        }
-
-        let calendar = Calendar.current
-        let startYear = calendar.component(.year, from: setlist.startDate)
-        let endYear = calendar.component(.year, from: setlist.endDate)
-
-        if startYear == endYear {
-            let shortFormatter = DateFormatter()
-            shortFormatter.dateFormat = "MM.dd"
-            let endShortString = shortFormatter.string(from: setlist.endDate)
-            return "\(startDateString)~\(endShortString)"
-        } else {
-            let endDateString = formatter.string(from: setlist.endDate)
-            return "\(startDateString)~\(endDateString)"
-        }
+        DateFormatter.formatDateRange(from: setlist.startDate, to: setlist.endDate)
     }
 }
 

--- a/Projects/Concert/ConcertTests/Sources/Mapper/SetlistMapperTests.swift
+++ b/Projects/Concert/ConcertTests/Sources/Mapper/SetlistMapperTests.swift
@@ -28,9 +28,9 @@ struct SetlistMapperTests {
                 title: "2025 콘서트 Day1",
                 imageURL: "https://example.com/setlist.jpg",
                 type: "ONGOING",
-                startDate: "2025-01-01T18:00:00Z",
-                endDate: "2025-01-01T21:00:00Z",
-                status: "expected",
+                startDate: "2025.01.01",
+                endDate: "2025.01.01",
+                status: "예상",
                 venue: "올림픽공원",
                 artist: "아티스트"
             )
@@ -56,8 +56,8 @@ struct SetlistMapperTests {
                 title: "2025 콘서트",
                 imageURL: nil,
                 type: "ONGOING",
-                startDate: "2025-01-01T18:00:00Z",
-                endDate: "2025-01-01T21:00:00Z",
+                startDate: "2025.01.01",
+                endDate: "2025.01.01",
                 status: nil,
                 venue: "올림픽공원",
                 artist: "아티스트"
@@ -81,9 +81,9 @@ struct SetlistMapperTests {
                 title: "2025 콘서트",
                 imageURL: nil,
                 type: "INVALID_TYPE",
-                startDate: "2025-01-01T18:00:00Z",
-                endDate: "2025-01-01T21:00:00Z",
-                status: "expected",
+                startDate: "2025.01.01",
+                endDate: "2025.01.01",
+                status: "예상",
                 venue: "올림픽공원",
                 artist: "아티스트"
             )
@@ -106,8 +106,8 @@ struct SetlistMapperTests {
             title: "2025 콘서트 Day1",
             imageURL: "https://example.com/setlist.jpg",
             type: "ONGOING",
-            startDate: "2025-01-01T18:00:00Z",
-            endDate: "2025-01-01T21:00:00Z",
+            startDate: "2025.01.01",
+            endDate: "2025.01.01",
             status: "최근",
             venue: "올림픽공원",
             artist: "아티스트"
@@ -132,8 +132,8 @@ struct SetlistMapperTests {
             imageURL: nil,
             type: "ONGOING",
             startDate: "invalid-date",
-            endDate: "2025-01-01T21:00:00Z",
-            status: "expected",
+            endDate: "2025.01.01",
+            status: "예상",
             venue: "올림픽공원",
             artist: "아티스트"
         )

--- a/Projects/DSKit/Sources/Component/ThumbnailCard.swift
+++ b/Projects/DSKit/Sources/Component/ThumbnailCard.swift
@@ -16,6 +16,7 @@ public struct ThumbnailCard: View {
     private let title: String
     private let subtitle: String?
     private let flexible: Bool
+    private let titleLineLimit: Int?
 
     // MARK: - Initializer
 
@@ -23,12 +24,14 @@ public struct ThumbnailCard: View {
         imageURL: URL?,
         title: String,
         subtitle: String? = nil,
-        flexible: Bool = false
+        flexible: Bool = false,
+        titleLineLimit: Int? = nil
     ) {
         self.imageURL = imageURL
         self.title = title
         self.subtitle = subtitle
         self.flexible = flexible
+        self.titleLineLimit = titleLineLimit
     }
 
     // MARK: - Body
@@ -40,6 +43,7 @@ public struct ThumbnailCard: View {
             Text(title)
                 .notosans(.body2Medium)
                 .foregroundStyle(Color.livithColor(.white100))
+                .lineLimit(titleLineLimit)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
             if let subtitle, !subtitle.isEmpty {
@@ -65,9 +69,8 @@ private extension ThumbnailCard {
                     .aspectRatio(108/158, contentMode: .fit)
                     .overlay {
                         AsyncImageView(url: imageURL)
-                            .clipShape(RoundedRectangle(cornerRadius: 6))
                     }
-                    .clipped()
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
             } else {
                 AsyncImageView(url: imageURL)
                     .frame(width: 108, height: 158)


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 콘서트 상세 화면의 셋리스트 탭을 구현했어요.

|    구현 내용    |   IPhone 15 Pro   |
| :-------------: | :----------: |
| GIF | <img width="300" src = "https://github.com/user-attachments/assets/b4291b8e-309d-4d41-93cb-d2823648b4b5"> |

## 🔗 연결된 이슈
- Resolved: LIVD-57
