### PR TITLE
[Feat] 셋리스트 기능 구현을 위한 Data, Domain 레이어 구현

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -27,6 +27,8 @@ let project = Project.make(
                 .login(.loginFeature),
                 .search(.searchData),
                 .search(.searchFeature),
+                .setlist(.setlistData),
+                .setlist(.setlistFeature),
                 .user(.userData),
                 .user(.userFeature),
             ]

--- a/Projects/App/Sources/LivithApp+InjectDependency.swift
+++ b/Projects/App/Sources/LivithApp+InjectDependency.swift
@@ -13,6 +13,7 @@ import ConcertData
 import HomeData
 import LoginData
 import SearchData
+import SetlistData
 import UserData
 
 extension LivithApp {
@@ -23,6 +24,7 @@ extension LivithApp {
                 HomeAssembler(),
                 LoginAssembler(),
                 SearchAssembler(),
+                SetlistAssembler(),
                 UserAssembler()
             ]
         )

--- a/Projects/Concert/ConcertData/Sources/Repository/SetlistRepositoryImpl.swift
+++ b/Projects/Concert/ConcertData/Sources/Repository/SetlistRepositoryImpl.swift
@@ -37,15 +37,4 @@ extension SetlistRepositoryImpl: SetlistRepository {
             throw errorMapper.mapToConcertError(error)
         }
     }
-
-    public func fetchSetlistSongList(setlistID: Int) async throws(ConcertError) -> [SetlistSong] {
-        do {
-            let response: DTO.Response.FetchSetlistSongList = try await service.request(
-                .fetchSetlistSongList(setlistID: setlistID)
-            )
-            return entityMapper.toDomain(from: response)
-        } catch {
-            throw errorMapper.mapToConcertError(error)
-        }
-    }
 }

--- a/Projects/Concert/ConcertDomain/Sources/Repository/SetlistRepository.swift
+++ b/Projects/Concert/ConcertDomain/Sources/Repository/SetlistRepository.swift
@@ -10,5 +10,4 @@ import Foundation
 
 public protocol SetlistRepository {
     func fetchConcertSetlist(setlistID: Int) async throws(ConcertError) -> ConcertSetlist
-    func fetchSetlistSongList(setlistID: Int) async throws(ConcertError) -> [SetlistSong]
 }

--- a/Projects/Concert/ConcertTests/Sources/Repository/SetlistRepositoryTests.swift
+++ b/Projects/Concert/ConcertTests/Sources/Repository/SetlistRepositoryTests.swift
@@ -33,18 +33,6 @@ struct SetlistRepositoryTests {
         #expect(result.id == setlistID)
     }
 
-    @Test("셋리스트 곡 목록 조회")
-    func test_셋리스트곡목록조회_실제API_곡목록반환() async throws {
-        // Given
-        let setlistID = 1549
-
-        // When
-        let result = try await repository.fetchSetlistSongList(setlistID: setlistID)
-
-        // Then
-        #expect(result.isEmpty == false)
-    }
-
     // MARK: - Error Tests
 
     @Test("존재하지 않는 셋리스트 조회 시 에러 발생")
@@ -55,17 +43,6 @@ struct SetlistRepositoryTests {
         // When & Then
         await #expect(throws: ConcertError.self) {
             try await repository.fetchConcertSetlist(setlistID: invalidSetlistID)
-        }
-    }
-
-    @Test("존재하지 않는 셋리스트 곡 목록 조회 시 에러 발생")
-    func test_셋리스트곡목록조회_존재하지않는ID_에러반환() async {
-        // Given
-        let invalidSetlistID = -1
-
-        // When & Then
-        await #expect(throws: ConcertError.self) {
-            try await repository.fetchSetlistSongList(setlistID: invalidSetlistID)
         }
     }
 }

--- a/Projects/Setlist/Project.swift
+++ b/Projects/Setlist/Project.swift
@@ -1,0 +1,35 @@
+//
+//  Project.swift
+//  Manifests
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.make(
+    project: .setlist,
+    targets: [
+        .make(
+            target: .setlist(.setlistData),
+            product: .framework,
+            dependencies: [
+                .setlist(.setlistDomain),
+                .core(.livithNetwork)
+            ]
+        ),
+        .make(
+            target: .setlist(.setlistDomain),
+            product: .framework
+        ),
+        .make(
+            target: .setlist(.setlistFeature),
+            product: .framework,
+            dependencies: [
+                .setlist(.setlistDomain),
+                .dsKit(),
+                .core(.diContainer),
+                .core(.livithConcurrency)
+            ]
+        )
+    ]
+)

