### PR TITLE
[Fix] 서버 변경에 따른 버전 정보 업데이트 및 변동사항 반영

### DIFF
--- a/Projects/App/Sources/View/AppRootView.swift
+++ b/Projects/App/Sources/View/AppRootView.swift
@@ -31,11 +31,17 @@ struct AppRootView: View {
         ZStack {
             contentView()
             splashOverlay()
-            welcomeSheetOverlay()
         }
         .animation(.easeInOut(duration: Constants.animationDuration), value: isLaunchScreenVisible)
         .animation(.easeInOut(duration: Constants.animationDuration), value: currentRoute)
-        .animation(.easeInOut(duration: Constants.animationDuration), value: isWelcomeSheetVisible)
+        .crossDissolve(isPresented: $isWelcomeSheetVisible, dismissOnTapOutside: false) {
+            LivithModal(
+                type: .welcome(nickname: nickname),
+                onConfirm: {
+                    isWelcomeSheetVisible = false
+                }
+            )
+        }
         .onReceive(NotificationCenter.default.publisher(for: Notification.Name.reloginRequired)) { notification in
             if let message = notification.userInfo?["toastMessage"] as? String {
                 toastMessage = message
@@ -88,22 +94,6 @@ private extension AppRootView {
         }
     }
 
-    @ViewBuilder
-    func welcomeSheetOverlay() -> some View {
-        if isWelcomeSheetVisible {
-            LivithModal(
-                type: .welcome(nickname: nickname),
-                onConfirm: {
-                    withAnimation(.easeInOut(duration: Constants.animationDuration)) {
-                        isWelcomeSheetVisible = false
-                    }
-                }
-            )
-            .transition(.opacity)
-            .zIndex(2)
-        }
-    }
-    
     func handleLoginCompleted(nickname: String) {
         transition(to: .main, nickname: nickname)
     }

--- a/Projects/ConcertFeature/Sources/View/ConcertView.swift
+++ b/Projects/ConcertFeature/Sources/View/ConcertView.swift
@@ -81,10 +81,46 @@ public struct ConcertView: View {
             duration: nil,
             topPadding: 16
         )
-        .overlay { interestConfirmDialogOverlay }
-        .animation(.easeInOut(duration: 0.3), value: showInterestConfirmDialog)
-        .overlay { communityDialogOverlay }
-        .animation(.easeInOut(duration: 0.3), value: communityStore.state.dialogState)
+        .crossDissolve(isPresented: $showInterestConfirmDialog, dismissOnTapOutside: false) {
+            LivithDangerModal(
+                message: "관심 콘서트를 설정하시겠어요?",
+                confirmTitle: "설정할래요",
+                cancelTitle: "취소할래요",
+                type: .confirm(onConfirm: {
+                    showInterestConfirmDialog = false
+                    store.send(.interestButtonTapped)
+                }),
+                onCancel: {
+                    showInterestConfirmDialog = false
+                }
+            )
+        }
+        .crossDissolve(isPresented: isDeleteDialogPresented, dismissOnTapOutside: false) {
+            LivithDangerModal(
+                message: "댓글을 삭제하시겠어요?",
+                confirmTitle: "지금은 삭제할래요",
+                cancelTitle: "잘못 눌렀어요",
+                type: .confirm(onConfirm: {
+                    communityStore.send(.confirmDelete)
+                }),
+                onCancel: {
+                    communityStore.send(.dismissDialog)
+                }
+            )
+        }
+        .crossDissolve(isPresented: isReportDialogPresented, dismissOnTapOutside: false) {
+            LivithDangerModal(
+                message: "댓글을 신고하시겠어요?",
+                confirmTitle: "신고할래요",
+                cancelTitle: "잘못 눌렀어요",
+                type: .report(onConfirm: { content in
+                    communityStore.send(.confirmReport(content: content))
+                }),
+                onCancel: {
+                    communityStore.send(.dismissDialog)
+                }
+            )
+        }
         .overlay { ticketReturnBannerOverlay }
         .animation(.spring(response: 0.4, dampingFraction: 0.8), value: store.state.showTicketReturnBanner)
         .onAppear {
@@ -163,61 +199,33 @@ private extension ConcertView {
     }
 }
 
-// MARK: - Dialog Overlays
+// MARK: - Computed Bindings
 
 private extension ConcertView {
-    @ViewBuilder
-    var interestConfirmDialogOverlay: some View {
-        if showInterestConfirmDialog {
-            LivithDangerModal(
-                message: "관심 콘서트를 설정하시겠어요?",
-                confirmTitle: "설정할래요",
-                cancelTitle: "취소할래요",
-                type: .confirm(onConfirm: {
-                    showInterestConfirmDialog = false
-                    store.send(.interestButtonTapped)
-                }),
-                onCancel: {
-                    showInterestConfirmDialog = false
-                }
-            )
-            .transition(.opacity)
-        }
+    var isDeleteDialogPresented: Binding<Bool> {
+        Binding(
+            get: { 
+                if case .delete = communityStore.state.dialogState { return true }
+                return false
+            },
+            set: { if !$0 { communityStore.send(.dismissDialog) } }
+        )
     }
+    
+    var isReportDialogPresented: Binding<Bool> {
+        Binding(
+            get: { 
+                if case .report = communityStore.state.dialogState { return true }
+                return false
+            },
+            set: { if !$0 { communityStore.send(.dismissDialog) } }
+        )
+    }
+}
 
-    @ViewBuilder
-    var communityDialogOverlay: some View {
-        switch communityStore.state.dialogState {
-        case .delete:
-            LivithDangerModal(
-                message: "댓글을 삭제하시겠어요?",
-                confirmTitle: "지금은 삭제할래요",
-                cancelTitle: "잘못 눌렀어요",
-                type: .confirm(onConfirm: {
-                    communityStore.send(.confirmDelete)
-                }),
-                onCancel: {
-                    communityStore.send(.dismissDialog)
-                }
-            )
-            .transition(.opacity)
-        case .report:
-            LivithDangerModal(
-                message: "댓글을 신고하시겠어요?",
-                confirmTitle: "신고할래요",
-                cancelTitle: "잘못 눌렀어요",
-                type: .report(onConfirm: { content in
-                    communityStore.send(.confirmReport(content: content))
-                }),
-                onCancel: {
-                    communityStore.send(.dismissDialog)
-                }
-            )
-            .transition(.opacity)
-        case .none:
-            EmptyView()
-        }
-    }
+// MARK: - Banner Overlays
+
+private extension ConcertView {
 
     @ViewBuilder
     var ticketReturnBannerOverlay: some View {

--- a/Projects/Core/LivithNetwork/Sources/Endpoint/CommentEndpoint.swift
+++ b/Projects/Core/LivithNetwork/Sources/Endpoint/CommentEndpoint.swift
@@ -21,13 +21,13 @@ extension CommentEndpoint: NetworkEndpoint {
     public var path: String? {
         switch self {
         case .fetchConcertCommentList(let concertID, _, _):
-            return "/api/v4/concerts/\(concertID)/comments"
+            return "/concerts/\(concertID)/comments"
         case .createComment(let concertID, _):
-            return "/api/v4/concerts/\(concertID)/comments"
+            return "/concerts/\(concertID)/comments"
         case .deleteComment(let commentID):
-            return "/api/v4/comments/\(commentID)"
+            return "/comments/\(commentID)"
         case .reportComment(let commentID, _):
-            return "/api/v4/comments/\(commentID)/report"
+            return "/comments/\(commentID)/report"
         }
     }
 

--- a/Projects/Core/LivithNetwork/Sources/Endpoint/ConcertEndpoint.swift
+++ b/Projects/Core/LivithNetwork/Sources/Endpoint/ConcertEndpoint.swift
@@ -25,21 +25,21 @@ extension ConcertEndpoint: NetworkEndpoint {
     public var path: String? {
         switch self {
         case .fetchConcertInfo(let concertID):
-            return "/api/v4/concerts/\(concertID)"
+            return "/concerts/\(concertID)"
         case .fetchConcertSchedule(let concertID):
-            return "/api/v4/concerts/\(concertID)/schedule"
+            return "/concerts/\(concertID)/schedule"
         case .fetchConcertCultureList(let concertID):
-            return "/api/v4/concerts/\(concertID)/cultures"
+            return "/concerts/\(concertID)/cultures"
         case .fetchConcertInfoList(let concertID):
-            return "/api/v4/concerts/\(concertID)/info"
+            return "/concerts/\(concertID)/info"
         case .fetchConcertMerchandiseList(let concertID):
-            return "/api/v4/concerts/\(concertID)/mds"
+            return "/concerts/\(concertID)/mds"
         case .fetchConcertSetlistList(let concertID):
-            return "/api/v4/concerts/\(concertID)/setlists"
+            return "/concerts/\(concertID)/setlists"
         case .fetchConcertArtistInfo(let concertID):
-            return "/api/v4/concerts/\(concertID)/artist"
+            return "/concerts/\(concertID)/artist"
         case .setInterestConcert:
-            return "/api/v4/users/interest-concert"
+            return "/users/interest-concert"
         }
     }
 

--- a/Projects/Core/LivithNetwork/Sources/Endpoint/HomeEndpoint.swift
+++ b/Projects/Core/LivithNetwork/Sources/Endpoint/HomeEndpoint.swift
@@ -21,13 +21,13 @@ extension HomeEndpoint: NetworkEndpoint {
     public var path: String? {
         switch self {
         case .fetchSectionList:
-            return "/api/v4/home/sections"
+            return "/home/sections"
         case .fetchInterestedConcert:
-            return "/api/v4/users/interest-concert"
+            return "/users/interest-concert"
         case .updateInterestedConcert:
-            return "/api/v4/users/interest-concert"
+            return "/users/interest-concert"
         case .deleteInterestedConcert:
-            return "/api/v4/users/interest-concert"
+            return "/users/interest-concert"
         }
     }
     

--- a/Projects/Core/LivithNetwork/Sources/Endpoint/OnboardingEndpoint.swift
+++ b/Projects/Core/LivithNetwork/Sources/Endpoint/OnboardingEndpoint.swift
@@ -22,15 +22,15 @@ extension OnboardingEndpoint: NetworkEndpoint {
     public var path: String? {
         switch self {
         case .appleLogin:
-            return "/api/v4/auth/apple/mobile"
+            return "/auth/apple/mobile"
         case .kakaoLogin:
-            return "/api/v4/auth/kakao/mobile"
+            return "/auth/kakao/mobile"
         case .signup:
-            return "/api/v4/auth/signup"
+            return "/auth/signup"
         case .checkNicknameDuplicate:
-            return "/api/v4/users/check-nickname"
+            return "/users/check-nickname"
         case .fetchUserInfo:
-            return "/api/v4/users/me"
+            return "/users/me"
         }
     }
     

--- a/Projects/Core/LivithNetwork/Sources/Endpoint/SearchEndpoint.swift
+++ b/Projects/Core/LivithNetwork/Sources/Endpoint/SearchEndpoint.swift
@@ -32,15 +32,15 @@ extension SearchEndpoint: NetworkEndpoint {
     public var path: String? {
         switch self {
         case .fetchSections:
-            return "/api/v4/search/sections"
+            return "/search/sections"
         case .fetchBanners:
-            return "/api/v4/search/banners"
+            return "/search/banners"
         case .fetchFilterSearchResult:
-            return "/api/v4/search"
+            return "/search"
         case .fetchRecommendedSearchResult:
-            return "/api/v4/search/suggestions"
+            return "/search/suggestions"
         case .fetchConcertList:
-            return "/api/v4/concerts"
+            return "/concerts"
         }
     }
 

--- a/Projects/Core/LivithNetwork/Sources/Endpoint/SearchEndpoint.swift
+++ b/Projects/Core/LivithNetwork/Sources/Endpoint/SearchEndpoint.swift
@@ -36,7 +36,7 @@ extension SearchEndpoint: NetworkEndpoint {
         case .fetchBanners:
             return "/search/banners"
         case .fetchFilterSearchResult:
-            return "/search"
+            return "/search/concerts"
         case .fetchRecommendedSearchResult:
             return "/search/suggestions"
         case .fetchConcertList:

--- a/Projects/Core/LivithNetwork/Sources/Endpoint/SetlistEndpoint.swift
+++ b/Projects/Core/LivithNetwork/Sources/Endpoint/SetlistEndpoint.swift
@@ -21,13 +21,13 @@ extension SetlistEndpoint: NetworkEndpoint {
     public var path: String? {
         switch self {
         case .fetchConcertSetlist(let setlistID):
-            return "/api/v4/setlists/\(setlistID)"
+            return "/setlists/\(setlistID)"
         case .fetchSetlistDetail(let concertID, let setlistID):
-            return "/api/v4/concerts/\(concertID)/setlists/\(setlistID)"
+            return "/concerts/\(concertID)/setlists/\(setlistID)"
         case .fetchSetlistSongList(let setlistID):
-            return "/api/v4/setlists/\(setlistID)/songs"
+            return "/setlists/\(setlistID)/songs"
         case .fetchConcertMainSetlist(let concertID):
-            return "/api/v4/concerts/\(concertID)/main-setlist"
+            return "/concerts/\(concertID)/main-setlist"
         }
     }
 

--- a/Projects/Core/LivithNetwork/Sources/Endpoint/SongEndpoint.swift
+++ b/Projects/Core/LivithNetwork/Sources/Endpoint/SongEndpoint.swift
@@ -19,9 +19,9 @@ extension SongEndpoint: NetworkEndpoint {
     public var path: String? {
         switch self {
         case .fetchSongLyrics(let songID):
-            return "/api/v4/songs/\(songID)"
+            return "/songs/\(songID)"
         case .fetchSongFanchant(let setlistID, let songID):
-            return "/api/v4/setlists/\(setlistID)/songs/\(songID)/fanchant"
+            return "/setlists/\(setlistID)/songs/\(songID)/fanchant"
         }
     }
 

--- a/Projects/Core/LivithNetwork/Sources/Endpoint/UserEndpoint.swift
+++ b/Projects/Core/LivithNetwork/Sources/Endpoint/UserEndpoint.swift
@@ -23,13 +23,13 @@ extension UserEndpoint: NetworkEndpoint {
     public var path: String? {
         switch self {
         case .logout:
-            return "/api/v4/auth/logout"
+            return "/auth/logout"
         case .checkNicknameDuplicate:
-            return "/api/v4/users/check-nickname"
+            return "/users/check-nickname"
         case .updateUserNickname:
-            return "/api/v4/users/nickname"
+            return "/users/nickname"
         case .withdraw:
-            return "/api/v4/auth/withdraw"
+            return "/auth/withdraw"
         }
     }
     

--- a/Projects/Core/LivithNetwork/Sources/Foundation/Extension/Bundle+.swift
+++ b/Projects/Core/LivithNetwork/Sources/Foundation/Extension/Bundle+.swift
@@ -9,11 +9,19 @@
 import Foundation
 
 public extension Bundle {
+    static let apiVersion: String = {
+        #if DEBUG
+        return "v5"
+        #else
+        return "v4"
+        #endif
+    }()
+
     static let baseURL: URL = {
-        guard let url = URL(string: baseURLString) else {
+        guard let url = URL(string: "\(baseURLString)/api/\(apiVersion)") else {
             fatalError("BASE_URL에서 추출한 문자열을 URL로 변환할 수 없습니다.")
         }
-        
+
         return url
     }()
 }

--- a/Projects/DesignSystem/Sources/Components/Modal/LivithDangerModal.swift
+++ b/Projects/DesignSystem/Sources/Components/Modal/LivithDangerModal.swift
@@ -69,16 +69,6 @@ public struct LivithDangerModal: View {
     public var body: some View {
         GeometryReader { geometry in
             ZStack {
-                Color(hex: "14171B", opacity: 0.9)
-                    .ignoresSafeArea()
-                    .onTapGesture {
-                        if isReportType {
-                            isFocused = false
-                        } else {
-                            onCancel()
-                        }
-                    }
-
                 dialogContent
                     .padding(.horizontal, 24)
                     .offset(y: isReportType && keyboardHeight > 0 ? -(keyboardHeight / 2) : 0)
@@ -92,6 +82,7 @@ public struct LivithDangerModal: View {
                         )
                 }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
         }
         .ignoresSafeArea(.keyboard)
         .onAppear {
@@ -166,7 +157,7 @@ private extension LivithDangerModal {
     }
 
     var confirmButton: some View {
-        LivithButton(confirmTitle, variant: .pink, cornerRadius: 8) {
+        DangerModalButton(title: confirmTitle, role: .confirm, cornerRadius: 8) {
             switch type {
             case .confirm(let onConfirm):
                 onConfirm()
@@ -178,30 +169,123 @@ private extension LivithDangerModal {
     }
 
     var cancelButton: some View {
-        LivithButton(cancelTitle, variant: .primary, cornerRadius: 8) {
+        DangerModalButton(title: cancelTitle, role: .cancel, cornerRadius: 8) {
             onCancel()
         }
     }
 }
 
-// MARK: - Preview
+// MARK: - Local Button
 
-#Preview("Confirm") {
-    LivithDangerModal(
-        message: "정말 로그아웃 하시겠어요?",
-        confirmTitle: "로그아웃 할래요",
-        cancelTitle: "취소할래요",
-        type: .confirm(onConfirm: { }),
-        onCancel: { }
-    )
+private struct DangerModalButton: View {
+    let title: String
+    let role: DangerModalButtonRole
+    let cornerRadius: CGFloat
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .notosans(.body3Semibold)
+                .foregroundStyle(role.enabledForeground)
+                .frame(maxWidth: .infinity)
+                .frame(height: 52)
+        }
+        .buttonStyle(DangerModalButtonStyle(role: role, cornerRadius: cornerRadius))
+    }
 }
 
-#Preview("Report") {
-    LivithDangerModal(
-        message: "댓글을 신고하시겠어요?",
-        confirmTitle: "신고할래요",
-        cancelTitle: "잘못 눌렀어요",
-        type: .report(onConfirm: { _ in }),
-        onCancel: { }
-    )
+private enum DangerModalButtonRole {
+    case confirm
+    case cancel
+
+    var enabledBackground: Color {
+        switch self {
+        case .confirm:
+            return .livithColor(.black5)
+        case .cancel:
+            return .livithColor(.black80)
+        }
+    }
+
+    var pressedBackground: Color {
+        switch self {
+        case .confirm:
+            return .livithColor(.black30)
+        case .cancel:
+            return .livithColor(.black50)
+        }
+    }
+
+    var enabledForeground: Color {
+        switch self {
+        case .confirm:
+            return .livithColor(.caution100)
+        case .cancel:
+            return .livithColor(.white100)
+        }
+    }
+}
+
+private struct DangerModalButtonStyle: ButtonStyle {
+    let role: DangerModalButtonRole
+    let cornerRadius: CGFloat
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .background(backgroundColor(isPressed: configuration.isPressed))
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
+    }
+
+    private func backgroundColor(isPressed: Bool) -> Color {
+        return isPressed ? role.pressedBackground : role.enabledBackground
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Danger Modals") {
+    LivithDangerModalPreviewContainer()
+}
+
+private struct LivithDangerModalPreviewContainer: View {
+    @State private var isConfirmPresented = false
+    @State private var isReportPresented = false
+
+    var body: some View {
+        ZStack {
+            Color.livithColor(.black100).ignoresSafeArea()
+
+            VStack(spacing: 16) {
+                Button("확인 모달 보기") {
+                    isConfirmPresented = true
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button("신고 모달 보기") {
+                    isReportPresented = true
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+        .crossDissolve(isPresented: $isConfirmPresented, dismissOnTapOutside: true) {
+            LivithDangerModal(
+                message: "정말 로그아웃 하시겠어요?",
+                confirmTitle: "로그아웃 할래요",
+                cancelTitle: "취소할래요",
+                type: .confirm(onConfirm: { isConfirmPresented = false }),
+                onCancel: { isConfirmPresented = false }
+            )
+        }
+        .crossDissolve(isPresented: $isReportPresented, dismissOnTapOutside: true) {
+            LivithDangerModal(
+                message: "댓글을 신고하시겠어요?",
+                confirmTitle: "신고할래요",
+                cancelTitle: "잘못 눌렀어요",
+                type: .report(onConfirm: { _ in isReportPresented = false }),
+                onCancel: { isReportPresented = false }
+            )
+        }
+    }
 }

--- a/Projects/DesignSystem/Sources/Components/Modal/LivithModal.swift
+++ b/Projects/DesignSystem/Sources/Components/Modal/LivithModal.swift
@@ -25,8 +25,6 @@ public struct LivithModal: View {
     private let confirmTitle: String
     private let onConfirm: (() -> Void)?
 
-    @State private var isVisible: Bool = false
-
     // MARK: - Initializer
 
     public init(
@@ -42,23 +40,7 @@ public struct LivithModal: View {
     // MARK: - Body
 
     public var body: some View {
-        ZStack {
-            Color.livithColor(.black100)
-                .opacity(0.9)
-                .ignoresSafeArea()
-
-            modalContent
-        }
-        .opacity(isVisible ? 1 : 0)
-        .presentationBackground(.clear)
-        .onAppear {
-            Task { @MainActor in
-                try? await Task.sleep(for: .seconds(0.4))
-                withAnimation(.easeInOut(duration: 0.3)) {
-                    isVisible = true
-                }
-            }
-        }
+        modalContent
     }
 
     private var modalContent: some View {
@@ -166,31 +148,45 @@ private extension LivithModal {
 
     var confirmButton: some View {
         LivithButton(buttonTitle, variant: buttonVariant, cornerRadius: 4) {
-            Task { @MainActor in
-                withAnimation(.easeInOut(duration: 0.3)) {
-                    isVisible = false
-                }
-
-                try? await Task.sleep(for: .seconds(0.4))
-                onConfirm?()
-            }
+            onConfirm?()
         }
     }
 }
 
 // MARK: - Preview
 
-#Preview("Welcome") {
-    LivithModal(
-        type: .welcome(nickname: "유지미"),
-        onConfirm: { }
-    )
+private struct LivithModalPreviewContainer: View {
+    @State private var isWelcomePresented = false
+    @State private var isErrorPresented = false
+    
+    var body: some View {
+        ZStack {
+            VStack(spacing: 20) {
+                Button("Welcome Modal 보기") {
+                    isWelcomePresented = true
+                }
+                
+                Button("Error Modal 보기") {
+                    isErrorPresented = true
+                }
+            }
+        }
+        .crossDissolve(isPresented: $isWelcomePresented, dismissOnTapOutside: true) {
+            LivithModal(
+                type: .welcome(nickname: "유지미"),
+                onConfirm: { isWelcomePresented = false }
+            )
+        }
+        .crossDissolve(isPresented: $isErrorPresented, dismissOnTapOutside: true) {
+            LivithModal(
+                type: .error(title: "탈퇴 후 7일이 지나지 않았어요", message: "7일이 지난 후 다시 시도해주세요"),
+                confirmTitle: "로그인으로 돌아가기",
+                onConfirm: { isErrorPresented = false }
+            )
+        }
+    }
 }
 
-#Preview("Error") {
-    LivithModal(
-        type: .error(title: "탈퇴 후 7일이 지나지 않았어요", message: "7일이 지난 후 다시 시도해주세요"),
-        confirmTitle: "로그인으로 돌아가기",
-        onConfirm: { }
-    )
+#Preview("Modal Examples") {
+    LivithModalPreviewContainer()
 }

--- a/Projects/DesignSystem/Sources/Modifiers/BottomSheetModifier.swift
+++ b/Projects/DesignSystem/Sources/Modifiers/BottomSheetModifier.swift
@@ -1,0 +1,380 @@
+//
+//  BottomSheetModifier.swift
+//  LivithDesignSystem
+//
+//  Created by Livith on 2026/01/24.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import SwiftUI
+
+// MARK: - Handle Style
+
+public enum HandleStyle {
+    case dark
+    case light
+    
+    var color: Color {
+        switch self {
+        case .dark:
+            return Color.livithColor(.black80)
+        case .light:
+            return Color.livithColor(.white100)
+        }
+    }
+    
+    var width: CGFloat {
+        switch self {
+        case .dark:
+            return 60
+        case .light:
+            return 132
+        }
+    }
+}
+
+/// 하단에서 올라오는 BottomSheet를 구현하는 ViewModifier입니다.
+/// `fullScreenCover`를 기반으로 하여 콘텐츠를 상단만 둥글게 처리하고,
+/// 슬라이드 애니메이션으로 표시/숨김 처리합니다.
+public struct BottomSheetModifier<SheetContent: View>: ViewModifier {
+    
+    // MARK: - Properties
+    
+    @Binding private var isPresented: Bool
+    private let dismissOnTapOutside: Bool
+    private let contentBackground: Color
+    private let handleStyle: HandleStyle
+    private let sheetContent: () -> SheetContent
+    
+    @State private var internalPresented: Bool = false
+    
+    // MARK: - Initializer
+    
+    public init(
+        isPresented: Binding<Bool>,
+        dismissOnTapOutside: Bool,
+        contentBackground: Color,
+        handleStyle: HandleStyle,
+        sheetContent: @escaping () -> SheetContent
+    ) {
+        self._isPresented = isPresented
+        self.dismissOnTapOutside = dismissOnTapOutside
+        self.contentBackground = contentBackground
+        self.handleStyle = handleStyle
+        self.sheetContent = sheetContent
+    }
+    
+    // MARK: - Body
+    
+    public func body(content: Content) -> some View {
+        content
+            .fullScreenCover(isPresented: $internalPresented) {
+                BottomSheetContainerView(
+                    isPresented: $isPresented,
+                    dismissOnTapOutside: dismissOnTapOutside,
+                    handleStyle: handleStyle,
+                    contentBackground: contentBackground,
+                    content: sheetContent
+                )
+                .presentationBackground(.clear)
+            }
+            .transaction { $0.disablesAnimations = true }
+            .onChange(of: isPresented) { _, newValue in
+                if newValue {
+                    internalPresented = true
+                }
+            }
+            .onChange(of: internalPresented) { _, newValue in
+                if !newValue {
+                    isPresented = false
+                }
+            }
+    }
+}
+
+// MARK: - BottomSheetContainerView
+
+private struct BottomSheetContainerView<Content: View>: View {
+    
+    // MARK: - Properties
+    
+    @Binding var isPresented: Bool
+    let dismissOnTapOutside: Bool
+    let handleStyle: HandleStyle
+    let contentBackground: Color
+    let content: () -> Content
+    
+    @State private var sheetOffset: CGFloat = UIScreen.main.bounds.height
+    @State private var dimOpacityValue: Double = 0
+    @Environment(\.dismiss) private var dismiss
+    
+    // MARK: - Body
+    
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            Color(hex: "14171B", opacity: 0.9 * dimOpacityValue)
+                .ignoresSafeArea()
+                .onTapGesture {
+                    if dismissOnTapOutside {
+                        dismissWithAnimation()
+                    }
+                }
+            
+            VStack(spacing: 0) {
+                handleBar
+                    .padding(.top, 10)
+                
+                content()
+                    .frame(maxWidth: .infinity)
+            }
+            .background(contentBackground)
+            .clipShape(
+                UnevenRoundedRectangle(
+                    topLeadingRadius: 20,
+                    topTrailingRadius: 20
+                )
+            )
+            .offset(y: sheetOffset)
+            .padding(.horizontal, 4)
+        }
+        .ignoresSafeArea(edges: .bottom)
+        .onAppear {
+            sheetOffset = UIScreen.main.bounds.height
+            dimOpacityValue = 0
+            withAnimation(.easeInOut(duration: 0.3)) {
+                sheetOffset = 0
+                dimOpacityValue = 1
+            }
+        }
+        .onChange(of: isPresented) { _, newValue in
+            if !newValue {
+                dismissWithAnimation()
+            }
+        }
+    }
+    
+    var handleBar: some View {
+        RoundedRectangle(cornerRadius: 3)
+            .fill(handleStyle.color)
+            .frame(width: handleStyle.width, height: 6)
+    }
+    
+    // MARK: - Private Methods
+    
+    private func dismissWithAnimation() {
+        withAnimation(.easeInOut(duration: 0.3)) {
+            sheetOffset = UIScreen.main.bounds.height
+            dimOpacityValue = 0
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            dismiss()
+        }
+    }
+}
+
+// MARK: - View Extension
+
+public extension View {
+    
+    /// 하단에서 올라오는 BottomSheet를 표시합니다.
+    ///
+    /// - Parameters:
+    ///   - isPresented: 바텀시트 표시 여부를 제어하는 바인딩
+    ///   - dismissOnTapOutside: 배경 탭 시 dismiss 여부 (기본값: `true`)
+    ///   - contentBackground: 바텀시트 배경색 (기본값: `black90`)
+    ///   - handleStyle: 상단 핸들 스타일 (기본값: `.dark`)
+    ///   - content: 표시할 바텀시트 콘텐츠
+    /// - Returns: BottomSheet 효과가 적용된 뷰
+    func bottomSheet<Content: View>(
+        isPresented: Binding<Bool>,
+        dismissOnTapOutside: Bool = true,
+        contentBackground: Color = .livithColor(.black90),
+        handleStyle: HandleStyle = .dark,
+        @ViewBuilder content: @escaping () -> Content
+    ) -> some View {
+        modifier(BottomSheetModifier(
+            isPresented: isPresented,
+            dismissOnTapOutside: dismissOnTapOutside,
+            contentBackground: contentBackground,
+            handleStyle: handleStyle,
+            sheetContent: content
+        ))
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+private struct DemoBottomSheetView: View {
+    @Binding var isPresented: Bool
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            HStack {
+                Text("바텀시트")
+                    .font(.headline)
+                    .fontWeight(.bold)
+                    .foregroundStyle(Color.black)
+                
+                Spacer()
+                
+                Button {
+                    isPresented = false
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.headline)
+                        .foregroundStyle(Color.black)
+                }
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 24)
+            
+            VStack(spacing: 12) {
+                Text("배경을 탭하면 닫힙니다")
+                    .font(.body)
+                    .foregroundStyle(Color.gray)
+                
+                Text("또는 닫기 버튼을 누르세요")
+                    .font(.caption)
+                    .foregroundStyle(Color.gray)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 20)
+            .background(Color.white.opacity(0.5))
+            .cornerRadius(12)
+            .padding(.horizontal, 24)
+            
+            Divider()
+                .padding(.horizontal, 24)
+                .padding(.vertical, 12)
+            
+            ScrollView {
+                VStack(spacing: 16) {
+                    ForEach(0..<5) { index in
+                        VStack(spacing: 8) {
+                            Text("아이템 \(index + 1)")
+                                .font(.headline)
+                                .foregroundStyle(Color.black)
+                            
+                            Text("바텀시트의 콘텐츠입니다")
+                                .font(.caption)
+                                .foregroundStyle(Color.gray)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(16)
+                        .background(Color.gray.opacity(0.1))
+                        .cornerRadius(8)
+                    }
+                }
+                .padding(.horizontal, 24)
+            }
+            
+            Button {
+                isPresented = false
+            } label: {
+                Text("닫기")
+                    .font(.subheadline)
+                    .fontWeight(.bold)
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.blue)
+                    .cornerRadius(8)
+            }
+            .padding(.horizontal, 24)
+            .padding(.bottom, 24)
+        }
+    }
+}
+
+private struct DemoSmallBottomSheetView: View {
+    @Binding var isPresented: Bool
+    
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("작은 바텀시트")
+                .font(.headline)
+                .fontWeight(.bold)
+                .foregroundStyle(Color.black)
+            
+            Text("크기와 관계없이 정상 작동합니다")
+                .font(.body)
+                .foregroundStyle(Color.gray)
+            
+            Button {
+                isPresented = false
+            } label: {
+                Text("닫기")
+                    .font(.subheadline)
+                    .fontWeight(.bold)
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.green)
+                    .cornerRadius(8)
+            }
+        }
+        .padding(24)
+    }
+}
+
+struct BottomSheetPreviewView: View {
+    @State private var isPresented = false
+    @State private var isSmallPresented = false
+    
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            // Main Content
+            VStack {
+                Spacer()
+                
+                VStack(spacing: 20) {
+                    Button("큰 바텀시트 열기") {
+                        isPresented = true
+                    }
+                    .buttonStyle(.borderedProminent)
+                    
+                    Button("작은 바텀시트 열기") {
+                        isSmallPresented = true
+                    }
+                    .buttonStyle(.bordered)
+                }
+                
+                Spacer()
+            }
+            .frame(maxWidth: .infinity)
+            
+            // Fake TabBar
+            VStack(spacing: 0) {
+                Divider()
+                HStack {
+                    ForEach(0..<4) { index in
+                        VStack(spacing: 4) {
+                            Image(systemName: index == 0 ? "house.fill" : "circle")
+                                .font(.system(size: 24))
+                            Text("Tab \(index + 1)")
+                                .font(.caption)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .foregroundStyle(index == 0 ? Color.blue : Color.gray)
+                    }
+                }
+                .padding(.top, 10)
+                .padding(.bottom, 34) // Safe Area
+                .background(Color.white)
+            }
+        }
+        .edgesIgnoringSafeArea(.bottom)
+        .bottomSheet(isPresented: $isPresented, dismissOnTapOutside: true) {
+            DemoBottomSheetView(isPresented: $isPresented)
+        }
+        .bottomSheet(isPresented: $isSmallPresented, dismissOnTapOutside: true) {
+            DemoSmallBottomSheetView(isPresented: $isSmallPresented)
+        }
+    }
+}
+
+#Preview {
+    BottomSheetPreviewView()
+}
+#endif

--- a/Projects/HomeFeature/Sources/Home/View/HomeInterestConcertView.swift
+++ b/Projects/HomeFeature/Sources/Home/View/HomeInterestConcertView.swift
@@ -30,11 +30,8 @@ struct HomeInterestConcertView: View {
         ZStack(alignment: .bottom) {
             mainContent
                 .background(.livithColor(.black100))
-            
-            customBottomSheet
-                .ignoresSafeArea()
         }
-        .crossDissolve(isPresented: $showDeleteDialog, dismissOnTapOutside: false) {
+        .crossDissolve(isPresented: $showDeleteDialog) {
             LivithDangerModal(
                 message: "관심 콘서트를 삭제하시나요?\n언제든 다시 지정할 수 있어요.",
                 confirmTitle: "지금은 삭제할래요",
@@ -44,6 +41,12 @@ struct HomeInterestConcertView: View {
                     showDeleteDialog = false
                     isTabBarHidden = false
                 }
+            )
+        }
+        .bottomSheet(isPresented: $showBottomSheet, handleStyle: .light) {
+            HomeInterestConcertBottomSheetView(
+                onChangeMainConcert: handleChangeMainConcert,
+                onDeleteConcert: handleDeleteConcert
             )
         }
     }
@@ -102,33 +105,6 @@ private extension HomeInterestConcertView {
         }
     }
     
-    var customBottomSheet: some View {
-        ZStack(alignment: .bottom) {
-            Color.black
-                .opacity(showBottomSheet ? 0.4 : 0)
-                .ignoresSafeArea()
-                .onTapGesture { showBottomSheet(flag: false) }
-                .allowsHitTesting(showBottomSheet)
-                .animation(.easeInOut(duration: 0.3), value: showBottomSheet)
-            
-            HomeInterestConcertBottomSheetView(
-                onChangeMainConcert: handleChangeMainConcert,
-                onDeleteConcert: handleDeleteConcert
-            )
-            .background(.livithColor(.black90))
-            .clipShape(
-                UnevenRoundedRectangle(
-                    topLeadingRadius: 24,
-                    bottomLeadingRadius: 0,
-                    bottomTrailingRadius: 0,
-                    topTrailingRadius: 24
-                )
-            )
-            .offset(y: showBottomSheet ? 0 : UIScreen.main.bounds.height)
-            .animation(.easeInOut(duration: 0.3), value: showBottomSheet)
-        }
-    }
-    
     var textHeaderView: some View {
         HStack(spacing: .zero) {
             Text("나의 관심 콘서트")
@@ -141,7 +117,7 @@ private extension HomeInterestConcertView {
             Spacer()
             
             LivithTextButton("수정하기") {
-                showBottomSheet(flag: true)
+                showBottomSheet = true
             }
             .padding(.top, 20)
             .padding([.bottom, .trailing], 16)
@@ -152,11 +128,6 @@ private extension HomeInterestConcertView {
 // MARK: - Helpers
 
 private extension HomeInterestConcertView {
-    func showBottomSheet(flag: Bool) {
-        self.isTabBarHidden = flag
-        self.showBottomSheet = flag
-    }
-    
     func handleMoreInfoTap() {
         guard let concertID = store.state.interestConcert?.id else { return }
         coordinator?.showConcertDetail(concertID: concertID)
@@ -174,7 +145,7 @@ private extension HomeInterestConcertView {
     }
 
     func handleChangeMainConcert() {
-        showBottomSheet(flag: false)
+        showBottomSheet = false
         coordinator?.push(to: .interest)
     }
     

--- a/Projects/HomeFeature/Sources/Home/View/HomeInterestConcertView.swift
+++ b/Projects/HomeFeature/Sources/Home/View/HomeInterestConcertView.swift
@@ -33,10 +33,19 @@ struct HomeInterestConcertView: View {
             
             customBottomSheet
                 .ignoresSafeArea()
-            
-            deleteDialog
         }
-        .animation(.easeInOut, value: showDeleteDialog)
+        .crossDissolve(isPresented: $showDeleteDialog, dismissOnTapOutside: false) {
+            LivithDangerModal(
+                message: "관심 콘서트를 삭제하시나요?\n언제든 다시 지정할 수 있어요.",
+                confirmTitle: "지금은 삭제할래요",
+                cancelTitle: "잘못 눌렀어요",
+                type: .confirm(onConfirm: handleDeleteConfirm),
+                onCancel: {
+                    showDeleteDialog = false
+                    isTabBarHidden = false
+                }
+            )
+        }
     }
 }
 
@@ -117,24 +126,6 @@ private extension HomeInterestConcertView {
             )
             .offset(y: showBottomSheet ? 0 : UIScreen.main.bounds.height)
             .animation(.easeInOut(duration: 0.3), value: showBottomSheet)
-        }
-    }
-    
-    var deleteDialog: some View {
-        Group {
-            if showDeleteDialog {
-                LivithDangerModal(
-                    message: "관심 콘서트를 삭제하시나요?\n언제든 다시 지정할 수 있어요.",
-                    confirmTitle: "지금은 삭제할래요",
-                    cancelTitle: "잘못 눌렀어요",
-                    type: .confirm(onConfirm: handleDeleteConfirm),
-                    onCancel: {
-                        showDeleteDialog = false
-                        isTabBarHidden = false
-                    }
-                )
-                .transition(.opacity)
-            }
         }
     }
     

--- a/Projects/HomeFeature/Sources/Home/View/Subview/HomeInterestConcertBottomSheetView.swift
+++ b/Projects/HomeFeature/Sources/Home/View/Subview/HomeInterestConcertBottomSheetView.swift
@@ -14,26 +14,24 @@ struct HomeInterestConcertBottomSheetView: View {
     let onChangeMainConcert: () -> Void
     let onDeleteConcert: () -> Void
     
-    var body: some View {
-        LivithBottomSheet(handleStyle: .light, handleWidth: 132) {
-            VStack(alignment: .leading, spacing: 12) {
-                actionButton(
-                    icon: .livithIcon(.change),
-                    title: "메인 콘서트 바꾸기",
-                    action: onChangeMainConcert
-                )
-                
-                actionButton(
-                    icon: .livithIcon(.trash),
-                    title: "콘서트 삭제하기",
-                    action: onDeleteConcert,
-                    isDestructive: true
-                )
-            }
-            .padding(.top, 24)
-            .padding(.horizontal, 12)
-            .padding(.bottom, 32)
+    var body: some View {       
+        VStack(alignment: .leading, spacing: 12) {
+            actionButton(
+                icon: .livithIcon(.change),
+                title: "메인 콘서트 바꾸기",
+                action: onChangeMainConcert
+            )
+            
+            actionButton(
+                icon: .livithIcon(.trash),
+                title: "콘서트 삭제하기",
+                action: onDeleteConcert,
+                isDestructive: true
+            )
         }
+        .padding(.top, 28)
+        .padding(.horizontal, 12)
+        .padding(.bottom, 32)
     }
 }
 

--- a/Projects/LoginFeature/Sources/Coordinator/LoginCoordinator.swift
+++ b/Projects/LoginFeature/Sources/Coordinator/LoginCoordinator.swift
@@ -43,19 +43,6 @@ final class LoginCoordinator: Coordinator {
         case .login:
             return UIHostingController(rootView: LoginView().environment(\.loginCoordinator, self))
             
-        case .loginForbidden:
-            let vc = UIHostingController(
-                rootView: LivithModal(
-                    type: .error(title: "탈퇴 후 7일이 지나지 않았어요", message: "7일이 지난 후 다시 시도해주세요"),
-                    confirmTitle: "로그인으로 돌아가기",
-                    onConfirm: { [weak self] in
-                        self?.dismiss()
-                    }
-                )
-            )
-            vc.view.backgroundColor = .clear
-            return vc
-            
         case .terms(let tempUser):
             self.tempUser = tempUser
             return UIHostingController(rootView: TermsView().environment(\.loginCoordinator, self))

--- a/Projects/LoginFeature/Sources/Coordinator/LoginCoordinator.swift
+++ b/Projects/LoginFeature/Sources/Coordinator/LoginCoordinator.swift
@@ -60,19 +60,6 @@ final class LoginCoordinator: Coordinator {
                 .environment(\.loginCoordinator, self)
             )
             
-        case .signupFailed:
-            let vc = UIHostingController(
-                rootView: LivithModal(
-                    type: .error(title: "오류가 발생했어요!", message: "잠시 후 다시 시도해주세요"),
-                    confirmTitle: "로그인으로 돌아가기",
-                    onConfirm: { [weak self] in
-                        self?.dismiss(completion: { self?.popToRoot() })
-                    }
-                )
-            )
-            vc.view.backgroundColor = .clear
-            return vc
-            
         case .safari(let url):
             let safariView = SafariView(url: url) { [weak self] in
                 self?.dismiss()

--- a/Projects/LoginFeature/Sources/Coordinator/LoginRoute.swift
+++ b/Projects/LoginFeature/Sources/Coordinator/LoginRoute.swift
@@ -16,6 +16,5 @@ enum LoginRoute: Route {
     case login
     case terms(TempUser)
     case nickname(Bool)
-    case signupFailed
     case safari(URL)
 }

--- a/Projects/LoginFeature/Sources/Coordinator/LoginRoute.swift
+++ b/Projects/LoginFeature/Sources/Coordinator/LoginRoute.swift
@@ -14,7 +14,6 @@ import Domain
 
 enum LoginRoute: Route {
     case login
-    case loginForbidden
     case terms(TempUser)
     case nickname(Bool)
     case signupFailed

--- a/Projects/LoginFeature/Sources/Login/View/LoginView.swift
+++ b/Projects/LoginFeature/Sources/Login/View/LoginView.swift
@@ -15,6 +15,8 @@ struct LoginView: View {
     @StateObject private var store = LoginStore()
     @Environment(\.loginCoordinator) private var coordinator
     
+    @State private var isForbiddenModalPresented = false
+    
     var body: some View {
         ZStack {
             Color.livithColor(.black100)
@@ -38,6 +40,18 @@ struct LoginView: View {
             duration: 2,
             position: .safeAreaTop
         )
+        .crossDissolve(isPresented: $isForbiddenModalPresented, dismissOnTapOutside: false) {
+            LivithModal(
+                type: .error(
+                    title: "탈퇴 후 7일이 지나지 않았어요",
+                    message: "7일이 지난 후 다시 시도해주세요"
+                ),
+                confirmTitle: "로그인으로 돌아가기",
+                onConfirm: {
+                    isForbiddenModalPresented = false
+                }
+            )
+        }
         .onChange(of: store.state.status) { oldValue, newValue in
             guard let loginStatus = newValue else { return }
             handleLoginSuccess(loginStatus)
@@ -51,8 +65,7 @@ struct LoginView: View {
         case .newUser(let tempUser):
             coordinator?.push(to: .terms(tempUser))
         case .forbidden:
-            coordinator?
-                .present(to: .loginForbidden, presentationStyle: .overFullScreen, transitionStyle: .crossDissolve)
+            isForbiddenModalPresented = true
         }
     }
 }

--- a/Projects/LoginFeature/Sources/Onboarding/View/NicknameSettingView.swift
+++ b/Projects/LoginFeature/Sources/Onboarding/View/NicknameSettingView.swift
@@ -27,6 +27,7 @@ struct NicknameSettingView: View {
     }
 
     var body: some View {
+        // TODO: - 회원가입 API 연결 취향 설정 이후로 빼기
         NicknameEditView(
             config: .signup(marketingConsent: marketingConsent, tempUser: tempUser),
             onDismiss: { coordinator?.pop() },

--- a/Projects/LoginFeature/Sources/Onboarding/View/NicknameSettingView.swift
+++ b/Projects/LoginFeature/Sources/Onboarding/View/NicknameSettingView.swift
@@ -15,8 +15,8 @@ import NicknameEditFeature
 struct NicknameSettingView: View {
     @Environment(\.loginCoordinator) private var coordinator
 
-    @State private var showErrorToast: Bool = false
-    @State private var errorMessage: String = ""
+    @State private var isSignupFailureModalPresented: Bool = false
+    @State private var signupFailureMessage: String = ""
 
     private let marketingConsent: Bool
     private let tempUser: TempUser
@@ -34,16 +34,22 @@ struct NicknameSettingView: View {
                 coordinator?.completeSignup(with: nickname)
             },
             onSubmitFailure: { message in
-                errorMessage = message
-                withAnimation { showErrorToast = true }
+                signupFailureMessage = message
+                isSignupFailureModalPresented = true
             }
         )
-        .livithToast(
-            isPresented: $showErrorToast,
-            type: .failure,
-            message: errorMessage,
-            duration: 2,
-            position: .safeAreaTop
-        )
+        .crossDissolve(isPresented: $isSignupFailureModalPresented, dismissOnTapOutside: false) {
+            LivithModal(
+                type: .error(title: "오류가 발생했어요!", message: signupFailureMessage),
+                confirmTitle: "로그인으로 돌아가기",
+                onConfirm: {
+                    isSignupFailureModalPresented = false
+                    Task { @MainActor in
+                        try? await Task.sleep(for: .seconds(0.25))
+                        coordinator?.popToRoot()
+                    }
+                }
+            )
+        }
     }
 }

--- a/Projects/SearchFeature/Sources/Search/View/SearchView.swift
+++ b/Projects/SearchFeature/Sources/Search/View/SearchView.swift
@@ -60,12 +60,11 @@ struct SearchView: View {
         .onChange(of: store.state.errorMessage) { _, newValue in
             showError = !newValue.isEmpty
         }
-        .overlay {
-            if showError {
-                LivithModal(
-                    type: .error(title: "오류가 발생했어요!", message: store.state.errorMessage)
-                )
-            }
+        .crossDissolve(isPresented: $showError, dismissOnTapOutside: true) {
+            LivithModal(
+                type: .error(title: "오류가 발생했어요!", message: store.state.errorMessage),
+                onConfirm: { showError = false }
+            )
         }
         .overlay {
             customFilterSheet

--- a/Projects/UserFeature/Sources/View/UserView.swift
+++ b/Projects/UserFeature/Sources/View/UserView.swift
@@ -131,10 +131,23 @@ public struct UserView: View {
                     .ignoresSafeArea(edges: .bottom)
             }
         }
-        .overlay {
-            logoutConfirmDialog
+        .crossDissolve(isPresented: Binding(
+            get: { overlayType == .logout },
+            set: { if !$0 { overlayType = .none } }
+        ), dismissOnTapOutside: false) {
+            LivithDangerModal(
+                message: Literals.logoutAlertMessage,
+                confirmTitle: Literals.logoutAlertConfirm,
+                cancelTitle: Literals.logoutAlertCancel,
+                type: .confirm(onConfirm: {
+                    overlayType = .none
+                    performLogout()
+                }),
+                onCancel: {
+                    overlayType = .none
+                }
+            )
         }
-        .animation(.easeInOut(duration: 0.3), value: overlayType)
         .onChange(of: path) { _, newPath in
             Task { @MainActor in
                 isTabBarHidden = !newPath.isEmpty
@@ -208,24 +221,6 @@ private extension UserView {
             Image.livithImage(.feedback)
                 .resizable()
                 .scaledToFill()
-        }
-    }
-
-    @ViewBuilder
-    var logoutConfirmDialog: some View {
-        if overlayType == .logout {
-            LivithDangerModal(
-                message: Literals.logoutAlertMessage,
-                confirmTitle: Literals.logoutAlertConfirm,
-                cancelTitle: Literals.logoutAlertCancel,
-                type: .confirm(onConfirm: {
-                    overlayType = .none
-                    performLogout()
-                }),
-                onCancel: {
-                    overlayType = .none
-                }
-            )
         }
     }
 }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

Note: 하단 PR 머지되면 확인 부탁드립니닷.

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- API 버전(`/api/v4`)을 BaseURL에 포함시켜 엔드포인트 코드 중복을 제거하고 개발 서버(v5)와 배포 서버(v4) 버전을 분기 처리했어요.
- 필터에 따른 검색 결과 콘서트 목록 조회 API의 엔드포인트를 수정했어요.

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### BaseURL에 API 버전 경로 통합
- 서버 버전이 변동되어 명세를 업데이트하는 과정에서 기존 버전 URI가 각 엔드포인트에 나위어있어 버전 수정 시 모든 엔드포인트를 수정해야 하는 이슈가 있었습니다.
- config 파일에 버전 정보를 포함시키는 방법도 있지만, 이는 모든 팀원이 각자의 config 파일을 변경해야 하므로 최대한 수정이 없는 선에서 서비스 내에서 하나의 엔트리만 변경하면 다른 API도 전부 변경되도록 설정했어요.

```swift
// Bundle+.swift
public extension Bundle {
    static let apiVersion: String = {
        #if DEBUG
        return "v5"
        #else
        return "v4"
        #endif
    }()

    static let baseURL: URL = {
        guard let url = URL(string: "\(baseURLString)/api/\(apiVersion)") else {
            fatalError("BASE_URL에서 추출한 문자열을 URL로 변환할 수 없습니다.")
        }
        return url
    }()
}
```

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 회원가입 API 호출 시점이 서버 명세에서 변경된 것 같은데, 새 기능 개발 후 변경해야 할 것 같아 TODO 주석만 남겨두었습니다. 이후 확인하시고 삭제 부탁드려요~~

## 🔗 연결된 이슈
- Resolved: #174 
