### PR TITLE
[Feat] 미완성 플로우 연결 및 전체 화면 레이아웃 및 기능 일부 수정

### DIFF
--- a/Projects/App/Sources/View/LivithMainTabView.swift
+++ b/Projects/App/Sources/View/LivithMainTabView.swift
@@ -46,10 +46,13 @@ struct LivithMainTabView: View {
     }
 
     // MARK: - Property
-    
+
     @Binding private var nickname: String
     @State private var selectedTab: Tab = .home
     @State private var isTabBarHidden: Bool = false
+    @State private var showToast: Bool = false
+    @State private var toastType: LivithToastType = .success
+    @State private var toastMessage: String = ""
     
     // MARK: - LifeCycle
 
@@ -70,7 +73,14 @@ struct LivithMainTabView: View {
                     .tag(Tab.search)
                     .toolbar(.hidden, for: .tabBar)
                 
-                UserView(isTabBarHidden: $isTabBarHidden)
+                UserView(
+                        isTabBarHidden: $isTabBarHidden,
+                        showToast: { type, message in
+                            toastType = type
+                            toastMessage = message
+                            showToast = true
+                        }
+                    )
                     .tag(Tab.my)
                     .toolbar(.hidden, for: .tabBar)
             }
@@ -85,6 +95,12 @@ struct LivithMainTabView: View {
         .animation(.easeInOut(duration: 0.3), value: isTabBarHidden)
         .animation(.easeInOut(duration: 0.3), value: selectedTab)
         .ignoresSafeArea(edges: .bottom)
+        .livithToast(
+            isPresented: $showToast,
+            type: toastType,
+            message: toastMessage,
+            position: .safeAreaTop
+        )
     }
 }
 

--- a/Projects/App/Sources/View/LivithMainTabView.swift
+++ b/Projects/App/Sources/View/LivithMainTabView.swift
@@ -70,7 +70,7 @@ struct LivithMainTabView: View {
                     .tag(Tab.search)
                     .toolbar(.hidden, for: .tabBar)
                 
-                UserView(nickname: $nickname, isTabBarHidden: $isTabBarHidden)
+                UserView(isTabBarHidden: $isTabBarHidden)
                     .tag(Tab.my)
                     .toolbar(.hidden, for: .tabBar)
             }

--- a/Projects/Core/LivithNetwork/Sources/DTO/UserFeature/UpdateUserNickname.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/UserFeature/UpdateUserNickname.swift
@@ -20,18 +20,19 @@ public extension DTO.Request {
 
 public extension DTO.Response {
     struct UpdateUserNickname: Decodable {
-        public let id: String
+        public let id: Int
         public let interestConcertID: Int?
         public let provider: String
         public let providerID: String
         public let email: String?
         public let nickname: String
         public let marketingConsent: Bool
-        
+
         enum CodingKeys: String, CodingKey {
             case id
             case interestConcertID = "interestConcertId"
-            case provider, providerID, email, nickname, marketingConsent
+            case providerID = "providerId"
+            case provider, email, nickname, marketingConsent
         }
     }
 }

--- a/Projects/Core/LivithNetwork/Sources/Foundation/Helper/ErrorMapper.swift
+++ b/Projects/Core/LivithNetwork/Sources/Foundation/Helper/ErrorMapper.swift
@@ -28,13 +28,22 @@ public final class ErrorMapper: ErrorMapperProtocol {
                 return .noConnection(error)
             case .invalidURL:
                 return .invalidURL
-            case .responseValidationFailed:
-                return .invalidResponse
+            case .responseValidationFailed(let reason):
+                return mapResponseValidationError(reason)
             default:
                 return .unknown(afError)
             }
         }
 
         return .unknown(error)
+    }
+
+    private func mapResponseValidationError(_ reason: AFError.ResponseValidationFailureReason) -> NetworkError {
+        switch reason {
+        case .unacceptableStatusCode(let code):
+            return NetworkError.from(statusCode: code)
+        default:
+            return .invalidResponse
+        }
     }
 }