--- a/Projects/Setlist/Project.swift
+++ b/Projects/Setlist/Project.swift
@@ -14,7 +14,8 @@ let project = Project.make(
             product: .framework,
             dependencies: [
                 .setlist(.setlistDomain),
-                .core(.livithNetwork)
+                .core(.livithNetwork),
+                .core(.diContainer)
             ]
         ),
         .make(

--- a/Projects/Setlist/SetlistData/Sources/Mapper/SetlistErrorMapper.swift
+++ b/Projects/Setlist/SetlistData/Sources/Mapper/SetlistErrorMapper.swift
@@ -1,0 +1,36 @@
+//
+//  SetlistErrorMapper.swift
+//  SetlistData
+//
+//  Created by Youjin Lee on 12/30/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+import LivithNetwork
+import SetlistDomain
+
+struct SetlistErrorMapper {
+    func mapToSetlistError(_ error: any Error) -> SetlistError {
+        if let networkError = error as? NetworkError {
+            return mapToSetlistError(networkError)
+        }
+        return .unknown
+    }
+
+    func mapToSetlistError(_ networkError: NetworkError) -> SetlistError {
+        switch networkError {
+        case .noConnection:
+            return .networkError
+        case .serverError:
+            return .serverError
+        case .noData, .notFound:
+            return .notFound
+        case .decodingFailed, .invalidURL, .invalidRequest, .invalidResponse, .badRequest, .clientError:
+            return .invalidResponse
+        case .unauthorized, .forbidden, .unknown:
+            return .unknown
+        }
+    }
+}

--- a/Projects/Setlist/SetlistData/Sources/Mapper/SetlistMapper.swift
+++ b/Projects/Setlist/SetlistData/Sources/Mapper/SetlistMapper.swift
@@ -1,0 +1,59 @@
+//
+//  SetlistMapper.swift
+//  SetlistData
+//
+//  Created by Youjin Lee on 12/30/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+import LivithNetwork
+import SetlistDomain
+
+struct SetlistMapper {
+    private let dateFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withFullDate]
+        return formatter
+    }()
+
+    func toDomain(from response: DTO.Response.FetchConcertSetlist) -> Setlist? {
+        guard let startDate = dateFormatter.date(from: response.startDate),
+              let endDate = dateFormatter.date(from: response.endDate) else {
+            return nil
+        }
+
+        let type: SetlistType
+        switch response.type.uppercased() {
+        case "EXPECTED":
+            type = .expected
+        case "RECENT":
+            type = .recent
+        default:
+            type = .none
+        }
+
+        return Setlist(
+            id: response.id,
+            title: response.title,
+            imageURL: response.imageURL,
+            type: type,
+            startDate: startDate,
+            endDate: endDate,
+            venue: response.venue,
+            artist: response.artist
+        )
+    }
+
+    func toDomain(from response: DTO.Response.FetchSetlistSongList) -> [SetlistSong] {
+        return response.map { song in
+            SetlistSong(
+                id: song.id,
+                title: song.title,
+                artist: song.artist,
+                orderIndex: song.orderIndex
+            )
+        }
+    }
+}

--- a/Projects/Setlist/SetlistData/Sources/Placeholder.swift
+++ b/Projects/Setlist/SetlistData/Sources/Placeholder.swift
@@ -1,6 +1,0 @@
-//
-//  Placeholder.swift
-//  SetlistData
-//
-
-import Foundation

--- a/Projects/Setlist/SetlistData/Sources/Placeholder.swift
+++ b/Projects/Setlist/SetlistData/Sources/Placeholder.swift
@@ -1,0 +1,6 @@
+//
+//  Placeholder.swift
+//  SetlistData
+//
+
+import Foundation

--- a/Projects/Setlist/SetlistData/Sources/Repository/SetlistRepositoryImpl.swift
+++ b/Projects/Setlist/SetlistData/Sources/Repository/SetlistRepositoryImpl.swift
@@ -1,0 +1,51 @@
+//
+//  SetlistRepositoryImpl.swift
+//  SetlistData
+//
+//  Created by Youjin Lee on 12/30/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+import LivithNetwork
+import SetlistDomain
+
+public struct SetlistRepositoryImpl {
+    private let service: SetlistService
+    private let mapper: SetlistMapper = .init()
+    private let errorMapper: SetlistErrorMapper = .init()
+
+    public init(service: SetlistService = .init()) {
+        self.service = service
+    }
+}
+
+extension SetlistRepositoryImpl: SetlistRepository {
+    public func fetchSetlist(setlistID: Int) async throws(SetlistError) -> Setlist {
+        do {
+            let response: DTO.Response.FetchConcertSetlist = try await service.request(
+                .fetchConcertSetlist(setlistID: setlistID)
+            )
+            guard let setlist = mapper.toDomain(from: response) else {
+                throw SetlistError.invalidResponse
+            }
+            return setlist
+        } catch let error as SetlistError {
+            throw error
+        } catch {
+            throw errorMapper.mapToSetlistError(error)
+        }
+    }
+
+    public func fetchSetlistSongs(setlistID: Int) async throws(SetlistError) -> [SetlistSong] {
+        do {
+            let response: DTO.Response.FetchSetlistSongList = try await service.request(
+                .fetchSetlistSongList(setlistID: setlistID)
+            )
+            return mapper.toDomain(from: response)
+        } catch {
+            throw errorMapper.mapToSetlistError(error)
+        }
+    }
+}

