### PR TITLE
[Fix] 로그아웃 시 불필요한 API 호출되는 이슈 해결

### DIFF
--- a/Projects/Home/HomeFeature/Sources/Home/Store/HomeNoInterestStore.swift
+++ b/Projects/Home/HomeFeature/Sources/Home/Store/HomeNoInterestStore.swift
@@ -12,6 +12,7 @@ import DIContainer
 import HomeDomain
 
 enum HomeNoInterestIntent {
+    case onAppear
     case onRefresh
     case onToastDisappear
     case _fetchHomeSectionListResult(Result<HomeSectionList, Error>)
@@ -30,13 +31,12 @@ final class HomeNoInterestStore: ObservableObject {
     
     private var refreshTask: Task<Void, Never>?
     
-    init() {
-        performFetchHomeSectionList()
-    }
-    
     @MainActor
     func send(_ intent: HomeNoInterestIntent) {
         switch intent {
+        case .onAppear:
+            performFetchHomeSectionList()
+
         case .onRefresh:
             state.isLoading = true
             performFetchHomeSectionList()

--- a/Projects/Home/HomeFeature/Sources/Home/View/HomeNoInterestView.swift
+++ b/Projects/Home/HomeFeature/Sources/Home/View/HomeNoInterestView.swift
@@ -45,6 +45,7 @@ struct HomeNoInterestView: View {
             }
             .refreshable { store.send(.onRefresh) }
             .ignoresSafeArea(edges: .bottom)
+            .onAppear { store.send(.onAppear) }
         }
         .background(.livithColor(.black90))
     }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 로그아웃 시 불필요한 API 호출이 발생하는 성능 이슈를 해결했어요.
- `HomeNoInterestStore`의 API 호출 시점을 `init()`에서 `onAppear`로 변경했어요.

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 설명할 코드 주제 또는 기능
- 로그아웃 후 로그인 화면으로 전환되는 과정에서 이미 로그아웃된 상태임에도 홈 섹션 API가 호출되는 현상이 발생했습니다.
- 원인을 분석해보니 SwiftUI의 렌더링 이슈였는데요, `AppRootView`에서 `currentRoute`가 `.login`으로 바뀌면서 뷰 계층이 재구성되고, 뷰가 재생성되며 init() 메서드가 다시 불리는 문제 때문에 API가 재호출되었습니다.
- 플로우는 아래와 같습니다.

```mermaid
flowchart TD
    A[🔘 로그아웃 버튼 탭] --> B[NotificationCenter.post\n.reloginRequired]
    B --> C[AppRootView\ncurrentRoute = .login]
    C --> D[SwiftUI 뷰 계층 재구성 시작]
    D --> E[HomeView 생성]
    D --> F[LoginView 생성]
    E --> G[HomeStore.state.mode\n= .noInterestedConcert\n기본값]
    G --> H[HomeNoInterestView\n렌더링 시작]
    H --> I["@StateObject var store\n= HomeNoInterestStore.init()"]
    I --> J[init 내부에서 API 호출 발생\nperformFetchHomeSectionList]
    J --> K[GET /api/v4/home/sections\n불필요한 네트워크 요청]

    style J fill:#ff6b6b,color:#fff
    style K fill:#ff6b6b,color:#fff
```

- 해결 후 플로우는 다음과 같습니다.
- init 메서드에서 API를 호출하지 않고 onappear에서 호출하도록 해 로그아웃 시 불필요한 API가 호출되지 않도록 했습니다.

```mermaid
flowchart TD
    A[🔘 로그아웃 버튼 탭] --> B[AppRootView\ncurrentRoute = .login]
    B --> C["HomeNoInterestStore.init()\n실행 (API 호출 없음)"]
    C --> D[화면이 LoginView로 전환]
    D --> E[HomeNoInterestView의\nonAppear 호출 안됨]
    E --> F[불필요한 API 호출 방지]

    style C fill:#51cf66,color:#fff
    style F fill:#51cf66,color:#fff
```

- `@StateObject`는 뷰의 `body`가 평가될 때 초기화되어 로그인 화면으로 전환되기 전에 `init()`이 실행되어 API가 호출될 수 있다고 합니다.

## 🔗 연결된 이슈
- Resolved: n/a
