### PR TITLE
[Refactor] 윈도우 기반 토스트 및 앱 진입점 로직 간소화

### DIFF
--- a/Projects/App/Sources/View/AppRootView.swift
+++ b/Projects/App/Sources/View/AppRootView.swift
@@ -67,9 +67,10 @@ private extension AppRootView {
         } catch {
             targetRoute = .login
         }
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
-            transition(to: targetRoute)
+
+        Task {
+            try? await Task.sleep(nanoseconds: UInt64(Constants.startupDelay * 1_000_000_000))
+            await MainActor.run { transition(to: targetRoute) }
         }
     }
     
@@ -85,5 +86,6 @@ private extension AppRootView {
 private extension AppRootView {
     enum Constants {
         static let animationDuration = 0.5
+        static let startupDelay: TimeInterval = 3.0
     }
 }

--- a/Projects/App/Sources/View/AppRootView.swift
+++ b/Projects/App/Sources/View/AppRootView.swift
@@ -18,8 +18,6 @@ struct AppRootView: View {
     @State private var isLaunchScreenVisible: Bool = true
     @State private var nickname: String = ""
     @State private var isWelcomeSheetVisible: Bool = false
-    @State private var showToast: Bool = false
-    @State private var toastMessage: String = ""
 
     private let localStorage: UserDefaultsStorage
     
@@ -43,17 +41,8 @@ struct AppRootView: View {
             )
         }
         .onReceive(NotificationCenter.default.publisher(for: Notification.Name.reloginRequired)) { notification in
-            if let message = notification.userInfo?["toastMessage"] as? String {
-                toastMessage = message
-                transition(to: .login)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    showToast = true
-                }
-            } else {
-                transition(to: .login)
-            }
+            transition(to: .login)
         }
-        .livithToast(isPresented: $showToast, type: .success, message: toastMessage, position: .safeAreaTop)
         .onAppear {
             handleOnAppear()
         }

--- a/Projects/App/Sources/View/AppRootView.swift
+++ b/Projects/App/Sources/View/AppRootView.swift
@@ -9,43 +9,29 @@
 import SwiftUI
 
 import LivithDesignSystem
-import LivithNetwork
+import Domain
 import LoginFeature
 import Persistence
 
 struct AppRootView: View {
-    @State private var currentRoute: AppRoute?
-    @State private var isLaunchScreenVisible: Bool = true
+    @State private var currentRoute: AppRoute = .launch
     @State private var nickname: String = ""
-    @State private var isWelcomeSheetVisible: Bool = false
-
-    private let localStorage: UserDefaultsStorage
-    
-    init(localStorage: UserDefaultsStorage = .init()) {
-        self.localStorage = localStorage
-    }
+    @State private var showWelcomeSheet: Bool = false
     
     var body: some View {
-        ZStack {
-            contentView()
-            splashOverlay()
-        }
-        .animation(.easeInOut(duration: Constants.animationDuration), value: isLaunchScreenVisible)
-        .animation(.easeInOut(duration: Constants.animationDuration), value: currentRoute)
-        .crossDissolve(isPresented: $isWelcomeSheetVisible, dismissOnTapOutside: false) {
-            LivithModal(
-                type: .welcome(nickname: nickname),
-                onConfirm: {
-                    isWelcomeSheetVisible = false
-                }
-            )
-        }
-        .onReceive(NotificationCenter.default.publisher(for: Notification.Name.reloginRequired)) { notification in
-            transition(to: .login)
-        }
-        .onAppear {
-            handleOnAppear()
-        }
+        contentView
+            .crossDissolve(isPresented: $showWelcomeSheet, dismissOnTapOutside: false) {
+                LivithModal(
+                    type: .welcome(nickname: nickname),
+                    onConfirm: { showWelcomeSheet = false }
+                )
+            }
+            .onReceive(NotificationCenter.default.publisher(for: Notification.Name.reloginRequired)) { notification in
+                transition(to: .login)
+            }
+            .onAppear {
+                handleOnAppear()
+            }
     }
 }
 
