### PR TITLE
[Feat] 로그아웃 및 회원탈퇴 기능 구현

### DIFF
--- a/Projects/App/Sources/View/AppRootView.swift
+++ b/Projects/App/Sources/View/AppRootView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+import DSKit
 import LoginFeature
 import LivithNetwork
 import Persistence
@@ -17,7 +18,9 @@ struct AppRootView: View {
     @State private var isLaunchScreenVisible: Bool = true
     @State private var nickname: String = ""
     @State private var isWelcomeSheetVisible: Bool = false
-    
+    @State private var showToast: Bool = false
+    @State private var toastMessage: String = ""
+
     private let localKeyValueStorage: LocalKeyValueStorage
     
     init(localKeyValueStorage: LocalKeyValueStorage = UserDefaultsStorage()) {
@@ -33,9 +36,18 @@ struct AppRootView: View {
         .animation(.easeInOut(duration: Constants.animationDuration), value: isLaunchScreenVisible)
         .animation(.easeInOut(duration: Constants.animationDuration), value: currentRoute)
         .animation(.easeInOut(duration: Constants.animationDuration), value: isWelcomeSheetVisible)
-        .onReceive(NotificationCenter.default.publisher(for: Notification.Name.reloginRequired)) { _ in
-            transition(to: .login)
+        .onReceive(NotificationCenter.default.publisher(for: Notification.Name.reloginRequired)) { notification in
+            if let message = notification.userInfo?["toastMessage"] as? String {
+                toastMessage = message
+                transition(to: .login)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    showToast = true
+                }
+            } else {
+                transition(to: .login)
+            }
         }
+        .livithToast(isPresented: $showToast, type: .success, message: toastMessage, position: .safeAreaTop)
         .onAppear {
             handleOnAppear()
         }

--- a/Projects/DSKit/Sources/Component/LivithToast.swift
+++ b/Projects/DSKit/Sources/Component/LivithToast.swift
@@ -89,7 +89,7 @@ private struct LivithToastModifier: ViewModifier {
                         let toastY: CGFloat = {
                             switch position {
                             case .top:
-                                return geometry.safeAreaInsets.top + 60
+                                return geometry.safeAreaInsets.top + topPadding
                             case .safeAreaTop:
                                 return geometry.safeAreaInsets.top
                             case .aboveKeyboard:

--- a/Projects/DSKit/Sources/Component/LivithToast.swift
+++ b/Projects/DSKit/Sources/Component/LivithToast.swift
@@ -26,6 +26,7 @@ public enum LivithToastType {
 
 public enum LivithToastPosition {
     case top
+    case safeAreaTop
     case aboveKeyboard
 }
 
@@ -86,10 +87,12 @@ private struct LivithToastModifier: ViewModifier {
                     GeometryReader { geometry in
                         let toastHeight: CGFloat = 54
                         let toastY: CGFloat = {
-                            if position == .top {
-                                return geometry.safeAreaInsets.top + topPadding + toastHeight / 2
-                            } else {
-                                // 토스트 하단이 키보드 상단에서 keyboardSpacing 위에 위치
+                            switch position {
+                            case .top:
+                                return geometry.safeAreaInsets.top + 60
+                            case .safeAreaTop:
+                                return geometry.safeAreaInsets.top
+                            case .aboveKeyboard:
                                 return geometry.size.height - keyboardHeight - keyboardSpacing - toastHeight / 2
                             }
                         }()

--- a/Projects/Home/HomeFeature/Sources/Home/View/HomeView.swift
+++ b/Projects/Home/HomeFeature/Sources/Home/View/HomeView.swift
@@ -35,8 +35,9 @@ struct HomeView: View {
             ),
             type: .failure,
             message: store.state.errorMessage,
-            duration: 2
-            )
+            duration: 2,
+            position: .safeAreaTop
+        )
         .background(.livithColor(.black90))
         .onAppear {
             store.send(.onAppear)

--- a/Projects/Home/HomeFeature/Sources/Interest/View/InterestConcertSearchView.swift
+++ b/Projects/Home/HomeFeature/Sources/Interest/View/InterestConcertSearchView.swift
@@ -48,7 +48,8 @@ struct InterestConcertSearchView: View {
                 ),
                 type: .failure,
                 message: store.state.errorMessage,
-                duration: 2
+                duration: 2,
+                position: .safeAreaTop
             )
             .onChange(of: isTextFieldFocused) { _, isFocused in
                 if isFocused {

--- a/Projects/Login/LoginFeature/Sources/Login/View/LoginView.swift
+++ b/Projects/Login/LoginFeature/Sources/Login/View/LoginView.swift
@@ -35,7 +35,8 @@ struct LoginView: View {
             ),
             type: .failure,
             message: store.state.errorMessage,
-            duration: 2
+            duration: 2,
+            position: .safeAreaTop
         )
         .onChange(of: store.state.status) { oldValue, newValue in
             guard let loginStatus = newValue else { return }

--- a/Projects/Login/LoginFeature/Sources/Onboarding/View/NicknameSettingView.swift
+++ b/Projects/Login/LoginFeature/Sources/Onboarding/View/NicknameSettingView.swift
@@ -59,7 +59,8 @@ struct NicknameSettingView: View {
             ),
             type: .failure,
             message: store.state.errorMessage,
-            duration: 2
+            duration: 2,
+            position: .safeAreaTop
         )
         .ignoresSafeArea(.all, edges: .bottom)
         .onChange(of: store.state.signupStatus) {

--- a/Projects/User/Project.swift
+++ b/Projects/User/Project.swift
@@ -15,7 +15,8 @@ let project = Project.make(
             dependencies: [
                 .user(.userDomain),
                 .core(.livithNetwork),
-                .core(.diContainer)
+                .core(.diContainer),
+                .core(.persistence)
             ]
         ),
         .make(
@@ -29,7 +30,8 @@ let project = Project.make(
                 .user(.userDomain),
                 .dsKit(),
                 .core(.diContainer),
-                .core(.livithConcurrency)
+                .core(.livithConcurrency),
+                .core(.livithNetwork)
             ]
         )
     ]

--- a/Projects/User/UserData/Sources/Mapper/UserErrorMapper.swift
+++ b/Projects/User/UserData/Sources/Mapper/UserErrorMapper.swift
@@ -28,6 +28,13 @@ public struct UserErrorMapper {
             return .unknown
         }
     }
+
+    func mapToUserError(_ error: any Error) -> UserError {
+        if let networkError = error as? NetworkError {
+            return mapToUserError(networkError)
+        }
+        return .unknown
+    }
 }
 
 private extension UserErrorMapper {

--- a/Projects/User/UserData/Sources/UserRepositoryImpl.swift
+++ b/Projects/User/UserData/Sources/UserRepositoryImpl.swift
@@ -9,20 +9,26 @@
 import Foundation
 
 import LivithNetwork
+import Persistence
 import UserDomain
 
 public final class UserRepositoryImpl {
-    // TODO: 토큰 서비스 선언
     private let userService: NetworkService<UserEndpoint>
     private let logoutService: NetworkService<LogoutEndpoint>
+    private let tokenService: TokenService
+    private let localStorage: LocalKeyValueStorage
     private let userErrorMapper: UserErrorMapper = .init()
 
     public init(
         userService: NetworkService<UserEndpoint> = .init(),
-        logoutService: NetworkService<LogoutEndpoint> = .init(interceptor: nil)
+        logoutService: NetworkService<LogoutEndpoint> = .init(interceptor: nil),
+        tokenService: TokenService = TokenServiceImpl(),
+        localStorage: LocalKeyValueStorage = UserDefaultsStorage()
     ) {
         self.userService = userService
         self.logoutService = logoutService
+        self.tokenService = tokenService
+        self.localStorage = localStorage
     }
 }
 
@@ -60,12 +66,35 @@ extension UserRepositoryImpl: UserRepository {
             let _: DTO.Response.DeleteUser = try await userService.request(
                 UserEndpoint.deleteUser(request: request)
             )
-        } catch let error {
+
+            try await tokenService.removeToken()
+            localStorage.remove(for: LocalStorageKeys.currentUser)
+            localStorage.remove(for: LocalStorageKeys.lastLoginPlatform)
+        } catch {
             throw userErrorMapper.mapToUserError(error)
         }
     }
     
     public func logoutSession() async throws(UserError) {
-        // TODO: 토큰 서비스로 토큰 받아서 로그아웃 처리하기
+        do {
+            let refreshToken = try await tokenService.getRefreshToken()
+            let request = DTO.Request.RequestLogout(refreshToken: refreshToken)
+
+            let _: DTO.Response.RequestLogout = try await logoutService.request(
+                LogoutEndpoint.logoutSession(request: request)
+            )
+
+            try await tokenService.removeToken()
+            localStorage.remove(for: LocalStorageKeys.currentUser)
+        } catch {
+            throw userErrorMapper.mapToUserError(error)
+        }
     }
+}
+
+// MARK: - LocalStorageKeys
+
+private enum LocalStorageKeys {
+    static let currentUser = "currentUser"
+    static let lastLoginPlatform = "lastLoginPlatform"
 }

--- a/Projects/User/UserData/Sources/UserRepositoryImpl.swift
+++ b/Projects/User/UserData/Sources/UserRepositoryImpl.swift
@@ -62,17 +62,18 @@ extension UserRepositoryImpl: UserRepository {
     public func deleteUser(reason: String) async throws(UserError) {
         do {
             let request = DTO.Request.DeleteUser(reason: reason)
-            
+
             let _: DTO.Response.DeleteUser = try await userService.request(
                 UserEndpoint.deleteUser(request: request)
             )
-
-            try await tokenService.removeToken()
-            localStorage.remove(for: LocalStorageKeys.currentUser)
-            localStorage.remove(for: LocalStorageKeys.lastLoginPlatform)
         } catch {
             throw userErrorMapper.mapToUserError(error)
         }
+
+        // 백엔드 삭제 성공 후에는 로컬 정리가 반드시 실행되어야 함
+        try? await tokenService.removeToken()
+        localStorage.remove(for: LocalStorageKeys.currentUser)
+        localStorage.remove(for: LocalStorageKeys.lastLoginPlatform)
     }
     
     public func logoutSession() async throws(UserError) {
@@ -83,12 +84,13 @@ extension UserRepositoryImpl: UserRepository {
             let _: DTO.Response.RequestLogout = try await logoutService.request(
                 LogoutEndpoint.logoutSession(request: request)
             )
-
-            try await tokenService.removeToken()
-            localStorage.remove(for: LocalStorageKeys.currentUser)
         } catch {
             throw userErrorMapper.mapToUserError(error)
         }
+
+        // 백엔드 로그아웃 성공 후에는 로컬 정리가 반드시 실행되어야 함
+        try? await tokenService.removeToken()
+        localStorage.remove(for: LocalStorageKeys.currentUser)
     }
 }
 

--- a/Projects/User/UserFeature/Sources/Store/DeleteUserStore.swift
+++ b/Projects/User/UserFeature/Sources/Store/DeleteUserStore.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 import DIContainer
+import LivithNetwork
 import UserDomain
 
 enum DeleteUserReason: String, CaseIterable {
@@ -40,6 +41,7 @@ enum DeleteUserIntent {
 
 final class DeleteUserStore: ObservableObject {
     @Published private(set) var state = DeleteUserState()
+    @Injected private var repository: UserRepository
 
     private let maxOtherReasonLength = 200
 
@@ -90,8 +92,9 @@ private extension DeleteUserStore {
 
         Task {
             do {
-                // TODO: 실제 탈퇴 API 호출
-                try await Task.sleep(for: .seconds(1))
+                let reason = buildReasonString()
+                try await repository.deleteUser(reason: reason)
+
                 await MainActor.run {
                     send(._setDeleteUserResult(.success))
                 }
@@ -101,5 +104,17 @@ private extension DeleteUserStore {
                 }
             }
         }
+    }
+
+    func buildReasonString() -> String {
+        var reasons = state.selectedReasons
+            .filter { $0 != .other }
+            .map { $0.rawValue }
+
+        if state.selectedReasons.contains(.other), !state.otherReasonText.isEmpty {
+            reasons.append(state.otherReasonText)
+        }
+
+        return reasons.joined(separator: ", ")
     }
 }

--- a/Projects/User/UserFeature/Sources/Store/LogoutStore.swift
+++ b/Projects/User/UserFeature/Sources/Store/LogoutStore.swift
@@ -1,0 +1,68 @@
+//
+//  LogoutStore.swift
+//  UserFeature
+//
+//  Created by Youjin Lee on 1/1/26.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+import DIContainer
+import LivithNetwork
+import UserDomain
+
+enum LogoutResult: Equatable {
+    case idle
+    case success
+    case failure(String)
+}
+
+struct LogoutState {
+    var isLoading: Bool = false
+    var logoutResult: LogoutResult = .idle
+}
+
+enum LogoutIntent {
+    case logout
+    case _setLogoutResult(LogoutResult)
+}
+
+final class LogoutStore: ObservableObject {
+    @Published private(set) var state = LogoutState()
+    @Injected private var repository: UserRepository
+
+    func send(_ intent: LogoutIntent) {
+        switch intent {
+        case .logout:
+            state.logoutResult = .idle
+            performLogout()
+
+        case ._setLogoutResult(let result):
+            state.isLoading = false
+            state.logoutResult = result
+        }
+    }
+}
+
+// MARK: - Helper
+
+private extension LogoutStore {
+    func performLogout() {
+        state.isLoading = true
+
+        Task {
+            do {
+                try await repository.logoutSession()
+
+                await MainActor.run {
+                    send(._setLogoutResult(.success))
+                }
+            } catch {
+                await MainActor.run {
+                    send(._setLogoutResult(.failure(error.localizedDescription)))
+                }
+            }
+        }
+    }
+}

--- a/Projects/User/UserFeature/Sources/View/DeleteUserView.swift
+++ b/Projects/User/UserFeature/Sources/View/DeleteUserView.swift
@@ -18,6 +18,8 @@ struct DeleteUserView: View {
     @State private var isConfirmed: Bool = false
     @FocusState private var isTextFieldFocused: Bool
     @State private var showConfirmSheet: Bool = false
+    @State private var showErrorToast: Bool = false
+    @State private var errorMessage: String = ""
 
     @ObservedObject private var store: DeleteUserStore
 
@@ -87,13 +89,17 @@ struct DeleteUserView: View {
                 case .idle:
                     break
                 case .success:
-                    // TODO: 로그인 화면으로 이동
-                    break
-                case .failure:
-                    // TODO: 에러 토스트 표시
-                    break
+                    NotificationCenter.default.post(
+                        name: .reloginRequired,
+                        object: nil,
+                        userInfo: ["toastMessage": Literals.deleteSuccessMessage]
+                    )
+                case .failure(let message):
+                    errorMessage = message
+                    showErrorToast = true
                 }
             }
+            .livithToast(isPresented: $showErrorToast, type: .failure, message: errorMessage, position: .safeAreaTop)
             .overlay {
                 customFilterSheet.ignoresSafeArea()
             }
@@ -294,6 +300,7 @@ private extension DeleteUserView {
         static let subtitle = "탈퇴 이유를 알려주시면,\n서비스 개선에 반영해 더 좋은 서비스로 찾아뵐게요"
         static let textFieldPlaceholder = "10자 이상의 사유를 작성해주세요"
         static let confirmButtonText = "탈퇴하기"
+        static let deleteSuccessMessage = "탈퇴가 완료되었어요.\n더 좋은 서비스로 다시 만나요!"
     }
 }
 

--- a/Projects/User/UserFeature/Sources/View/NicknameUpdateView.swift
+++ b/Projects/User/UserFeature/Sources/View/NicknameUpdateView.swift
@@ -67,7 +67,8 @@ struct NicknameUpdateView: View {
         .livithToast(
             isPresented: $showFailureToast,
             type: .failure,
-            message: Literals.toastFailure
+            message: Literals.toastFailure,
+            position: .safeAreaTop
         )
         .onChange(of: store.state.updateResult) { _, result in
             switch result {

--- a/Projects/User/UserFeature/Sources/View/UserView.swift
+++ b/Projects/User/UserFeature/Sources/View/UserView.swift
@@ -42,11 +42,16 @@ public struct UserView: View {
     @State private var path = NavigationPath()
     @State private var overlayType: OverlayType = .none
     @State private var showSuccessToast: Bool = false
+    @State private var showLogoutToast: Bool = false
+    @State private var logoutToastType: LivithToastType = .success
+    @State private var logoutToastMessage: String = ""
 
     @Binding private var isTabBarHidden: Bool
-    
+
+    @StateObject private var logoutStore = LogoutStore()
+
     // MARK: - LifeCycle
-    
+
     public init(nickname: Binding<String>, isTabBarHidden: Binding<Bool>) {
         self._nickname = nickname
         self._isTabBarHidden = isTabBarHidden
@@ -114,8 +119,18 @@ public struct UserView: View {
             .livithToast(
                 isPresented: $showSuccessToast,
                 type: .success,
-                message: Literals.toastSuccess
+                message: Literals.toastSuccess,
+                position: .safeAreaTop
             )
+            .livithToast(
+                isPresented: $showLogoutToast,
+                type: logoutToastType,
+                message: logoutToastMessage,
+                position: .safeAreaTop
+            )
+        }
+        .onChange(of: logoutStore.state.logoutResult) { _, newResult in
+            handleLogoutResult(newResult)
         }
         .sheet(isPresented: isSheetPresented) {
             if let url = overlayType.sheetURL {
@@ -251,13 +266,29 @@ private extension UserView {
     }
 
     func performLogout() {
-        // TODO: 로그아웃 처리
+        logoutStore.send(.logout)
     }
 
     func deleteAccount() {
         path.append(Path.deleteUser)
     }
 
+    func handleLogoutResult(_ result: LogoutResult) {
+        switch result {
+        case .idle:
+            break
+        case .success:
+            NotificationCenter.default.post(
+                name: .reloginRequired,
+                object: nil,
+                userInfo: ["toastMessage": Literals.logoutSuccessMessage]
+            )
+        case .failure(let message):
+            logoutToastType = .failure
+            logoutToastMessage = message
+            showLogoutToast = true
+        }
+    }
 }
 
 // MARK: - Constants
@@ -287,5 +318,6 @@ private extension UserView {
         static let logoutAlertMessage = "정말 로그아웃 하시겠어요?"
         static let logoutAlertCancel = "취소할래요"
         static let logoutAlertConfirm = "로그아웃 할래요"
+        static let logoutSuccessMessage = "로그아웃이 완료되었어요"
     }
 }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 로그아웃 및 회원탈퇴 기능을 구현했어요.
- 토스트 위치에 `safeAreaTop` 케이스를 추가하고, 상세화면을 제외한 모든 토스트에 적용했어요.
- 로그아웃/탈퇴 성공 시 로그인 화면에서, 실패 시 현재 화면에서 토스트를 표시하도록 구현했어요.


## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 로그아웃/탈퇴 성공 토스트를 로그인 화면에서 표시

- 로그아웃/탈퇴 성공 시 토스트를 현재 화면이 아닌 로그인 화면에서 보여주기 위해 NotificationCenter의 userInfo를 활용했습니다.

```swift
// UserView.swift - 로그아웃 성공 시
NotificationCenter.default.post(
    name: .reloginRequired,
    object: nil,
    userInfo: ["toastMessage": "로그아웃이 완료되었어요"]
)

// AppRootView.swift - 토스트 메시지 수신 및 표시
.onReceive(NotificationCenter.default.publisher(for: .reloginRequired)) { notification in
    if let message = notification.userInfo?["toastMessage"] as? String {
        toastMessage = message
        transition(to: .login)
        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
            showToast = true
        }
    } else {
        transition(to: .login)
    }
}
```

### 토스트 safeAreaTop 위치 케이스 추가

- 기존 `top` 위치(safeArea + 60pt)와 별개로, safeArea 바로 아래에 토스트를 표시하는 `safeAreaTop` 케이스를 추가했습니다.
- 상세화면(ConcertView)을 제외한 모든 화면의 토스트에 `safeAreaTop`을 적용했습니다.

```swift
// LivithToast.swift
public enum LivithToastPosition {
    case top
    case safeAreaTop  // 새로 추가
    case aboveKeyboard
}

// 위치 계산
case .safeAreaTop:
    return geometry.safeAreaInsets.top
```

## 🔗 연결된 이슈
- Resolved: #111 LIVD-76