--- a/Projects/Home/HomeDomain/Sources/Enum/SetlistType.swift
+++ b/Projects/Home/HomeDomain/Sources/Enum/SetlistType.swift
@@ -11,13 +11,14 @@ import Foundation
 public enum SetlistType: String, CaseIterable {
     case expected = "EXPECTED"
     case recent = "RECENT"
+    case past = "PAST"
     case none = "NONE"
 
     public var displayText: String {
         switch self {
         case .expected:
             return "예상 셋리스트"
-        case .recent, .none:
+        case .recent, .past, .none:
             return "셋리스트"
         }
     }
@@ -26,8 +27,17 @@ public enum SetlistType: String, CaseIterable {
         switch self {
         case .expected:
             return "예상"
-        case .recent, .none:
+        case .recent, .past, .none:
             return nil
+        }
+    }
+
+    public var isPastSetlist: Bool {
+        switch self {
+        case .recent, .past:
+            return true
+        case .expected, .none:
+            return false
         }
     }
 }

--- a/Projects/Home/HomeFeature/Sources/Coordinator/HomeCoordinator.swift
+++ b/Projects/Home/HomeFeature/Sources/Coordinator/HomeCoordinator.swift
@@ -59,4 +59,26 @@ final class HomeCoordinator: Coordinator {
         self.concertCoordinator = coordinator
         coordinator.start(concertID: concertID)
     }
+
+    func showSongDetail(songID: Int, setlistID: Int, songTitle: String) {
+        let coordinator = ConcertCoordinator(
+            navigationController: navigationController,
+            onDismiss: { [weak self] in
+                self?.concertCoordinator = nil
+            }
+        )
+        self.concertCoordinator = coordinator
+        coordinator.push(to: .songLyrics(songID: songID, setlistID: setlistID, songTitle: songTitle))
+    }
+
+    func showSetlistDetail(concertID: Int, setlistID: Int) {
+        let coordinator = ConcertCoordinator(
+            navigationController: navigationController,
+            onDismiss: { [weak self] in
+                self?.concertCoordinator = nil
+            }
+        )
+        self.concertCoordinator = coordinator
+        coordinator.push(to: .setlistDetail(concertID: concertID, setlistID: setlistID))
+    }
 }