@@ -53,73 +39,43 @@ struct AppRootView: View {
 
 private extension AppRootView {
     @ViewBuilder
-    func contentView() -> some View {
-        if let route = currentRoute {
-            switch route {
-            case .login:
-                LoginContentView(
-                    onLoginCompleted: { nickname in
-                        handleLoginCompleted(nickname: nickname)
-                    },
-                    onSignupCompleted: { nickname in
-                        handleSignupCompleted(nickname: nickname)
-                    }
-                )
-
-            case .main:
-                LivithMainTabView(nickname: $nickname)
-            }
-        } else {
-            Color.clear
-        }
-    }
-    
-    @ViewBuilder
-    func splashOverlay() -> some View {
-        if isLaunchScreenVisible {
+    var contentView: some View {
+        switch currentRoute {
+        case .launch:
             LaunchScreenView()
-                .transition(.opacity)
-                .zIndex(1)
+        case .login:
+            LoginContentView(
+                onLoginCompleted: { transition(to: .main) },
+                onSignupCompleted: { nickname in
+                    transition(to: .main)
+                    self.nickname = nickname
+                    self.showWelcomeSheet = true
+                }
+            )
+        case .main:
+            LivithMainTabView()
         }
-    }
-
-    func handleLoginCompleted(nickname: String) {
-        transition(to: .main, nickname: nickname)
     }
     
-    func handleSignupCompleted(nickname: String) {
-        transition(to: .main, nickname: nickname, showWelcome: true)
-    }
-
     func handleOnAppear() {
-        checkInitialRoute()
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
-            withAnimation(.easeInOut(duration: Constants.animationDuration)) {
-                isLaunchScreenVisible = false
-            }
-        }
-    }
-
-    func checkInitialRoute() {
+        if currentRoute != .launch { return }
+        
+        let targetRoute: AppRoute
         do {
-            let user: DTO.Response.FetchUserInfo = try localStorage.fetch(for: .currentUser)
-            self.nickname = user.nickname
-            currentRoute = .main
+            let _: User = try UserDefaultsStorage().fetch(for: .currentUser)
+            targetRoute = .main
         } catch {
-            currentRoute = .login
+            targetRoute = .login
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+            transition(to: targetRoute)
         }
     }
-
-    func transition(to route: AppRoute, nickname: String? = nil, showWelcome: Bool = false) {
+    
+    func transition(to route: AppRoute) {
         withAnimation(.easeInOut(duration: Constants.animationDuration)) {
             currentRoute = route
-
-            if let nickname = nickname {
-                self.nickname = nickname
-            }
-
-            isWelcomeSheetVisible = showWelcome
         }
     }
 }

--- a/Projects/App/Sources/View/AppRoute.swift
+++ b/Projects/App/Sources/View/AppRoute.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 enum AppRoute {
+    case launch
     case login
     case main
 }

--- a/Projects/App/Sources/View/LivithMainTabView.swift
+++ b/Projects/App/Sources/View/LivithMainTabView.swift
@@ -26,9 +26,6 @@ struct LivithMainTabView: View {
     @Binding private var nickname: String
     @State private var selectedTab: Tab = .home
     @State private var isTabBarHidden: Bool = false
-    @State private var showToast: Bool = false
-    @State private var toastType: LivithToastType = .success
-    @State private var toastMessage: String = ""
     @State private var deepLinkConcertID: Int?
     
     // MARK: - LifeCycle
@@ -45,12 +42,7 @@ struct LivithMainTabView: View {
             HomeContentView(
                 nickname: $nickname,
                 isTabBarHidden: $isTabBarHidden,
-                deepLinkConcertID: $deepLinkConcertID,
-                showToast: { type, message in
-                    toastType = type
-                    toastMessage = message
-                    showToast = true
-                }
+                deepLinkConcertID: $deepLinkConcertID
             )
             .tag(Tab.home)
             .tabItem {
@@ -67,12 +59,7 @@ struct LivithMainTabView: View {
             
             UserView(
                 nickname: $nickname,
-                isTabBarHidden: $isTabBarHidden,
-                showToast: { type, message in
-                    toastType = type
-                    toastMessage = message
-                    showToast = true
-                }
+                isTabBarHidden: $isTabBarHidden
             )
             .tag(Tab.my)
             .tabItem {
@@ -81,12 +68,6 @@ struct LivithMainTabView: View {
             .toolbar(isTabBarHidden ? .hidden : .visible, for: .tabBar)
         }
         .preferredColorScheme(.dark)
-        .livithToast(
-            isPresented: $showToast,
-            type: toastType,
-            message: toastMessage,
-            position: .safeAreaTop
-        )
         .onReceive(NotificationCenter.default.publisher(for: .openConcertDetail)) { notification in
             if let concertID = notification.userInfo?["concertID"] as? Int {
                 selectedTab = .home

--- a/Projects/App/Sources/View/LivithMainTabView.swift
+++ b/Projects/App/Sources/View/LivithMainTabView.swift
@@ -23,15 +23,13 @@ struct LivithMainTabView: View {
     
     // MARK: - Property
     
-    @Binding private var nickname: String
     @State private var selectedTab: Tab = .home
     @State private var isTabBarHidden: Bool = false
     @State private var deepLinkConcertID: Int?
     
     // MARK: - LifeCycle
     
-    init(nickname: Binding<String>) {
-        self._nickname = nickname
+    init() {
         configureTabBarAppearance()
     }
     
@@ -40,7 +38,6 @@ struct LivithMainTabView: View {
     var body: some View {
         TabView(selection: $selectedTab) {
             HomeContentView(
-                nickname: $nickname,
                 isTabBarHidden: $isTabBarHidden,
                 deepLinkConcertID: $deepLinkConcertID
             )
@@ -57,10 +54,7 @@ struct LivithMainTabView: View {
                 }
                 .toolbar(isTabBarHidden ? .hidden : .visible, for: .tabBar)
             
-            UserView(
-                nickname: $nickname,
-                isTabBarHidden: $isTabBarHidden
-            )
+            UserView(isTabBarHidden: $isTabBarHidden)
             .tag(Tab.my)
             .tabItem {
                 makeTabItem(.my)

--- a/Projects/ConcertFeature/Sources/View/ConcertView.swift
+++ b/Projects/ConcertFeature/Sources/View/ConcertView.swift
@@ -64,22 +64,17 @@ public struct ConcertView: View {
                 set: { if !$0 { dismissCurrentToast() } }
             ),
             type: toastInfo?.type ?? .failure,
-            message: toastInfo?.message ?? "",
-            topPadding: 16
+            message: toastInfo?.message ?? ""
         )
         .livithToast(
             isPresented: $isExceedingLineLimit,
             type: .failure,
-            message: "댓글은 15줄을 초과할 수 없어요",
-            duration: nil,
-            topPadding: 16
+            message: "댓글은 15줄을 초과할 수 없어요"
         )
         .livithToast(
             isPresented: $isExceedingCharacterLimit,
             type: .failure,
-            message: "댓글은 400자를 초과할 수 없어요",
-            duration: nil,
-            topPadding: 16
+            message: "댓글은 400자를 초과할 수 없어요"
         )
         .crossDissolve(isPresented: $showInterestConfirmDialog, dismissOnTapOutside: true) {
             LivithDangerModal(

--- a/Projects/Data/UserData/Sources/Repository/UserRepositoryImpl.swift
+++ b/Projects/Data/UserData/Sources/Repository/UserRepositoryImpl.swift
@@ -81,7 +81,7 @@ struct UserRepositoryImpl: UserRepository {
             return concert
         } catch NetworkError.noData {
             return nil
-        }catch {
+        } catch {
             let userError: UserError = errorMapper.mapToUserError(error)
             throw userError
         }

--- a/Projects/DesignSystem/Sources/Components/Toast/Helper/LivithToastModifier.swift
+++ b/Projects/DesignSystem/Sources/Components/Toast/Helper/LivithToastModifier.swift
@@ -1,0 +1,76 @@
+//
+//  LivithToastModifier.swift
+//  LivithDesignSystem
+//
+//  Created by 김진웅 on 01/27/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import SwiftUI
+
+// MARK: - Toast Content
+
+struct ToastContent {
+    let type: LivithToastType
+    let message: String
+}
+
+// MARK: - Toast Configuration
+
+struct ToastConfiguration {
+    let duration: TimeInterval?
+    let topPadding: CGFloat
+    let position: LivithToastPosition
+    let keyboardSpacing: CGFloat
+    
+    static let `default` = ToastConfiguration(
+        duration: 2.0,
+        topPadding: 10,
+        position: .safeAreaTop,
+        keyboardSpacing: 16
+    )
+}
+
+// MARK: - Modifier
+
+struct LivithToastModifier: ViewModifier {
+    @Binding var isPresented: Bool
+    let type: LivithToastType
+    let message: String
+    
+    @Environment(\.self) var environment
+    @State private var windowScene: UIWindowScene?
+    
+    func body(content: Content) -> some View {
+        content
+            .background(
+                WindowSceneFinder { scene in
+                    self.windowScene = scene
+                }
+            )
+            .onChange(of: isPresented) { _, newValue in
+                handlePresentationChange(isPresented: newValue)
+            }
+    }
+    
+    private func handlePresentationChange(isPresented: Bool) {
+        guard isPresented else {
+            ToastWindowManager.shared.dismiss()
+            return
+        }
+        
+        guard let scene = windowScene else {
+            print("⚠️ UIWindowScene not found")
+            self.isPresented = false
+            return
+        }
+        
+        ToastWindowManager.shared.show(
+            scene: scene,
+            environment: environment,
+            content: ToastContent(type: type, message: message),
+            configuration: .default,
+            onDismiss: { self.isPresented = false }
+        )
+    }
+}

--- a/Projects/DesignSystem/Sources/Components/Toast/Helper/ToastContainerView.swift
+++ b/Projects/DesignSystem/Sources/Components/Toast/Helper/ToastContainerView.swift
@@ -92,6 +92,9 @@ private extension ToastContainerView {
     func dismissToast() {
         guard isVisible else { return }
         withAnimation { isVisible = false }
-        DispatchQueue.main.asyncAfter(deadline: .now() + Animation.dismissDelay) { onDismiss() }
+        Task {
+            try? await Task.sleep(nanoseconds: UInt64(Animation.dismissDelay * 1_000_000_000))
+            await MainActor.run { onDismiss() }
+        }
     }
 }

--- a/Projects/DesignSystem/Sources/Components/Toast/Helper/ToastContainerView.swift
+++ b/Projects/DesignSystem/Sources/Components/Toast/Helper/ToastContainerView.swift
@@ -1,0 +1,97 @@
+//
+//  ToastContainerView.swift
+//  LivithDesignSystem
+//
+//  Created by 김진웅 on 01/27/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import SwiftUI
+
+struct ToastContainerView: View {
+    
+    private enum Animation {
+        static let springResponse: Double = 0.4
+        static let springDamping: Double = 0.8
+        static let keyboardAnimationDuration: Double = 0.2
+        static let dismissDelay: Double = 0.4
+    }
+    
+    let content: ToastContent
+    let configuration: ToastConfiguration
+    let onDismiss: () -> Void
+    
+    @State private var isVisible = false
+    @ObservedObject private var keyboardObserver = KeyboardHeightObserver.shared
+    
+    var body: some View {
+        GeometryReader { geometry in
+            VStack(spacing: 0) {
+                topSpacer(geometry: geometry)
+                toastView
+                bottomSpacer
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .animation(.spring(response: Animation.springResponse, dampingFraction: Animation.springDamping), value: isVisible)
+            .animation(.easeOut(duration: Animation.keyboardAnimationDuration), value: keyboardObserver.height)
+        }
+        .onAppear {
+            withAnimation { isVisible = true }
+            scheduleDismissIfNeeded()
+        }
+    }
+}
+
+// MARK: - Subviews
+
+private extension ToastContainerView {
+    func topSpacer(geometry: GeometryProxy) -> some View {
+        Group {
+            switch configuration.position {
+            case .top:
+                Spacer().frame(height: geometry.safeAreaInsets.top + configuration.topPadding)
+            case .safeAreaTop:
+                Spacer().frame(height: geometry.safeAreaInsets.top)
+            case .aboveKeyboard:
+                Spacer()
+            }
+        }
+    }
+    
+    @ViewBuilder
+    var toastView: some View {
+        if isVisible {
+            LivithToast(type: content.type, message: content.message)
+                .transition(.move(edge: .top).combined(with: .opacity))
+                .onTapGesture { dismissToast() }
+        }
+    }
+    
+    @ViewBuilder
+    var bottomSpacer: some View {
+        if configuration.position == .aboveKeyboard {
+            Spacer().frame(height: keyboardObserver.height + configuration.keyboardSpacing)
+        } else {
+            Spacer()
+        }
+    }
+}
+
+// MARK: - Actions
+
+private extension ToastContainerView {
+    func scheduleDismissIfNeeded() {
+        guard let duration = configuration.duration else { return }
+        Task {
+            try? await Task.sleep(for: .seconds(duration))
+            guard !Task.isCancelled else { return }
+            await MainActor.run { dismissToast() }
+        }
+    }
+    
+    func dismissToast() {
+        guard isVisible else { return }
+        withAnimation { isVisible = false }
+        DispatchQueue.main.asyncAfter(deadline: .now() + Animation.dismissDelay) { onDismiss() }
+    }
+}

--- a/Projects/DesignSystem/Sources/Components/Toast/Helper/ToastHelperViews.swift
+++ b/Projects/DesignSystem/Sources/Components/Toast/Helper/ToastHelperViews.swift
@@ -1,0 +1,58 @@
+//
+//  ToastHelperViews.swift
+//  LivithDesignSystem
+//
+//  Created by 김진웅 on 01/27/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import SwiftUI
+import UIKit
+
+// MARK: - Window Scene Finder
+
+struct WindowSceneFinder: UIViewRepresentable {
+    var onFound: (UIWindowScene) -> Void
+    
+    func makeUIView(context: Context) -> UIView {
+        let view = WindowSceneFinderView()
+        view.onFound = onFound
+        return view
+    }
+    
+    func updateUIView(_ uiView: UIView, context: Context) {}
+    
+    private class WindowSceneFinderView: UIView {
+        var onFound: ((UIWindowScene) -> Void)?
+        
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            if let windowScene = window?.windowScene {
+                onFound?(windowScene)
+            }
+        }
+    }
+}
+
+// MARK: - Environment Passing View
+
+struct EnvPassingView<Content: View>: View {
+    let content: Content
+    let environment: EnvironmentValues
+    
+    var body: some View {
+        content
+            .transformEnvironment(\.self) { target in
+                target = environment
+            }
+    }
+}
+
+// MARK: - Passthrough Window
+
+final class PassthroughWindow: UIWindow {
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        guard let hitView = super.hitTest(point, with: event) else { return nil }
+        return hitView == rootViewController?.view ? nil : hitView
+    }
+}

--- a/Projects/DesignSystem/Sources/Components/Toast/Helper/ToastWindowManager.swift
+++ b/Projects/DesignSystem/Sources/Components/Toast/Helper/ToastWindowManager.swift
@@ -1,0 +1,59 @@
+//
+//  ToastWindowManager.swift
+//  LivithDesignSystem
+//
+//  Created by 김진웅 on 01/27/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import SwiftUI
+import UIKit
+
+@MainActor
+final class ToastWindowManager {
+    static let shared = ToastWindowManager()
+    
+    private var toastWindow: UIWindow?
+    private var hostingController: UIHostingController<AnyView>?
+    
+    private init() {}
+    
+    func show(
+        scene: UIWindowScene,
+        environment: EnvironmentValues,
+        content: ToastContent,
+        configuration: ToastConfiguration,
+        onDismiss: @escaping () -> Void
+    ) {
+        dismiss()
+        
+        let window = PassthroughWindow(windowScene: scene)
+        window.windowLevel = .alert + 1
+        window.backgroundColor = .clear
+        
+        let toastContainer = ToastContainerView(
+            content: content,
+            configuration: configuration
+        ) { [weak self] in
+            self?.dismiss()
+            onDismiss()
+        }
+        
+        let envView = EnvPassingView(content: toastContainer, environment: environment)
+        
+        let hostingController = UIHostingController(rootView: AnyView(envView))
+        hostingController.view.backgroundColor = .clear
+        
+        window.rootViewController = hostingController
+        window.isHidden = false
+        
+        self.toastWindow = window
+        self.hostingController = hostingController
+    }
+    
+    func dismiss() {
+        toastWindow?.isHidden = true
+        toastWindow = nil
+        hostingController = nil
+    }
+}

--- a/Projects/DesignSystem/Sources/Components/Toast/LivithToast.swift
+++ b/Projects/DesignSystem/Sources/Components/Toast/LivithToast.swift
@@ -8,16 +8,16 @@
 
 import SwiftUI
 
+// MARK: - Toast Type
+
 public enum LivithToastType {
     case success
     case failure
-
+    
     var icon: Image {
         switch self {
-        case .success:
-            return .livithIcon(.checkYellow)
-        case .failure:
-            return .livithIcon(.cautionTriangleSmall)
+        case .success: return .livithIcon(.checkYellow)
+        case .failure: return .livithIcon(.cautionTriangleSmall)
         }
     }
 }
@@ -30,93 +30,49 @@ public enum LivithToastPosition {
     case aboveKeyboard
 }
 
+// MARK: - Toast View
+
 public struct LivithToast: View {
-
-    // MARK: - Property
-
+    
+    private enum Layout {
+        static let iconSize: CGFloat = 30
+        static let horizontalSpacing: CGFloat = 10
+        static let leadingPadding: CGFloat = 20
+        static let verticalPadding: CGFloat = 12
+        static let toastWidth: CGFloat = 343
+        static let cornerRadius: CGFloat = 8
+        static let shadowRadius: CGFloat = 18
+        static let shadowOpacity: Double = 0.4
+    }
+    
     private let type: LivithToastType
     private let message: String
-
-    // MARK: - LifeCycle
-
+    
     public init(type: LivithToastType, message: String) {
         self.type = type
         self.message = message
     }
-
-    // MARK: - Body
-
+    
     public var body: some View {
-        HStack(alignment: .center, spacing: 10) {
+        HStack(alignment: .center, spacing: Layout.horizontalSpacing) {
             type.icon
                 .resizable()
-                .frame(width: 30, height: 30)
-
+                .frame(width: Layout.iconSize, height: Layout.iconSize)
+            
             Text(message)
                 .notosans(.body4Semibold)
                 .foregroundStyle(Color.livithColor(.white100))
                 .lineLimit(2)
-
+                .multilineTextAlignment(.leading)
+            
             Spacer()
         }
-        .padding(.leading, 20)
-        .padding(.vertical, 12)
-        .frame(width: 343)
+        .padding(.leading, Layout.leadingPadding)
+        .padding(.vertical, Layout.verticalPadding)
+        .frame(width: Layout.toastWidth)
         .background(Color.livithColor(.black80))
-        .shadow(color: .livithColor(.black100).opacity(0.4), radius: 18)
-        .clipShape(RoundedRectangle(cornerRadius: 8))
-    }
-}
-
-// MARK: - Toast ViewModifier
-
-private struct LivithToastModifier: ViewModifier {
-    @Binding var isPresented: Bool
-    let type: LivithToastType
-    let message: String
-    let duration: TimeInterval?
-    let topPadding: CGFloat
-    let position: LivithToastPosition
-    let keyboardSpacing: CGFloat
-
-    @State private var keyboardHeight: CGFloat = KeyboardHeightObserver.shared.height
-
-    func body(content: Content) -> some View {
-        content
-            .overlay {
-                if isPresented {
-                    GeometryReader { geometry in
-                        let toastHeight: CGFloat = 54
-                        let toastY: CGFloat = {
-                            switch position {
-                            case .top:
-                                return geometry.safeAreaInsets.top + topPadding
-                            case .safeAreaTop:
-                                return geometry.safeAreaInsets.top
-                            case .aboveKeyboard:
-                                return geometry.size.height - keyboardHeight - keyboardSpacing - toastHeight / 2
-                            }
-                        }()
-
-                        LivithToast(type: type, message: message)
-                            .position(x: geometry.size.width / 2, y: toastY)
-                            .transition(.opacity)
-                    }
-                    .onAppear {
-                        keyboardHeight = KeyboardHeightObserver.shared.height
-                    }
-                    .task(id: isPresented) {
-                        guard let duration else { return }
-                        try? await Task.sleep(for: .seconds(duration))
-                        guard !Task.isCancelled else { return }
-                        withAnimation { isPresented = false }
-                    }
-                }
-            }
-            .animation(.easeInOut(duration: 0.3), value: isPresented)
-            .onReceive(KeyboardHeightObserver.shared.$height) { height in
-                keyboardHeight = height
-            }
+        .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius))
+        .shadow(color: Color.livithColor(.black100).opacity(Layout.shadowOpacity), radius: Layout.shadowRadius)
     }
 }
 
@@ -126,23 +82,17 @@ public extension View {
     func livithToast(
         isPresented: Binding<Bool>,
         type: LivithToastType,
-        message: String,
-        duration: TimeInterval? = 2,
-        topPadding: CGFloat = 60,
-        position: LivithToastPosition = .top,
-        keyboardSpacing: CGFloat = 16
+        message: String
     ) -> some View {
         modifier(LivithToastModifier(
             isPresented: isPresented,
             type: type,
-            message: message,
-            duration: duration,
-            topPadding: topPadding,
-            position: position,
-            keyboardSpacing: keyboardSpacing
+            message: message
         ))
     }
 }
+
+// MARK: - Preview
 
 #Preview {
     VStack(spacing: 20) {

--- a/Projects/HomeFeature/Sources/Coordinator/HomeContentView.swift
+++ b/Projects/HomeFeature/Sources/Coordinator/HomeContentView.swift
@@ -19,10 +19,9 @@ public struct HomeContentView: View {
     public init(
         nickname: Binding<String>,
         isTabBarHidden: Binding<Bool>,
-        deepLinkConcertID: Binding<Int?> = .constant(nil),
-        showToast: ((LivithToastType, String) -> Void)? = nil
+        deepLinkConcertID: Binding<Int?> = .constant(nil)
     ) {
-        self._coordinator = State(initialValue: HomeCoordinator(nickname: nickname, isTabBarHidden: isTabBarHidden, showToast: showToast))
+        self._coordinator = State(initialValue: HomeCoordinator(nickname: nickname, isTabBarHidden: isTabBarHidden))
         self._isTabBarHidden = isTabBarHidden
         self._deepLinkConcertID = deepLinkConcertID
     }

--- a/Projects/HomeFeature/Sources/Coordinator/HomeContentView.swift
+++ b/Projects/HomeFeature/Sources/Coordinator/HomeContentView.swift
@@ -17,11 +17,10 @@ public struct HomeContentView: View {
     @Binding private var deepLinkConcertID: Int?
 
     public init(
-        nickname: Binding<String>,
         isTabBarHidden: Binding<Bool>,
         deepLinkConcertID: Binding<Int?> = .constant(nil)
     ) {
-        self._coordinator = State(initialValue: HomeCoordinator(nickname: nickname, isTabBarHidden: isTabBarHidden))
+        self._coordinator = State(initialValue: HomeCoordinator(isTabBarHidden: isTabBarHidden))
         self._isTabBarHidden = isTabBarHidden
         self._deepLinkConcertID = deepLinkConcertID
     }

--- a/Projects/HomeFeature/Sources/Coordinator/HomeCoordinator.swift
+++ b/Projects/HomeFeature/Sources/Coordinator/HomeCoordinator.swift
@@ -9,8 +9,6 @@
 import SwiftUI
 
 import ConcertFeature
-
-import LivithDesignSystem
 import Coordinator
 
 final class HomeCoordinator: Coordinator {
@@ -21,13 +19,11 @@ final class HomeCoordinator: Coordinator {
     private let nickname: Binding<String>
     private var concertCoordinator: ConcertCoordinator?
     private let isTabBarHidden: Binding<Bool>
-    private let showToast: ((LivithToastType, String) -> Void)?
 
-    init(nickname: Binding<String>, isTabBarHidden: Binding<Bool>, showToast: ((LivithToastType, String) -> Void)? = nil) {
+    init(nickname: Binding<String>, isTabBarHidden: Binding<Bool>) {
         self.navigationController = UINavigationController()
         self.nickname = nickname
         self.isTabBarHidden = isTabBarHidden
-        self.showToast = showToast
 
         self.navigationController.setNavigationBarHidden(true, animated: false)
     }
@@ -39,7 +35,7 @@ final class HomeCoordinator: Coordinator {
     func buildViewController(for route: R) -> UIViewController {
         switch route {
         case .home:
-            return UIHostingController(rootView: HomeView(nickname: nickname, isTabBarHidden: isTabBarHidden, showToast: showToast).environment(\.homeCoordinator, self))
+            return UIHostingController(rootView: HomeView(nickname: nickname, isTabBarHidden: isTabBarHidden).environment(\.homeCoordinator, self))
 
         case .interest:
             return UIHostingController(rootView: InterestConcertSearchView().environment(\.homeCoordinator, self))

--- a/Projects/HomeFeature/Sources/Coordinator/HomeCoordinator.swift
+++ b/Projects/HomeFeature/Sources/Coordinator/HomeCoordinator.swift
@@ -15,14 +15,12 @@ final class HomeCoordinator: Coordinator {
     typealias R = HomeRoute
 
     let navigationController: UINavigationController
-
-    private let nickname: Binding<String>
+    
     private var concertCoordinator: ConcertCoordinator?
     private let isTabBarHidden: Binding<Bool>
 
-    init(nickname: Binding<String>, isTabBarHidden: Binding<Bool>) {
+    init(isTabBarHidden: Binding<Bool>) {
         self.navigationController = UINavigationController()
-        self.nickname = nickname
         self.isTabBarHidden = isTabBarHidden
 
         self.navigationController.setNavigationBarHidden(true, animated: false)
@@ -35,7 +33,7 @@ final class HomeCoordinator: Coordinator {
     func buildViewController(for route: R) -> UIViewController {
         switch route {
         case .home:
-            return UIHostingController(rootView: HomeView(nickname: nickname, isTabBarHidden: isTabBarHidden).environment(\.homeCoordinator, self))
+            return UIHostingController(rootView: HomeView(isTabBarHidden: isTabBarHidden).environment(\.homeCoordinator, self))
 
         case .interest:
             return UIHostingController(rootView: InterestConcertSearchView().environment(\.homeCoordinator, self))

--- a/Projects/HomeFeature/Sources/Home/Store/HomeStore.swift
+++ b/Projects/HomeFeature/Sources/Home/Store/HomeStore.swift
@@ -24,12 +24,14 @@ enum HomeIntent {
     case _fetchMainSetlistResult(Result<Setlist, Error>)
     case _fetchSetlistSongListResult(Result<[SetlistSong], Error>)
     case _deleteInterestConcertResult(Result<Void, Error>)
+    case _fetchUserResult(Result<User, Error>)
 
     case onRefreshSections
     case _fetchHomeSectionListResult(Result<[ConcertSection], Error>)
 }
 
 struct HomeState {
+    var userName: String = ""
     var interestConcert: Concert? = nil
     var toastMessage: String = ""
     var errorMessage: String = ""
@@ -59,6 +61,7 @@ final class HomeStore: ObservableObject {
     func send(_ intent: HomeIntent) {
         switch intent {
         case .onAppear:
+            performFetchUser()
             performFetchUserInterestedConcert()
             
         case .onErrorToastDisappear:
@@ -135,6 +138,14 @@ final class HomeStore: ObservableObject {
             case .failure(let error):
                 state.errorMessage = error.localizedDescription
             }
+
+        case ._fetchUserResult(let result):
+            switch result {
+            case .success(let user):
+                state.userName = user.nickname
+            case .failure(let error):
+                state.errorMessage = getErrorMessage(from: error)
+            }
         
         case .onRefreshSections:
             state.isSectionsLoading = true
@@ -164,6 +175,18 @@ private extension HomeStore {
                 await send(._fetchUserInterestConcertResult(.success(result)))
             } catch {
                 await send(._fetchUserInterestConcertResult(.failure(error)))
+            }
+        }
+    }
+
+    func performFetchUser() {
+        cancellables[.fetchUser]?.cancel()
+        cancellables[.fetchUser] = Task {
+            do {
+                let result = try await userRepository.fetchUser()
+                await send(._fetchUserResult(.success(result)))
+            } catch {
+                await send(._fetchUserResult(.failure(error)))
             }
         }
     }
@@ -257,5 +280,6 @@ private extension HomeStore {
         case fetchMainSetlist
         case fetchSetlistSongList
         case refreshSections
+        case fetchUser
     }
 }

--- a/Projects/HomeFeature/Sources/Home/View/HomeConcertSectionView.swift
+++ b/Projects/HomeFeature/Sources/Home/View/HomeConcertSectionView.swift
@@ -13,12 +13,10 @@ import Domain
 import LivithDesignSystem
 
 struct HomeConcertSectionView: View {
-    @Binding var nickname: String
     @Environment(\.homeCoordinator) private var coordinator
     @ObservedObject private var store: HomeStore
 
-    init(nickname: Binding<String>, store: HomeStore) {
-        self._nickname = nickname
+    init(store: HomeStore) {
         self.store = store
     }
 
@@ -29,7 +27,7 @@ struct HomeConcertSectionView: View {
             ScrollView {
                 VStack(spacing: .zero) {                    
                     HomeHeaderView(
-                        nickname: nickname,
+                        nickname: store.state.userName,
                         action: { coordinator?.push(to: .interest) }
                     )
 

--- a/Projects/HomeFeature/Sources/Home/View/HomeView.swift
+++ b/Projects/HomeFeature/Sources/Home/View/HomeView.swift
@@ -14,13 +14,11 @@ struct HomeView: View {
     @StateObject private var store: HomeStore = .init()
 
     @Binding private var isTabBarHidden: Bool
-    private let nickname: Binding<String>
     
     @State private var showErrorToast = false
     @State private var showSuccessToast = false
 
-    init(nickname: Binding<String>, isTabBarHidden: Binding<Bool>) {
-        self.nickname = nickname
+    init(isTabBarHidden: Binding<Bool>) {
         self._isTabBarHidden = isTabBarHidden
     }
     
@@ -66,7 +64,7 @@ struct HomeView: View {
                 isTabBarHidden: $isTabBarHidden
             )
         } else {
-            HomeConcertSectionView(nickname: nickname, store: store)
+            HomeConcertSectionView(store: store)
         }
     }
 }

--- a/Projects/HomeFeature/Sources/Home/View/HomeView.swift
+++ b/Projects/HomeFeature/Sources/Home/View/HomeView.swift
@@ -15,12 +15,13 @@ struct HomeView: View {
 
     @Binding private var isTabBarHidden: Bool
     private let nickname: Binding<String>
-    private let showToast: ((LivithToastType, String) -> Void)?
+    
+    @State private var showErrorToast = false
+    @State private var showSuccessToast = false
 
-    init(nickname: Binding<String>, isTabBarHidden: Binding<Bool>, showToast: ((LivithToastType, String) -> Void)? = nil) {
+    init(nickname: Binding<String>, isTabBarHidden: Binding<Bool>) {
         self.nickname = nickname
         self._isTabBarHidden = isTabBarHidden
-        self.showToast = showToast
     }
     
     var body: some View {
@@ -31,16 +32,30 @@ struct HomeView: View {
             }
             .onChange(of: store.state.errorMessage) { _, newValue in
                 if !newValue.isEmpty {
-                    showToast?(.failure, newValue)
-                    store.send(.onErrorToastDisappear)
+                    showErrorToast = true
                 }
             }
             .onChange(of: store.state.toastMessage) { _, newValue in
                 if !newValue.isEmpty {
-                    showToast?(.success, newValue)
-                    store.send(.onToastDisappear)
+                    showSuccessToast = true
                 }
             }
+            .livithToast(
+                isPresented: Binding(
+                    get: { showErrorToast && !store.state.errorMessage.isEmpty },
+                    set: { if !$0 { showErrorToast = false; store.send(.onErrorToastDisappear) } }
+                ),
+                type: .failure,
+                message: store.state.errorMessage
+            )
+            .livithToast(
+                isPresented: Binding(
+                    get: { showSuccessToast && !store.state.toastMessage.isEmpty },
+                    set: { if !$0 { showSuccessToast = false; store.send(.onToastDisappear) } }
+                ),
+                type: .success,
+                message: store.state.toastMessage
+            )
     }
 
     @ViewBuilder
@@ -55,3 +70,4 @@ struct HomeView: View {
         }
     }
 }
+

--- a/Projects/HomeFeature/Sources/Interest/View/InterestConcertSearchView.swift
+++ b/Projects/HomeFeature/Sources/Interest/View/InterestConcertSearchView.swift
@@ -46,9 +46,7 @@ struct InterestConcertSearchView: View {
                     set: { _ in store.send(.onToastDisappear) }
                 ),
                 type: .failure,
-                message: store.state.errorMessage,
-                duration: 2,
-                position: .safeAreaTop
+                message: store.state.errorMessage
             )
             .onChange(of: isTextFieldFocused) { _, isFocused in
                 if isFocused {

--- a/Projects/LoginFeature/Sources/Coordinator/LoginContentView.swift
+++ b/Projects/LoginFeature/Sources/Coordinator/LoginContentView.swift
@@ -13,7 +13,7 @@ public struct LoginContentView: View {
     @State private var coordinator: LoginCoordinator
     
     public init(
-        onLoginCompleted: @escaping (String) -> Void,
+        onLoginCompleted: @escaping () -> Void,
         onSignupCompleted: @escaping (String) -> Void
     ) {
         _coordinator = State(

--- a/Projects/LoginFeature/Sources/Coordinator/LoginCoordinator.swift
+++ b/Projects/LoginFeature/Sources/Coordinator/LoginCoordinator.swift
@@ -20,11 +20,11 @@ final class LoginCoordinator: Coordinator {
     
     private var tempUser: Domain.TempUser?
     
-    private let onLoginCompleted: ((String) -> Void)
+    private let onLoginCompleted: (() -> Void)
     private let onSignupCompleted: ((String) -> Void)
     
     init(
-        onLoginCompleted: @escaping (String) -> Void = { _ in },
+        onLoginCompleted: @escaping () -> Void = { },
         onSignupCompleted: @escaping (String) -> Void = { _ in }
     ) {
         self.navigationController = UINavigationController()
@@ -68,8 +68,8 @@ final class LoginCoordinator: Coordinator {
         }
     }
     
-    func completeLogin(with nickname: String) {
-        onLoginCompleted(nickname)
+    func completeLogin() {
+        onLoginCompleted()
     }
     
     func completeSignup(with nickname: String) {

--- a/Projects/LoginFeature/Sources/Login/View/LoginView.swift
+++ b/Projects/LoginFeature/Sources/Login/View/LoginView.swift
@@ -36,9 +36,7 @@ struct LoginView: View {
                 set: { _ in store.send(.setErrorMessage("")) }
             ),
             type: .failure,
-            message: store.state.errorMessage,
-            duration: 2,
-            position: .safeAreaTop
+            message: store.state.errorMessage
         )
         .crossDissolve(isPresented: $isForbiddenModalPresented, dismissOnTapOutside: false) {
             LivithModal(

--- a/Projects/LoginFeature/Sources/Login/View/LoginView.swift
+++ b/Projects/LoginFeature/Sources/Login/View/LoginView.swift
@@ -58,8 +58,8 @@ struct LoginView: View {
     
     private func handleLoginSuccess(_ status: LoginStatus) {
         switch status {
-        case .existingUser(let nickname):
-            coordinator?.completeLogin(with: nickname)
+        case .existingUser:
+            coordinator?.completeLogin()
         case .newUser(let tempUser):
             coordinator?.push(to: .terms(tempUser))
         case .forbidden:

--- a/Projects/UserFeature/Sources/Store/UserStore.swift
+++ b/Projects/UserFeature/Sources/Store/UserStore.swift
@@ -8,7 +8,8 @@
 
 import Foundation
 
-import Persistence
+import DIContainer
+import Domain
 
 struct UserState {
     var nickname: String = ""
@@ -16,22 +17,27 @@ struct UserState {
 
 enum UserIntent {
     case fetchNickname
+    case _fetchUserResult(Result<User, Error>)
 }
 
 final class UserStore: ObservableObject {
     @Published private(set) var state = UserState()
 
-    private let localStorage: UserDefaultsStorage
-
-    init(localStorage: UserDefaultsStorage = .init()) {
-        self.localStorage = localStorage
-    }
+    @Injected private var userRepository: UserRepository
 
     @MainActor
     func send(_ intent: UserIntent) {
         switch intent {
         case .fetchNickname:
-            fetchNicknameFromStorage()
+            performFetchUser()
+            
+        case ._fetchUserResult(let result):
+            switch result {
+            case .success(let user):
+                state.nickname = user.nickname
+            case .failure:
+                break
+            }
         }
     }
 }
@@ -39,17 +45,14 @@ final class UserStore: ObservableObject {
 // MARK: - Helper
 
 private extension UserStore {
-    @MainActor
-    func fetchNicknameFromStorage() {
-        guard let user: StoredUserInfo = try? localStorage.fetch(for: .currentUser) else {
-            return
+    func performFetchUser() {
+        Task {
+            do {
+                let user = try await userRepository.fetchUser()
+                await send(._fetchUserResult(.success(user)))
+            } catch {
+                await send(._fetchUserResult(.failure(error)))
+            }
         }
-        state.nickname = user.nickname
     }
-}
-
-// MARK: - StoredUserInfo
-
-private struct StoredUserInfo: Decodable {
-    let nickname: String
 }

--- a/Projects/UserFeature/Sources/View/DeleteUserView.swift
+++ b/Projects/UserFeature/Sources/View/DeleteUserView.swift
@@ -107,7 +107,7 @@ struct DeleteUserView: View {
                     showErrorToast = true
                 }
             }
-            .livithToast(isPresented: $showErrorToast, type: .failure, message: errorMessage, position: .safeAreaTop)
+            .livithToast(isPresented: $showErrorToast, type: .failure, message: errorMessage)
             .livithSheet(
                 isPresented: $showConfirmSheet,
                 detents: [.fraction(445.0 / 812.0)]

--- a/Projects/UserFeature/Sources/View/NicknameUpdateView.swift
+++ b/Projects/UserFeature/Sources/View/NicknameUpdateView.swift
@@ -46,8 +46,7 @@ public struct NicknameUpdateView: View {
         .livithToast(
             isPresented: $showFailureToast,
             type: .failure,
-            message: toastMessage,
-            position: .safeAreaTop
+            message: toastMessage
         )
     }
 }

--- a/Projects/UserFeature/Sources/View/UserView.swift
+++ b/Projects/UserFeature/Sources/View/UserView.swift
@@ -42,24 +42,21 @@ public struct UserView: View {
     @State private var showLogoutToast: Bool = false
     @State private var logoutToastType: LivithToastType = .success
     @State private var logoutToastMessage: String = ""
+    @State private var showNicknameSuccessToast: Bool = false
 
     @Binding private var isTabBarHidden: Bool
     @Binding private var nickname: String
 
     @StateObject private var logoutStore = LogoutStore()
 
-    private let showToast: ((LivithToastType, String) -> Void)?
-
     // MARK: - LifeCycle
 
     public init(
         nickname: Binding<String>,
-        isTabBarHidden: Binding<Bool>,
-        showToast: ((LivithToastType, String) -> Void)? = nil
+        isTabBarHidden: Binding<Bool>
     ) {
         self._nickname = nickname
         self._isTabBarHidden = isTabBarHidden
-        self.showToast = showToast
     }
     
     // MARK: - Body
@@ -109,7 +106,7 @@ public struct UserView: View {
                         onSuccess: { newNickname in
                             if !path.isEmpty { path.removeLast() }
                             nickname = newNickname
-                            showToast?(.success, Literals.toastSuccess)
+                            showNicknameSuccessToast = true
                         }
                     )
                     .navigationBarBackButtonHidden()
@@ -156,8 +153,12 @@ public struct UserView: View {
         .livithToast(
             isPresented: $showLogoutToast,
             type: logoutToastType,
-            message: logoutToastMessage,
-            position: .safeAreaTop
+            message: logoutToastMessage
+        )
+        .livithToast(
+            isPresented: $showNicknameSuccessToast,
+            type: .success,
+            message: Literals.toastSuccess
         )
     }
 }
@@ -272,11 +273,10 @@ private extension UserView {
         case .idle:
             break
         case .success:
-            NotificationCenter.default.post(
-                name: .reloginRequired,
-                object: nil,
-                userInfo: ["toastMessage": Literals.logoutSuccessMessage]
-            )
+            NotificationCenter.default.post(name: .reloginRequired, object: nil)
+            logoutToastType = .success
+            logoutToastMessage = Literals.logoutSuccessMessage
+            showLogoutToast = true
         case .failure(let message):
             logoutToastType = .failure
             logoutToastMessage = message

--- a/Projects/UserFeature/Sources/View/UserView.swift
+++ b/Projects/UserFeature/Sources/View/UserView.swift
@@ -45,17 +45,15 @@ public struct UserView: View {
     @State private var showNicknameSuccessToast: Bool = false
 
     @Binding private var isTabBarHidden: Bool
-    @Binding private var nickname: String
-
+    
+    @StateObject private var store = UserStore()
     @StateObject private var logoutStore = LogoutStore()
 
     // MARK: - LifeCycle
 
     public init(
-        nickname: Binding<String>,
         isTabBarHidden: Binding<Bool>
     ) {
-        self._nickname = nickname
         self._isTabBarHidden = isTabBarHidden
     }
     
@@ -105,7 +103,7 @@ public struct UserView: View {
                         onDismiss: { if !path.isEmpty { path.removeLast() } },
                         onSuccess: { newNickname in
                             if !path.isEmpty { path.removeLast() }
-                            nickname = newNickname
+                            store.send(.fetchNickname)
                             showNicknameSuccessToast = true
                         }
                     )
@@ -160,6 +158,9 @@ public struct UserView: View {
             type: .success,
             message: Literals.toastSuccess
         )
+        .onAppear {
+            store.send(.fetchNickname)
+        }
     }
 }
 
@@ -184,8 +185,8 @@ private extension UserView {
     
     var titleText: some View {
         Text.init(
-            String(format: Literals.titleFormat, nickname),
-            highlighting: "\(nickname)",
+            String(format: Literals.titleFormat, store.state.nickname),
+            highlighting: "\(store.state.nickname)",
             color: .livithColor(.white100),
             font: .notosans(.headSemibold)
         )


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 윈도우 기반 토스트를 구현하고 적용하였습니다.
- 앱 진입점으로부터 닉네임 의존성을 끊어내고, 내부적으로 조회하도록 하였습니다. (홈, 유저)
- 앱 진입점의 로직을 간소화 하였습니다.
- 런치스크린을 표현하는 방식을 수정하였습니다.

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 윈도우 기반 토스트
```mermaid
sequenceDiagram
    participant User as 사용자
    participant View as SwiftUI 뷰 (호출처)
    participant Modifier as ToastModifier
    participant Manager as WindowManager
    participant Window as 투명 윈도우 (Passthrough)
    participant Container as 토스트 컨테이너
    participant Toast as 토스트 UI

    Note over User, View: 1. 트리거 (Trigger)
    User->>View: 특정 동작 수행 (예: 저장)
    View->>Modifier: isPresented = true 설정
    
    Note over Modifier, Manager: 2. 요청 (Request)
    Modifier->>Modifier: 현재 WindowScene 탐색
    Modifier->>Manager: show(scene, content) 요청
    activate Manager

    Note over Manager, Window: 3. 인프라 구성 (Infrastructure)
    Manager->>Window: 윈도우 생성/재사용
    activate Window
    Manager->>Window: 레벨 설정 (.alert + 1)
    Manager->>Window: RootVC 설정 (Container)
    Manager->>Window: isHidden = false (표시)
    
    Note over Window, Container: 4. 렌더링 (Render)
    Window->>Container: 초기화 및 onAppear
    activate Container
    Container->>Toast: UI 그리기 (메시지, 아이콘)
    activate Toast
    Toast-->>Container: 뷰 반환
    deactivate Toast
    Container->>User: 등장 애니메이션 (Slide In)
    
    Note right of User: 사용자는 토스트 뒤의 앱을 계속 조작 가능

    Note over Container, Modifier: 5. 자동 종료 (Auto Dismiss)
    Container->>Container: 일정 시간 대기 (Timer)
    Container->>User: 퇴장 애니메이션 (Slide Out)
    Container-->>Manager: onDismiss 콜백 호출
    deactivate Container
    
    Manager->>Window: isHidden = true (숨김)
    deactivate Window
    
    Manager-->>Modifier: 상태 초기화 요청
    deactivate Manager
    Modifier->>View: isPresented = false 복구
```

#### 1. ToastWindowManager
- 토스트를 위한 별도의 UIWindow를 생성하고 관리하는 싱글톤
#### 2. LivithToastModifier
- `isPresented`의 상태가 변하면 매니저에게 토스트 표시/숨김을 요청한다.
#### 3. ToastContainerView
- 토스트 UI를 감싸며, 위치와 애니메이션 등을 담당한다.
#### 4. PassthroughWindow
- 유저의 터치 이벤트를 처리하는 투명 유리창으로 토스트가 아닌 빈 영역 터치 시, 앱 화면으로 통과시킨다.
#### 5. WindowSceneFinder
- UIKit 브릿징을 하여 WindowScene에 접근하고, 매니저에게 전달한다.
#### 6. EnvPassingView
- 토스트는 별도의 윈도우에서 생성되므로 기존 앱의 환경 변수들을 물려받을 수 있도록 한다.


## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- [윈도우 오버레이 라이브러리](https://github.com/sunghyun-k/swiftui-window-overlay)를 참고하였습니다.

## 🔗 연결된 이슈
- Resolved: #178 