--- a/Projects/Setlist/SetlistData/Sources/SetlistAssembler.swift
+++ b/Projects/Setlist/SetlistData/Sources/SetlistAssembler.swift
@@ -1,0 +1,20 @@
+//
+//  SetlistAssembler.swift
+//  SetlistData
+//
+//  Created by Youjin Lee on 12/30/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+import DIContainer
+import SetlistDomain
+
+public struct SetlistAssembler: DependencyAssembler {
+    public init() {}
+
+    public func assemble(to container: any DependencyContainer) {
+        container.register(SetlistRepositoryImpl(), for: SetlistRepository.self)
+    }
+}

--- a/Projects/Setlist/SetlistDomain/Sources/Entity/Setlist.swift
+++ b/Projects/Setlist/SetlistDomain/Sources/Entity/Setlist.swift
@@ -1,0 +1,40 @@
+//
+//  Setlist.swift
+//  SetlistDomain
+//
+//  Created by Youjin Lee on 12/30/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+public struct Setlist: Identifiable, Hashable {
+    public let id: Int
+    public let title: String
+    public let imageURL: String?
+    public let type: SetlistType
+    public let startDate: Date
+    public let endDate: Date
+    public let venue: String
+    public let artist: String
+
+    public init(
+        id: Int,
+        title: String,
+        imageURL: String?,
+        type: SetlistType,
+        startDate: Date,
+        endDate: Date,
+        venue: String,
+        artist: String
+    ) {
+        self.id = id
+        self.title = title
+        self.imageURL = imageURL
+        self.type = type
+        self.startDate = startDate
+        self.endDate = endDate
+        self.venue = venue
+        self.artist = artist
+    }
+}

--- a/Projects/Setlist/SetlistDomain/Sources/Entity/SetlistSong.swift
+++ b/Projects/Setlist/SetlistDomain/Sources/Entity/SetlistSong.swift
@@ -1,0 +1,28 @@
+//
+//  SetlistSong.swift
+//  SetlistDomain
+//
+//  Created by Youjin Lee on 12/30/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+public struct SetlistSong: Identifiable, Hashable {
+    public let id: Int
+    public let title: String
+    public let artist: String
+    public let orderIndex: Int
+
+    public init(
+        id: Int,
+        title: String,
+        artist: String,
+        orderIndex: Int
+    ) {
+        self.id = id
+        self.title = title
+        self.artist = artist
+        self.orderIndex = orderIndex
+    }
+}

--- a/Projects/Setlist/SetlistDomain/Sources/Enum/SetlistType.swift
+++ b/Projects/Setlist/SetlistDomain/Sources/Enum/SetlistType.swift
@@ -1,0 +1,33 @@
+//
+//  SetlistType.swift
+//  SetlistDomain
+//
+//  Created by Youjin Lee on 12/30/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+public enum SetlistType: String, CaseIterable {
+    case expected = "EXPECTED"
+    case recent = "RECENT"
+    case none = "NONE"
+
+    public var displayText: String {
+        switch self {
+        case .expected:
+            return "예상 셋리스트"
+        case .recent, .none:
+            return "셋리스트"
+        }
+    }
+
+    public var badgeText: String? {
+        switch self {
+        case .expected:
+            return "예상"
+        case .recent, .none:
+            return nil
+        }
+    }
+}

--- a/Projects/Setlist/SetlistDomain/Sources/Error/SetlistError.swift
+++ b/Projects/Setlist/SetlistDomain/Sources/Error/SetlistError.swift
@@ -1,0 +1,32 @@
+//
+//  SetlistError.swift
+//  SetlistDomain
+//
+//  Created by Youjin Lee on 12/30/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+public enum SetlistError: LocalizedError {
+    case networkError
+    case serverError
+    case invalidResponse
+    case notFound
+    case unknown
+
+    public var errorDescription: String? {
+        switch self {
+        case .networkError:
+            return "네트워크 연결을 확인해주세요."
+        case .serverError:
+            return "서버 오류가 발생했어요."
+        case .invalidResponse:
+            return "데이터를 불러오는데 실패했어요."
+        case .notFound:
+            return "셋리스트를 찾을 수 없어요."
+        case .unknown:
+            return "알 수 없는 오류가 발생했어요."
+        }
+    }
+}