--- a/Projects/Home/HomeFeature/Sources/Home/View/HomeInterestConcertView.swift
+++ b/Projects/Home/HomeFeature/Sources/Home/View/HomeInterestConcertView.swift
@@ -75,11 +75,11 @@ private extension HomeInterestConcertView {
                             ConcertSetlistTabView(
                                 setlist: store.state.setlist,
                                 songs: store.state.songList,
-                                onSongTap: { _ in
-                                    // TODO: 곡 상세 화면으로 이동
+                                onSongTap: { songID in
+                                    handleSongTap(songID: songID)
                                 },
-                                onMoreTap: { _ in
-                                    // TODO: 셋리스트 상세 화면으로 이동
+                                onMoreTap: { setlistID in
+                                    handleSetlistMoreTap(setlistID: setlistID)
                                 }
                             )
                         }
@@ -174,6 +174,17 @@ private extension HomeInterestConcertView {
     func handleMoreInfoTap() {
         guard let concertID = store.state.interestConcert?.id else { return }
         coordinator?.showConcertDetail(concertID: concertID)
+    }
+
+    func handleSongTap(songID: Int) {
+        guard let setlistID = store.state.setlist?.id,
+              let song = store.state.songList.first(where: { $0.id == songID }) else { return }
+        coordinator?.showSongDetail(songID: songID, setlistID: setlistID, songTitle: song.title)
+    }
+
+    func handleSetlistMoreTap(setlistID: Int) {
+        guard let concertID = store.state.interestConcert?.id else { return }
+        coordinator?.showSetlistDetail(concertID: concertID, setlistID: setlistID)
     }
 
     func handleChangeMainConcert() {

--- a/Projects/Home/HomeFeature/Sources/Home/View/HomeInterestConcertView.swift
+++ b/Projects/Home/HomeFeature/Sources/Home/View/HomeInterestConcertView.swift
@@ -58,7 +58,8 @@ private extension HomeInterestConcertView {
                         remainDays: store.state.interestConcert?.daysLeft ?? 0,
                         date: store.state.interestConcert?.startDate ?? "",
                         location: store.state.interestConcert?.venue ?? "",
-                        title: store.state.interestConcert?.title ?? ""
+                        title: store.state.interestConcert?.title ?? "",
+                        onMoreInfoTap: handleMoreInfoTap
                     )
                     
                     SegmentTabBar(
@@ -170,6 +171,11 @@ private extension HomeInterestConcertView {
         self.showBottomSheet = flag
     }
     
+    func handleMoreInfoTap() {
+        guard let concertID = store.state.interestConcert?.id else { return }
+        coordinator?.showConcertDetail(concertID: concertID)
+    }
+
     func handleChangeMainConcert() {
         showBottomSheet(flag: false)
         coordinator?.push(to: .interest)

--- a/Projects/Home/HomeFeature/Sources/Home/View/Subview/ConcertSetlistTabView.swift
+++ b/Projects/Home/HomeFeature/Sources/Home/View/Subview/ConcertSetlistTabView.swift
@@ -53,7 +53,7 @@ private extension ConcertSetlistTabView {
             }
             
             VStack(spacing: .zero) {
-                ForEach(songs, id: \.self) { song in
+                ForEach(songs.prefix(3), id: \.self) { song in
                     SongRowView(
                         orderIndex: song.orderIndex,
                         title: song.title,

--- a/Projects/Home/HomeFeature/Sources/Home/View/Subview/ConcertSetlistTabView.swift
+++ b/Projects/Home/HomeFeature/Sources/Home/View/Subview/ConcertSetlistTabView.swift
@@ -47,7 +47,7 @@ private extension ConcertSetlistTabView {
             titleText()
                 .padding(.top, 24)
             
-            if let setlist = self.setlist, setlist.type == .recent {
+            if let setlist = self.setlist, setlist.type.isPastSetlist {
                 setlistCard(setlist: setlist)
                     .padding(.top, 20)
             }
@@ -74,7 +74,7 @@ private extension ConcertSetlistTabView {
     }
     
     func titleText() -> some View {
-        Text(setlist?.type == .recent ? "이전 콘서트에서\n어떤 노래를 불렀을까요?" : "이전 콘서트를 기반으로\n이런 노래를 예상해요")
+        Text(setlist?.type.isPastSetlist == true ? "이전 콘서트에서\n어떤 노래를 불렀을까요?" : "이전 콘서트를 기반으로\n이런 노래를 예상해요")
             .notosans(.body1Semibold)
             .foregroundStyle(.livithColor(.white100))
             .multilineTextAlignment(.leading)

--- a/Projects/Home/HomeFeature/Sources/Home/View/Subview/ConcertSetlistTabView.swift
+++ b/Projects/Home/HomeFeature/Sources/Home/View/Subview/ConcertSetlistTabView.swift
@@ -86,19 +86,24 @@ private extension ConcertSetlistTabView {
             posterImageView(urlString: setlist.imageURL ?? "")
                 .padding([.vertical, .leading], 16)
             
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: 0) {
                 Text(setlist.title)
                     .notosans(.body2Medium)
                     .foregroundStyle(.livithColor(.black100))
                     .lineLimit(1)
+                    .padding(.bottom, 4)
                 
                 Text(setlist.artist)
                     .notosans(.body4Regular)
                     .foregroundStyle(.livithColor(.black80))
                     .lineLimit(1)
+                    .padding(.bottom, 10)
                 
                 HStack(spacing: 6) {
-                    tagView(text: setlist.venue)
+                    if setlist.venue != "" {
+                        tagView(text: setlist.venue)
+                    }
+                    
                     tagView(text: formatDate(setlist.startDate))
                 }
             }

--- a/Projects/Home/HomeFeature/Sources/Home/View/Subview/ConcertSetlistTabView.swift
+++ b/Projects/Home/HomeFeature/Sources/Home/View/Subview/ConcertSetlistTabView.swift
@@ -60,13 +60,13 @@ private extension ConcertSetlistTabView {
                         artist: song.artist,
                         onTapped: { onSongTap(song.id) }
                     )
-                    .padding(.vertical, 12)
+                    .padding(.bottom, 12)
                 }
                 moreButton()
             }
             .background(.livithColor(.black90))
-            .clipShape(RoundedRectangle(cornerRadius: 24))
-            .padding(.top, 20)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.vertical, 20)
             
             Spacer()
                 .frame(height: 232)

--- a/Projects/Home/HomeFeature/Sources/Home/View/Subview/ConcertSetlistTabView.swift
+++ b/Projects/Home/HomeFeature/Sources/Home/View/Subview/ConcertSetlistTabView.swift
@@ -84,22 +84,22 @@ private extension ConcertSetlistTabView {
     func setlistCard(setlist: Setlist) -> some View {
         HStack(spacing: 16) {
             posterImageView(urlString: setlist.imageURL ?? "")
-                .padding([.vertical, .leading], 12)
+                .padding([.vertical, .leading], 16)
             
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 4) {
                 Text(setlist.title)
-                    .notosans(.body1Semibold)
+                    .notosans(.body2Medium)
                     .foregroundStyle(.livithColor(.black100))
                     .lineLimit(1)
                 
                 Text(setlist.artist)
-                    .notosans(.body2Regular)
+                    .notosans(.body4Regular)
                     .foregroundStyle(.livithColor(.black80))
                     .lineLimit(1)
                 
-                HStack(spacing: 8) {
+                HStack(spacing: 6) {
                     tagView(text: setlist.venue)
-                    tagView(text: formatDateRange(start: setlist.startDate, end: setlist.endDate))
+                    tagView(text: formatDate(setlist.startDate))
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -158,23 +158,14 @@ private extension ConcertSetlistTabView {
 // MARK: - Helpers
 
 private extension ConcertSetlistTabView {
-    static let yearFormatter: DateFormatter = {
+    static let dateFormatter: DateFormatter = {
         let f = DateFormatter()
-        f.dateFormat = "yyyy.MM.dd"
+        f.dateFormat = "yyyy년 M월 d일"
         return f
     }()
 
-    static let noYearFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "MM.dd"
-        return f
-    }()
-
-    func formatDateRange(start: Date, end: Date) -> String {
-        let startDateString = Self.yearFormatter.string(from: start)
-        let endDateString = Self.noYearFormatter.string(from: end)
-
-        return "\(startDateString) ~ \(endDateString)"
+    func formatDate(_ date: Date) -> String {
+        Self.dateFormatter.string(from: date)
     }
 }
 

--- a/Projects/Home/HomeFeature/Sources/Home/View/Subview/HomeInterestConcertBottomSheetView.swift
+++ b/Projects/Home/HomeFeature/Sources/Home/View/Subview/HomeInterestConcertBottomSheetView.swift
@@ -62,12 +62,12 @@ private extension HomeInterestConcertBottomSheetView {
                 icon
                     .resizable()
                     .frame(width: 36, height: 36)
-                    .foregroundStyle(isDestructive ? .livithColor(.transition) : .livithColor(.white100))
+                    .foregroundStyle(isDestructive ? .livithColor(.translation) : .livithColor(.white100))
                     .padding([.vertical, .leading], 8)
                 
                 Text(title)
                     .notosans(.body2Semibold)
-                    .foregroundStyle(isDestructive ? .livithColor(.transition) : .livithColor(.white100))
+                    .foregroundStyle(isDestructive ? .livithColor(.translation) : .livithColor(.white100))
                 
                 Spacer()
             }

--- a/Projects/Home/HomeFeature/Sources/Interest/View/InteresetConcertCompleteView.swift
+++ b/Projects/Home/HomeFeature/Sources/Interest/View/InteresetConcertCompleteView.swift
@@ -43,8 +43,10 @@ struct InteresetConcertCompleteView: View {
                         .foregroundStyle(.livithColor(.white100)))
                     .notosans(.headSemibold)
                     .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
                 }
                 .padding(.top, 80)
+                .padding(.horizontal, 16)
             }
             
             Button {

--- a/Projects/Login/LoginFeature/Sources/Coordinator/LoginCoordinator.swift
+++ b/Projects/Login/LoginFeature/Sources/Coordinator/LoginCoordinator.swift
@@ -46,7 +46,8 @@ final class LoginCoordinator: Coordinator {
             let vc = UIHostingController(
                 rootView: ErrorSheetView(
                     title: "탈퇴 후 7일이 지나지 않았어요",
-                    message: "7일이 지난 후 다시 시도해주세요"
+                    message: "7일이 지난 후 다시 시도해주세요",
+                    confirmTitle: "홈으로 돌아가기"
                 ) { [weak self] in
                     self?.dismiss()
                 }

--- a/Projects/User/UserData/Sources/UserRepositoryImpl.swift
+++ b/Projects/User/UserData/Sources/UserRepositoryImpl.swift
@@ -48,15 +48,35 @@ extension UserRepositoryImpl: UserRepository {
     public func updateUserNickname(nickname: String) async throws(UserError) -> String {
         do {
             let request = DTO.Request.UpdateUserNickname(nickname: nickname)
-            
+
             let response: DTO.Response.UpdateUserNickname = try await userService.request(
                 UserEndpoint.updateUserNickname(request: request)
             )
-            
+
+            updateStoredUserNickname(response.nickname)
+
             return response.nickname
         } catch let error {
             throw userErrorMapper.mapToUserError(error)
         }
+    }
+
+    private func updateStoredUserNickname(_ nickname: String) {
+        guard let currentUser: DTO.Response.FetchUserInfo = try? localStorage.fetch(for: LocalStorageKeys.currentUser) else {
+            return
+        }
+
+        let updatedUser = DTO.Response.FetchUserInfo(
+            id: currentUser.id,
+            interestConcertID: currentUser.interestConcertID,
+            provider: currentUser.provider,
+            providerID: currentUser.providerID,
+            email: currentUser.email,
+            nickname: nickname,
+            marketingConsent: currentUser.marketingConsent
+        )
+
+        try? localStorage.save(updatedUser, for: LocalStorageKeys.currentUser)
     }
     
     public func deleteUser(reason: String) async throws(UserError) {

--- a/Projects/User/UserFeature/Sources/Store/UserStore.swift
+++ b/Projects/User/UserFeature/Sources/Store/UserStore.swift
@@ -1,0 +1,55 @@
+//
+//  UserStore.swift
+//  UserFeature
+//
+//  Created by Youjin Lee on 1/2/26.
+//  Copyright © 2025 Livith. All rights reserved.
+//
+
+import Foundation
+
+import Persistence
+
+struct UserState {
+    var nickname: String = ""
+}
+
+enum UserIntent {
+    case fetchNickname
+}
+
+final class UserStore: ObservableObject {
+    @Published private(set) var state = UserState()
+
+    private let localStorage: LocalKeyValueStorage
+
+    init(localStorage: LocalKeyValueStorage = UserDefaultsStorage()) {
+        self.localStorage = localStorage
+    }
+
+    @MainActor
+    func send(_ intent: UserIntent) {
+        switch intent {
+        case .fetchNickname:
+            fetchNicknameFromStorage()
+        }
+    }
+}
+
+// MARK: - Helper
+
+private extension UserStore {
+    @MainActor
+    func fetchNicknameFromStorage() {
+        guard let user: StoredUserInfo = try? localStorage.fetch(for: "currentUser") else {
+            return
+        }
+        state.nickname = user.nickname
+    }
+}
+
+// MARK: - StoredUserInfo
+
+private struct StoredUserInfo: Decodable {
+    let nickname: String
+}

--- a/Projects/User/UserFeature/Sources/View/UserView.swift
+++ b/Projects/User/UserFeature/Sources/View/UserView.swift
@@ -37,8 +37,6 @@ public struct UserView: View {
 
     // MARK: - Property
 
-    @Binding private var nickname: String
-
     @State private var path = NavigationPath()
     @State private var overlayType: OverlayType = .none
     @State private var showSuccessToast: Bool = false
@@ -48,12 +46,12 @@ public struct UserView: View {
 
     @Binding private var isTabBarHidden: Bool
 
+    @StateObject private var userStore = UserStore()
     @StateObject private var logoutStore = LogoutStore()
 
     // MARK: - LifeCycle
 
-    public init(nickname: Binding<String>, isTabBarHidden: Binding<Bool>) {
-        self._nickname = nickname
+    public init(isTabBarHidden: Binding<Bool>) {
         self._isTabBarHidden = isTabBarHidden
     }
     
@@ -129,6 +127,9 @@ public struct UserView: View {
                 position: .safeAreaTop
             )
         }
+        .onAppear {
+            userStore.send(.fetchNickname)
+        }
         .onChange(of: logoutStore.state.logoutResult) { _, newResult in
             handleLogoutResult(newResult)
         }
@@ -171,8 +172,8 @@ private extension UserView {
     
     var titleText: some View {
         Text.init(
-            String(format: Literals.titleFormat, nickname),
-            highlighting: "\(nickname)",
+            String(format: Literals.titleFormat, userStore.state.nickname),
+            highlighting: "\(userStore.state.nickname)",
             color: .livithColor(.white100),
             font: .notosans(.headSemibold)
         )

--- a/Projects/User/UserFeature/Sources/View/UserView.swift
+++ b/Projects/User/UserFeature/Sources/View/UserView.swift
@@ -39,7 +39,6 @@ public struct UserView: View {
 
     @State private var path = NavigationPath()
     @State private var overlayType: OverlayType = .none
-    @State private var showSuccessToast: Bool = false
     @State private var showLogoutToast: Bool = false
     @State private var logoutToastType: LivithToastType = .success
     @State private var logoutToastMessage: String = ""
@@ -49,10 +48,13 @@ public struct UserView: View {
     @StateObject private var userStore = UserStore()
     @StateObject private var logoutStore = LogoutStore()
 
+    private let showToast: ((LivithToastType, String) -> Void)?
+
     // MARK: - LifeCycle
 
-    public init(isTabBarHidden: Binding<Bool>) {
+    public init(isTabBarHidden: Binding<Bool>, showToast: ((LivithToastType, String) -> Void)? = nil) {
         self._isTabBarHidden = isTabBarHidden
+        self.showToast = showToast
     }
     
     // MARK: - Body
@@ -102,7 +104,8 @@ public struct UserView: View {
                         onDismiss: { path.removeLast() },
                         onSuccess: {
                             path.removeLast()
-                            withAnimation { showSuccessToast = true }
+                            userStore.send(.fetchNickname)
+                            showToast?(.success, Literals.toastSuccess)
                         }
                     )
                     .navigationBarBackButtonHidden()
@@ -114,18 +117,6 @@ public struct UserView: View {
                     .navigationBarBackButtonHidden()
                 }
             }
-            .livithToast(
-                isPresented: $showSuccessToast,
-                type: .success,
-                message: Literals.toastSuccess,
-                position: .safeAreaTop
-            )
-            .livithToast(
-                isPresented: $showLogoutToast,
-                type: logoutToastType,
-                message: logoutToastMessage,
-                position: .safeAreaTop
-            )
         }
         .onAppear {
             userStore.send(.fetchNickname)
@@ -148,6 +139,12 @@ public struct UserView: View {
                 isTabBarHidden = !newPath.isEmpty
             }
         }
+        .livithToast(
+            isPresented: $showLogoutToast,
+            type: logoutToastType,
+            message: logoutToastMessage,
+            position: .safeAreaTop
+        )
     }
 }
 


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- InteresetConcertCompleteView에서 콘서트 제목이 길어도 잘리지 않고 아랫줄로 넘어가도록 수정했어요.
- 홈화면 셋리스트 탭에서 노래가 3개만 표시되도록 제한했어요.
- 홈화면 셋리스트 탭에서 지난 셋리스트가 예상 셋리스트로 표시되는 문제를 해결했어요.
- 홈화면 셋리스트에서 곡 탭 시 곡 상세로, 더보기 탭 시 셋리스트 상세로 이동하는 네비게이션을 구현했어요.
- ConcertSetlistTabView의 날짜 형식을 "yyyy년 M월 d일"로 변경했어요.
- 닉네임 수정 후 UserView로 돌아올 때 닉네임이 갱신되도록 수정했어요.
- 토스트가 탭 전환 시에도 정상적으로 표시되도록 LivithMainTabView 레벨로 이동했어요.
- 회원탈퇴 후 7일 이내 로그인 시 403 에러가 발생하면 ErrorSheetView를 표시하도록 구현했어요.

## 🔗 연결된 이슈
- Resolved: #122
