### PR TITLE
[Fix] 2차 QA 반영

### DIFF
--- a/Projects/Login/LoginFeature/Sources/Onboarding/View/Subview/CheckboxRowView.swift
+++ b/Projects/Login/LoginFeature/Sources/Onboarding/View/Subview/CheckboxRowView.swift
@@ -36,6 +36,8 @@ struct CheckboxRow: View {
             } label: {
                 HStack(spacing: 4) {
                     Image.livithIcon(isChecked ? .checkboxLineEnabled : .checkboxLineDefault)
+                        .resizable()
+                        .frame(width: 24, height: 24)
                     
                     Text(title)
                         .notosans(.body2Medium)
@@ -48,6 +50,7 @@ struct CheckboxRow: View {
                     }
                 }
             }
+            .buttonStyle(.plain)
             
             Spacer()
             

--- a/Projects/Login/LoginFeature/Sources/Onboarding/View/TermsView.swift
+++ b/Projects/Login/LoginFeature/Sources/Onboarding/View/TermsView.swift
@@ -38,6 +38,7 @@ struct TermsView: View {
                 termsSection
                     .padding(.top, 20)
                     .padding(.leading, 36)
+                    .padding(.trailing, 20)
 
                 Spacer()
 
@@ -94,6 +95,7 @@ private extension TermsView {
             .background(Color.livithColor(.black80))
             .cornerRadius(12)
         }
+        .buttonStyle(.plain)
     }
     
     var termsSection: some View {
@@ -118,7 +120,6 @@ private extension TermsView {
                     Text(Literals.moreButtonText)
                         .notosans(.caption2Semibold)
                         .foregroundStyle(Color.livithColor(.white100))
-                        .padding(.trailing, 4)
                 }
             )
         )

--- a/Projects/Search/SearchFeature/Sources/Explore/View/Subview/BannerSectionView.swift
+++ b/Projects/Search/SearchFeature/Sources/Explore/View/Subview/BannerSectionView.swift
@@ -12,29 +12,95 @@ import LivithDesignSystem
 import SearchDomain
 
 struct BannerSectionView: View {
-	@Binding var currentPage: Int
-	let banners: [Banner]
+    
+    // MARK: - Constants
+    
+    private enum Constants {
+        static let dragThreshold: CGFloat = 50
+        static let minimumDragDistance: CGFloat = 20
+        static let animationDuration: Double = 0.3
+        static let indicatorBottomPadding: CGFloat = 16
+    }
+    
+    // MARK: - Property
+    
+    @Binding var currentPage: Int
+    let banners: [Banner]
+    
+    @State private var dragOffset: CGFloat = 0
+    
+    // MARK: - Body
+    
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            bannerContent
+            pageIndicator
+        }
+        .contentShape(Rectangle())
+        .gesture(dragGesture)
+    }
+}
 
-	var body: some View {
-		ZStack(alignment: .bottom) {
-			TabView(selection: $currentPage) {
-				ForEach(Array(banners.enumerated()), id: \.element.id) { index, banner in
-					BannerCell(
-						imageURL: banner.imageURL,
-						category: banner.category,
-						title: banner.title,
-						description: banner.description
-					)
-					.tag(index)
-				}
-			}
-			.tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
-            
-            LivithPageIndicatorView(
-                currentPage: currentPage,
-                pageCount: banners.count
+// MARK: - Subviews
+
+private extension BannerSectionView {
+    var bannerContent: some View {
+        ForEach(Array(banners.enumerated()), id: \.element.id) { index, banner in
+            BannerCell(
+                imageURL: banner.imageURL,
+                category: banner.category,
+                title: banner.title,
+                description: banner.description
             )
-            .padding(.bottom, 16)
-		}
-	}
+            .opacity(index == currentPage ? 1 : 0)
+        }
+    }
+    
+    var pageIndicator: some View {
+        LivithPageIndicatorView(
+            currentPage: currentPage,
+            pageCount: banners.count
+        )
+        .padding(.bottom, Constants.indicatorBottomPadding)
+    }
+}
+
+// MARK: - Gesture
+
+private extension BannerSectionView {
+    var dragGesture: some Gesture {
+        DragGesture(minimumDistance: Constants.minimumDragDistance)
+            .onChanged { dragOffset = $0.translation.width }
+            .onEnded(handleDragEnded)
+    }
+    
+    func handleDragEnded(_ value: DragGesture.Value) {
+        let horizontalAmount = value.translation.width
+        let newIndex = calculateNewIndex(from: horizontalAmount)
+        
+        if newIndex != currentPage {
+            withAnimation(.easeInOut(duration: Constants.animationDuration)) {
+                currentPage = newIndex
+            }
+        }
+        
+        dragOffset = 0
+    }
+    
+    func calculateNewIndex(from horizontalAmount: CGFloat) -> Int {
+        if horizontalAmount < -Constants.dragThreshold {
+            return nextIndex
+        } else if horizontalAmount > Constants.dragThreshold {
+            return previousIndex
+        }
+        return currentPage
+    }
+    
+    var nextIndex: Int {
+        (currentPage + 1) % banners.count
+    }
+    
+    var previousIndex: Int {
+        (currentPage - 1 + banners.count) % banners.count
+    }
 }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 약관동의 화면의 '더보기' 버튼 위치 조정
- 홈 탭 관심 콘서트 화면 '더 많은 정보 확인하기' 탭 배경색 지정
    - 디자인 시스템에 적용
    - [커밋 내용 확인하기 👉🏽](https://github.com/mediunn/Livith-iOS-DesignSystem/commit/5d181fd8a578e0631c8dbea3148e2e09d8066ff8)
- 탐색 탭 배너 섹션 무한 횡스크롤 구현

|    구현 내용    |   iPhone 16   |
| :-------------: | :----------: |
| 탐색 탭 무한 횡스크롤 | <img src = "https://github.com/user-attachments/assets/4db76b73-2f4c-4942-b980-d9b01b984e4a" width=250> |
| 약관동의 화면 더보기 위치 조정 | <img src = "https://github.com/user-attachments/assets/5fcdf131-3b5e-4c2e-bfa6-0c5189e6e615" width=250> |

## 🔗 연결된 이슈
- Resolved: #147