--- a/Projects/Setlist/SetlistDomain/Sources/Placeholder.swift
+++ b/Projects/Setlist/SetlistDomain/Sources/Placeholder.swift
@@ -1,0 +1,6 @@
+//
+//  Placeholder.swift
+//  SetlistDomain
+//
+
+import Foundation

--- a/Projects/Setlist/SetlistDomain/Sources/Placeholder.swift
+++ b/Projects/Setlist/SetlistDomain/Sources/Placeholder.swift
@@ -1,6 +1,0 @@
-//
-//  Placeholder.swift
-//  SetlistDomain
-//
-
-import Foundation

--- a/Projects/Setlist/SetlistDomain/Sources/Repository/SetlistRepository.swift
+++ b/Projects/Setlist/SetlistDomain/Sources/Repository/SetlistRepository.swift
@@ -1,0 +1,14 @@
+//
+//  SetlistRepository.swift
+//  SetlistDomain
+//
+//  Created by Youjin Lee on 12/30/25.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+public protocol SetlistRepository {
+    func fetchSetlist(setlistID: Int) async throws(SetlistError) -> Setlist
+    func fetchSetlistSongs(setlistID: Int) async throws(SetlistError) -> [SetlistSong]
+}

--- a/Projects/Setlist/SetlistFeature/Sources/Placeholder.swift
+++ b/Projects/Setlist/SetlistFeature/Sources/Placeholder.swift
@@ -1,0 +1,6 @@
+//
+//  Placeholder.swift
+//  SetlistFeature
+//
+
+import Foundation

--- a/Tuist/ProjectDescriptionHelpers/Module/Module+Constant.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module/Module+Constant.swift
@@ -68,6 +68,15 @@ public enum ConcertModule: String {
     case concertTests = "ConcertTests"
 }
 
+
+// MARK: - Setlist Module
+
+public enum SetlistModule: String {
+    case setlistData = "SetlistData"
+    case setlistDomain = "SetlistDomain"
+    case setlistFeature = "SetlistFeature"
+}
+
 // MARK: - External Dependency
 
 public enum ExternalDependency: String {

--- a/Tuist/ProjectDescriptionHelpers/Module/Module+ProjectID.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module/Module+ProjectID.swift
@@ -19,6 +19,7 @@ public enum ProjectID: String, CaseIterable {
     case home = "Home"
     
     case concert = "Concert"
+    case setlist = "Setlist"
     public var name: String { rawValue }
     
     public var path: Path {

--- a/Tuist/ProjectDescriptionHelpers/Module/Module+TargetID.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module/Module+TargetID.swift
@@ -15,6 +15,7 @@ public enum TargetID {
     case login(LoginModule)
     case dsKit
     case search(SearchModule)
+    case setlist(SetlistModule)
     case concert(ConcertModule)
     case home(HomeModule)
     case user(UserModule)
@@ -26,6 +27,7 @@ public enum TargetID {
         case .dsKit: return "DSKit"
         case .login(let module): return module.rawValue
         case .search(let module): return module.rawValue
+        case .setlist(let module): return module.rawValue
         case .concert(let module): return module.rawValue
         case .home(let module): return module.rawValue
         case .user(let module): return module.rawValue
@@ -52,6 +54,8 @@ public enum TargetID {
         case .login(let module):
             return ["\(module.rawValue)/Sources/**"]
         case .search(let module):
+            return ["\(module.rawValue)/Sources/**"]
+        case .setlist(let module):
             return ["\(module.rawValue)/Sources/**"]
         case .concert(let module):
             return ["\(module.rawValue)/Sources/**"]

--- a/Tuist/ProjectDescriptionHelpers/Module/TargetDependency+Extension.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module/TargetDependency+Extension.swift
@@ -41,4 +41,8 @@ extension TargetDependency {
     public static func concert(_ module: ConcertModule) -> TargetDependency {
         return .project(target: module.rawValue, path: ProjectID.concert.path)
     }
+
+    public static func setlist(_ module: SetlistModule) -> TargetDependency {
+        return .project(target: module.rawValue, path: ProjectID.setlist.path)
+    }
 }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 셋리스트 모듈을 생성했어요.
- 셋리스트 기능 구현을 위한 Data, Domain 레이어를 구현했어요.
- Concert 모듈에서 사용하지 않는 `fetchSetlistSongList` 메서드를 삭제했어요

## 🔗 연결된 이슈
- Resolved: n/a
