### PR TITLE
[Feat] 선호 아티스트 설정 UI 구현

### DIFF
--- a/Projects/DesignSystem/Sources/Components/Chip/RemovableChip.swift
+++ b/Projects/DesignSystem/Sources/Components/Chip/RemovableChip.swift
@@ -48,7 +48,7 @@ public struct RemovableChip: View {
                 Image.livithIcon(.closeLineSmall)
                     .renderingMode(.template)
                     .frame(width: Constants.iconSize, height: Constants.iconSize)
-                    .tint(Color.livithColor(.black100))
+                    .foregroundStyle(Color.livithColor(.black100))
             }
             .buttonStyle(.plain)
         }

--- a/Projects/Domain/Sources/Entity/Preference/PreferredArtist.swift
+++ b/Projects/Domain/Sources/Entity/Preference/PreferredArtist.swift
@@ -1,0 +1,28 @@
+//
+//  PreferredArtist.swift
+//  Domain
+//
+//  Created by 김진웅 on 2/2/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+public struct PreferredArtist: Hashable, Identifiable {
+    public let id: Int
+    public let name: String
+    public let genreID: Int
+    public let imageURL: URL?
+
+    public init(
+        id: Int,
+        name: String,
+        genreID: Int,
+        imageURL: URL?
+    ) {
+        self.id = id
+        self.name = name
+        self.genreID = genreID
+        self.imageURL = imageURL
+    }
+}

--- a/Projects/Shared/NicknameEditFeature/Tests/NicknameEditStoreTests.swift
+++ b/Projects/Shared/NicknameEditFeature/Tests/NicknameEditStoreTests.swift
@@ -78,7 +78,7 @@ final class MockUserRepository: UserRepository {
             providerID: "123",
             email: nil,
             nickname: "test",
-            marketingConsent: false
+            authority: UserAuthority(deviceNotification: true, marketingConsent: false)
         )
     }
 

--- a/Projects/Shared/PreferenceFeature/Sources/Artist/Model/ArtistEditConfig.swift
+++ b/Projects/Shared/PreferenceFeature/Sources/Artist/Model/ArtistEditConfig.swift
@@ -1,14 +1,14 @@
 //
-//  GenreEditConfig.swift
+//  ArtistEditConfig.swift
 //  PreferenceFeature
 //
-//  Created by 김진웅 on 1/29/26.
+//  Created by 김진웅 on 2/2/26.
 //  Copyright © 2026 Livith. All rights reserved.
 //
 
 import Foundation
 
-public struct GenreEditConfig {
+public struct ArtistEditConfig {
     public let stepIndicator: (current: Int, total: Int)?
     public let navigationTitle: String
     public let title: String
@@ -30,34 +30,32 @@ public struct GenreEditConfig {
     }
 }
 
-// MARK: - Factory Methods
-
-public extension GenreEditConfig {
-    static func onboarding() -> GenreEditConfig {
-        GenreEditConfig(
-            stepIndicator: (current: 3, total: 4),
+public extension ArtistEditConfig {
+    static func onboarding() -> ArtistEditConfig {
+        ArtistEditConfig(
+            stepIndicator: (current: 4, total: 4),
             navigationTitle: "회원가입",
-            title: "선호하는 장르를\n3개 선택해 주세요",
+            title: "선호하는 아티스트를\n3명 선택해 주세요",
             subtitle: "마이페이지에서 언제든 바꿀 수 있어요",
-            submitTitle: "다음"
+            submitTitle: "가입 완료"
         )
     }
     
-    static func home() -> GenreEditConfig {
-        GenreEditConfig(
-            stepIndicator: (current: 1, total: 2),
+    static func home() -> ArtistEditConfig {
+        ArtistEditConfig(
+            stepIndicator: (current: 2, total: 2),
             navigationTitle: "취향 선택",
-            title: "좋아하는 장르를\n3개 선택해 주세요",
+            title: "좋아하는 아티스트를\n3명 선택해 주세요",
             subtitle: nil,
-            submitTitle: "다음"
+            submitTitle: "취향 선택 완료"
         )
     }
     
-    static func edit() -> GenreEditConfig {
-        GenreEditConfig(
+    static func edit() -> ArtistEditConfig {
+        ArtistEditConfig(
             stepIndicator: nil,
-            navigationTitle: "장르 변경",
-            title: "선호하는 장르를\n3개 선택해 주세요",
+            navigationTitle: "아티스트 변경",
+            title: "선호하는 아티스트를\n3명 선택해 주세요",
             subtitle: nil,
             submitTitle: "변경하기"
         )

--- a/Projects/Shared/PreferenceFeature/Sources/Artist/Store/ArtistSelectionStore.swift
+++ b/Projects/Shared/PreferenceFeature/Sources/Artist/Store/ArtistSelectionStore.swift
@@ -1,0 +1,113 @@
+//
+//  ArtistSelectionStore.swift
+//  PreferenceFeature
+//
+//  Created by 김진웅 on 2/2/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+
+enum ArtistSelectionIntent {
+    case onAppear
+    case search(keyword: String)
+    case toggle(id: Int)
+    case resetMaxSelectionToast
+}
+
+public struct ArtistSelectionState: Equatable {
+    public var selectedArtistList: [PreferredArtist] = []
+    var isLoading: Bool = false
+    var allArtistList: [PreferredArtist] = []
+    var filteredArtistList: [PreferredArtist] = []
+    var searchKeyword: String = ""
+    var isMaxSelectionToastPresented: Bool = false
+}
+
+public final class ArtistSelectionStore: ObservableObject {
+    @Published public private(set) var state: ArtistSelectionState = ArtistSelectionState()
+    
+    public init() {}
+    
+    @MainActor
+    func send(_ intent: ArtistSelectionIntent) {
+        switch intent {
+        case .onAppear:
+            state.isLoading = true
+            state.allArtistList = ArtistSelectionStore.mockArtists()
+            state.filteredArtistList = state.allArtistList
+            state.isLoading = false
+            
+        case .search(let keyword):
+            state.searchKeyword = keyword
+            if keyword.isEmpty {
+                state.filteredArtistList = state.allArtistList
+            } else {
+                state.filteredArtistList = state.allArtistList.filter { artist in
+                    artist.name.lowercased().contains(keyword.lowercased())
+                }
+            }
+            
+        case .toggle(let id):
+            guard let artist = state.allArtistList.first(where: { $0.id == id }) else { return }
+            
+            if let index = state.selectedArtistList.firstIndex(where: { $0.id == id }) {
+                state.selectedArtistList.remove(at: index)
+                state.isMaxSelectionToastPresented = false
+            } else if state.selectedArtistList.count < PreferenceSelectionRule.maxCount {
+                state.selectedArtistList.append(artist)
+                state.isMaxSelectionToastPresented = false
+            } else {
+                state.isMaxSelectionToastPresented = true
+            }
+            
+        case .resetMaxSelectionToast:
+            state.isMaxSelectionToastPresented = false
+        }
+    }
+}
+
+// MARK: - Mock Data
+
+extension ArtistSelectionStore {
+    static func mockArtists() -> [PreferredArtist] {
+        [
+            PreferredArtist(id: 1, name: "34", genreID: 1, imageURL: mockImageURL()),
+            PreferredArtist(id: 2, name: "Sunset Rollercoaster", genreID: 1, imageURL: mockImageURL()),
+            PreferredArtist(id: 3, name: "IU", genreID: 2, imageURL: mockImageURL()),
+            PreferredArtist(id: 4, name: "IUee", genreID: 2, imageURL: mockImageURL()),
+            PreferredArtist(id: 5, name: "IUeee434", genreID: 2, imageURL: mockImageURL()),
+            PreferredArtist(id: 6, name: "Day6", genreID: 3, imageURL: mockImageURL()),
+            PreferredArtist(id: 7, name: "Seventeen", genreID: 1, imageURL: mockImageURL()),
+            PreferredArtist(id: 8, name: "NewJeans", genreID: 2, imageURL: mockImageURL()),
+            PreferredArtist(id: 9, name: "Stray Kids", genreID: 1, imageURL: mockImageURL()),
+            PreferredArtist(id: 10, name: "BTS", genreID: 2, imageURL: mockImageURL()),
+            PreferredArtist(id: 11, name: "BLACKPINK", genreID: 3, imageURL: mockImageURL()),
+            PreferredArtist(id: 12, name: "EXO", genreID: 1, imageURL: mockImageURL()),
+            PreferredArtist(id: 13, name: "TWICE", genreID: 2, imageURL: mockImageURL()),
+            PreferredArtist(id: 14, name: "Red Velvet", genreID: 3, imageURL: mockImageURL()),
+            PreferredArtist(id: 15, name: "GOT7", genreID: 1, imageURL: mockImageURL()),
+            PreferredArtist(id: 16, name: "Aespa", genreID: 2, imageURL: mockImageURL()),
+            PreferredArtist(id: 17, name: "Enhypen", genreID: 1, imageURL: mockImageURL()),
+            PreferredArtist(id: 18, name: "IVE", genreID: 3, imageURL: mockImageURL()),
+            PreferredArtist(id: 19, name: "Le Sserafim", genreID: 2, imageURL: mockImageURL()),
+            PreferredArtist(id: 20, name: "CL", genreID: 1, imageURL: mockImageURL()),
+            PreferredArtist(id: 21, name: "Psy", genreID: 2, imageURL: mockImageURL()),
+            PreferredArtist(id: 22, name: "Jay Park", genreID: 3, imageURL: mockImageURL()),
+            PreferredArtist(id: 23, name: "Taeyeon", genreID: 1, imageURL: mockImageURL()),
+            PreferredArtist(id: 24, name: "Taemin", genreID: 2, imageURL: mockImageURL()),
+            PreferredArtist(id: 25, name: "Jungkook", genreID: 1, imageURL: mockImageURL()),
+            PreferredArtist(id: 26, name: "Lisa", genreID: 3, imageURL: mockImageURL()),
+            PreferredArtist(id: 27, name: "Jennie", genreID: 2, imageURL: mockImageURL()),
+            PreferredArtist(id: 28, name: "Rose", genreID: 1, imageURL: mockImageURL()),
+            PreferredArtist(id: 29, name: "Jisoo", genreID: 2, imageURL: mockImageURL()),
+            PreferredArtist(id: 30, name: "HyunA", genreID: 3, imageURL: mockImageURL())
+        ]
+    }
+    
+    private static func mockImageURL() -> URL? {
+        URL(string: "https://fastly.picsum.photos/id/366/108/108.jpg?hmac=aV1brwLNkVd52uapZPMKWfSPXS2oPwaXCrko27s_hwQ")
+    }
+}

--- a/Projects/Shared/PreferenceFeature/Sources/Artist/View/ArtistEditView.swift
+++ b/Projects/Shared/PreferenceFeature/Sources/Artist/View/ArtistEditView.swift
@@ -1,0 +1,203 @@
+//
+//  ArtistEditView.swift
+//  PreferenceFeature
+//
+//  Created by 김진웅 on 2/2/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import SwiftUI
+
+import Domain
+import LivithDesignSystem
+
+public struct ArtistEditView: View {
+    
+    // MARK: - Properties
+    
+    @StateObject private var store: ArtistSelectionStore
+    @State private var isSearchFocused: Bool = false
+    
+    private let config: ArtistEditConfig
+    private let onBack: () -> Void
+    private let onSkip: (() -> Void)?
+    private let onSubmit: ([PreferredArtist]) -> Void
+    
+    public init(
+        config: ArtistEditConfig,
+        onBack: @escaping () -> Void,
+        onSkip: (() -> Void)? = nil,
+        onSubmit: @escaping ([PreferredArtist]) -> Void
+    ) {
+        self._store = StateObject(wrappedValue: ArtistSelectionStore())
+        self.config = config
+        self.onBack = onBack
+        self.onSkip = onSkip
+        self.onSubmit = onSubmit
+    }
+    
+    // MARK: - Body
+    
+    public var body: some View {
+        VStack(spacing: .zero) {
+            navigationSection
+            
+            VStack(spacing: .zero) {
+                stepIndicator
+                    .padding(.top, Constants.indicatorTopPadding)
+                
+                titleSection
+                    .padding(.top, Constants.titleTopPadding)
+                
+                ArtistSelectionView(
+                    store: store,
+                    isSearchFocused: $isSearchFocused
+                )
+                
+                Spacer()
+                
+                submitButton
+                    .padding(.bottom, Constants.bottomPadding)
+            }
+            .padding(.horizontal, Constants.horizontalPadding)
+        }
+        .background(.livithColor(.black100))
+        .ignoresSafeArea(.keyboard)
+        .navigationBarHidden(true)
+        .simultaneousGesture(TapGesture().onEnded { _ in
+            isSearchFocused = false
+        })
+        .livithToast(
+            isPresented: exceedMaxSelectionToastBinding,
+            type: .failure,
+            message: Literals.exceedMaxSelectionToastMessage
+        )
+        .onAppear {
+            store.send(.onAppear)
+        }
+    }
+}
+
+// MARK: - Subviews
+
+private extension ArtistEditView {
+    var navigationSection: some View {
+        if let onSkip {
+            LivithNavigationView(
+                type: .back(
+                    title: config.navigationTitle,
+                    onBack: onBack,
+                    rightButtonTitle: "건너뛰기",
+                    onRightButtonTap: onSkip
+                )
+            )
+        } else {
+            LivithNavigationView(
+                type: .back(
+                    title: config.navigationTitle,
+                    onBack: onBack
+                )
+            )
+        }
+    }
+    
+    @ViewBuilder
+    var stepIndicator: some View {
+        if let stepInfo = config.stepIndicator {
+            StepIndicatorView(
+                currentStep: stepInfo.current,
+                totalSteps: stepInfo.total
+            )
+        }
+    }
+    
+    @ViewBuilder
+    var titleSection: some View {
+        if !isSearchFocused {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(config.title)
+                        .notosans(.body1Semibold)
+                        .foregroundStyle(Color.livithColor(.white100))
+                        .multilineTextAlignment(.leading)
+                    
+                    if let subtitle = config.subtitle {
+                        Text(subtitle)
+                            .notosans(.body4Semibold)
+                            .foregroundStyle(.livithColor(.black50))
+                    }
+                }
+                
+                Spacer()
+                
+                Text(selectedCountText)
+                    .notosans(.body4Medium)
+                    .foregroundStyle(Color.livithColor(.black50))
+            }
+        }
+    }
+    
+    var submitButton: some View {
+        LivithButton(config.submitTitle) {
+            onSubmit(store.state.selectedArtistList)
+        }
+        .disabled(store.state.selectedArtistList.isEmpty)
+    }
+}
+
+// MARK: - Helpers
+
+private extension ArtistEditView {
+    var selectedCountText: String {
+        "\(store.state.selectedArtistList.count)/\(PreferenceSelectionRule.maxCount)"
+    }
+    
+    var searchTextBinding: Binding<String> {
+        Binding(
+            get: { store.state.searchKeyword },
+            set: { store.send(.search(keyword: $0)) }
+        )
+    }
+    
+    var exceedMaxSelectionToastBinding: Binding<Bool> {
+        Binding(
+            get: { store.state.isMaxSelectionToastPresented },
+            set: { isPresented in
+                guard !isPresented else { return }
+                store.send(.resetMaxSelectionToast)
+            }
+        )
+    }
+}
+
+// MARK: - Constants
+
+private extension ArtistEditView {
+    enum Constants {
+        static let horizontalPadding: CGFloat = 16
+        static let titleTopPadding: CGFloat = 30
+        static let indicatorTopPadding: CGFloat = 10
+        static let bottomPadding: CGFloat = 16
+    }
+}
+
+// MARK: - Literals
+
+private extension ArtistEditView {
+    enum Literals {
+        static let exceedMaxSelectionToastMessage = "해제 후 선택해 주세요"
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ArtistEditView(
+        config: .onboarding(),
+        onBack: { print("뒤로가기 눌림") },
+        onSkip: { print("건너뛰기 눌림") },
+        onSubmit: { artists in
+            print("\(artists) 제출")
+        }
+    )
+}

--- a/Projects/Shared/PreferenceFeature/Sources/Artist/View/ArtistEditView.swift
+++ b/Projects/Shared/PreferenceFeature/Sources/Artist/View/ArtistEditView.swift
@@ -67,11 +67,6 @@ public struct ArtistEditView: View {
         .simultaneousGesture(TapGesture().onEnded { _ in
             isSearchFocused = false
         })
-        .livithToast(
-            isPresented: exceedMaxSelectionToastBinding,
-            type: .failure,
-            message: Literals.exceedMaxSelectionToastMessage
-        )
         .onAppear {
             store.send(.onAppear)
         }
@@ -178,14 +173,6 @@ private extension ArtistEditView {
         static let titleTopPadding: CGFloat = 30
         static let indicatorTopPadding: CGFloat = 10
         static let bottomPadding: CGFloat = 16
-    }
-}
-
-// MARK: - Literals
-
-private extension ArtistEditView {
-    enum Literals {
-        static let exceedMaxSelectionToastMessage = "해제 후 선택해 주세요"
     }
 }
 

--- a/Projects/Shared/PreferenceFeature/Sources/Artist/View/ArtistSelectionView.swift
+++ b/Projects/Shared/PreferenceFeature/Sources/Artist/View/ArtistSelectionView.swift
@@ -1,0 +1,163 @@
+//
+//  ArtistSelectionView.swift
+//  PreferenceFeature
+//
+//  Created by 김진웅 on 2/2/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import SwiftUI
+
+import Domain
+import LivithDesignSystem
+
+public struct ArtistSelectionView: View {
+    @ObservedObject private var store: ArtistSelectionStore
+    @Binding private var isSearchFocused: Bool
+    
+    public init(store: ArtistSelectionStore, isSearchFocused: Binding<Bool>) {
+        self.store = store
+        self._isSearchFocused = isSearchFocused
+    }
+    
+    public var body: some View {
+        VStack(spacing: .zero) {
+            searchBar
+                .padding(.top, Constants.searchBarTopPadding)
+                .padding(.bottom, Constants.gridTopPadding)
+            
+            scrollContent
+        }
+        .livithToast(
+            isPresented: exceedMaxSelectionToastBinding,
+            type: .failure,
+            message: Literals.exceedMaxSelectionToastMessage
+        )
+        .onAppear {
+            store.send(.onAppear)
+        }
+    }
+}
+
+// MARK: - Subviews
+
+private extension ArtistSelectionView {
+    var searchBar: some View {
+        LivithTextField(
+            text: searchTextBinding,
+            isFocused: $isSearchFocused,
+            type: .search,
+            placeholder: Literals.searchPlaceholder,
+            onChange: {
+                store.send(.search(keyword: store.state.searchKeyword))
+            }
+        )
+    }
+    
+    @ViewBuilder
+    var scrollContent: some View {
+        if store.state.isLoading {
+            loadingIndicator
+        } else {
+            ZStack(alignment: .bottom) {
+                ScrollView {
+                    artistGrid
+                        .padding(2)
+                }
+                .scrollIndicators(.hidden)
+                
+                if !store.state.selectedArtistList.isEmpty {
+                    selectedArtistChips
+                        .padding(.vertical, Constants.chipVerticalPadding)
+                        .background(BackgroundGradientView())
+                }
+            }
+        }
+    }
+    
+    var loadingIndicator: some View {
+        VStack {
+            Spacer()
+            
+            ProgressView()
+                .tint(Color.livithColor(.white100))
+            
+            Spacer()
+        }
+    }
+    
+    var artistGrid: some View {
+        LazyVGrid(
+            columns: Array(repeating: GridItem(.flexible(), spacing: Constants.gridSpacing), count: Constants.gridColumns),
+            spacing: Constants.gridSpacing
+        ) {
+            ForEach(store.state.filteredArtistList) { artist in
+                PreferenceCard(
+                    title: artist.name,
+                    imageURL: artist.imageURL,
+                    isSelected: store.state.selectedArtistList.contains(where: { $0.id == artist.id }),
+                    action: {
+                        store.send(.toggle(id: artist.id))
+                    }
+                )
+            }
+        }
+    }
+    
+    var selectedArtistChips: some View {
+        HStack(spacing: Constants.chipSpacing) {
+            ForEach(store.state.selectedArtistList) { artist in
+                RemovableChip(artist.name) {
+                    store.send(.toggle(id: artist.id))
+                }
+            }
+            
+            Spacer()
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private extension ArtistSelectionView {
+    var searchTextBinding: Binding<String> {
+        Binding(
+            get: { store.state.searchKeyword },
+            set: { store.send(.search(keyword: $0)) }
+        )
+    }
+    
+    var exceedMaxSelectionToastBinding: Binding<Bool> {
+        Binding(
+            get: { store.state.isMaxSelectionToastPresented },
+            set: { isPresented in
+                guard !isPresented else { return }
+                store.send(.resetMaxSelectionToast)
+            }
+        )
+    }
+}
+
+// MARK: - Constants & Literals
+
+private extension ArtistSelectionView {
+    enum Constants {
+        static let gridColumns = 3
+        static let gridSpacing: CGFloat = 12
+        static let searchBarTopPadding: CGFloat = 30
+        static let gridTopPadding: CGFloat = 20
+        static let chipVerticalPadding: CGFloat = 15
+        static let chipSpacing: CGFloat = 10
+    }
+    
+    enum Literals {
+        static let searchPlaceholder = "아티스트를 검색하세요"
+        static let exceedMaxSelectionToastMessage = "해제 후 선택해 주세요"
+    }
+}
+
+#Preview {
+    ArtistSelectionView(store: ArtistSelectionStore(), isSearchFocused: .constant(false))
+        .frame(width: 375, height: 600)
+        .background(Color.livithColor(.black100))
+}

--- a/Projects/Shared/PreferenceFeature/Tests/ArtistSelectionStoreTests.swift
+++ b/Projects/Shared/PreferenceFeature/Tests/ArtistSelectionStoreTests.swift
@@ -1,0 +1,204 @@
+//
+//  ArtistSelectionStoreTests.swift
+//  PreferenceFeatureTests
+//
+//  Created by 김진웅 on 2/2/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Testing
+import Foundation
+
+@testable import PreferenceFeature
+
+struct ArtistSelectionStoreTests {
+    
+    // MARK: - 초기 상태 테스트
+    
+    @Test("초기 상태에서 isLoading은 false여야 한다")
+    func testInitialLoadingState() {
+        let sut = ArtistSelectionStore()
+        #expect(!sut.state.isLoading)
+    }
+    
+    @Test("초기 상태에서 선택된 아티스트가 없어야 한다")
+    func testInitialState() {
+        let sut = ArtistSelectionStore()
+        #expect(sut.state.selectedArtistList.isEmpty)
+    }
+    
+    @Test("초기 상태에서 검색 키워드는 빈 문자열이어야 한다")
+    func testInitialSearchKeyword() {
+        let sut = ArtistSelectionStore()
+        #expect(sut.state.searchKeyword.isEmpty)
+    }
+    
+    // MARK: - onAppear 테스트
+    
+    @Test("onAppear 완료 후 isLoading은 false여야 한다")
+    func testOnAppearSetsLoadingFalse() async {
+        let sut = ArtistSelectionStore()
+        await sut.send(.onAppear)
+        #expect(!sut.state.isLoading)
+        #expect(!sut.state.allArtistList.isEmpty)
+    }
+    
+    @Test("onAppear 시 아티스트 목록이 로드되어야 한다")
+    func testOnAppearLoadsArtists() async {
+        let sut = ArtistSelectionStore()
+        await sut.send(.onAppear)
+        #expect(!sut.state.allArtistList.isEmpty)
+        #expect(sut.state.filteredArtistList == sut.state.allArtistList)
+    }
+    
+    // MARK: - 검색 테스트
+    
+    @Test("검색어 입력 시 filteredArtistList가 필터링되어야 한다")
+    func testSearchFiltersArtists() async {
+        let sut = ArtistSelectionStore()
+        await sut.send(.onAppear)
+        
+        await sut.send(.search(keyword: "IU"))
+        
+        #expect(sut.state.searchKeyword == "IU")
+        #expect(sut.state.filteredArtistList.allSatisfy { $0.name.lowercased().contains("iu") })
+    }
+    
+    @Test("빈 검색어 입력 시 전체 목록이 표시되어야 한다")
+    func testEmptySearchShowsAllArtists() async {
+        let sut = ArtistSelectionStore()
+        await sut.send(.onAppear)
+        await sut.send(.search(keyword: "IU"))
+        
+        await sut.send(.search(keyword: ""))
+        
+        #expect(sut.state.filteredArtistList == sut.state.allArtistList)
+    }
+    
+    @Test("대소문자 구분 없이 검색되어야 한다")
+    func testSearchIsCaseInsensitive() async {
+        let sut = ArtistSelectionStore()
+        await sut.send(.onAppear)
+        
+        await sut.send(.search(keyword: "bts"))
+        
+        #expect(sut.state.filteredArtistList.contains { $0.name == "BTS" })
+    }
+    
+    // MARK: - 토글 테스트
+    
+    @Test("아티스트를 토글하면 선택된 목록에 추가되어야 한다")
+    func testToggleAddsArtistWhenNotSelected() async {
+        let sut = ArtistSelectionStore()
+        await sut.send(.onAppear)
+        
+        await sut.send(.toggle(id: 1))
+        
+        #expect(sut.state.selectedArtistList.count == 1)
+        #expect(sut.state.selectedArtistList.first?.id == 1)
+    }
+    
+    @Test("이미 선택된 아티스트를 토글하면 목록에서 제거되어야 한다")
+    func testToggleRemovesArtistWhenAlreadySelected() async {
+        let sut = ArtistSelectionStore()
+        await sut.send(.onAppear)
+        await sut.send(.toggle(id: 1))
+        
+        await sut.send(.toggle(id: 1))
+        
+        #expect(sut.state.selectedArtistList.isEmpty)
+    }
+    
+    @Test("존재하지 않는 아티스트 ID를 토글하면 아무 변화가 없어야 한다")
+    func testToggleNonExistentArtistDoesNothing() async {
+        let sut = ArtistSelectionStore()
+        await sut.send(.onAppear)
+        
+        await sut.send(.toggle(id: 9999))
+        
+        #expect(sut.state.selectedArtistList.isEmpty)
+    }
+    
+    @Test("3개 선택된 상태에서 새로운 아티스트를 토글해도 추가되지 않아야 한다")
+    func testToggleDoesNotAddWhenMaxSelectionReached() async {
+        let sut = ArtistSelectionStore()
+        await sut.send(.onAppear)
+        await sut.send(.toggle(id: 1))
+        await sut.send(.toggle(id: 2))
+        await sut.send(.toggle(id: 3))
+        
+        await sut.send(.toggle(id: 4))
+        
+        #expect(sut.state.selectedArtistList.count == 3)
+        #expect(!sut.state.selectedArtistList.contains { $0.id == 4 })
+    }
+    
+    @Test("3개 선택된 상태에서 이미 선택된 아티스트를 토글하면 제거되어야 한다")
+    func testToggleRemovesArtistEvenWhenMaxSelectionReached() async {
+        let sut = ArtistSelectionStore()
+        await sut.send(.onAppear)
+        await sut.send(.toggle(id: 1))
+        await sut.send(.toggle(id: 2))
+        await sut.send(.toggle(id: 3))
+        
+        await sut.send(.toggle(id: 2))
+        
+        #expect(sut.state.selectedArtistList.count == 2)
+        #expect(!sut.state.selectedArtistList.contains { $0.id == 2 })
+        #expect(sut.state.selectedArtistList.contains { $0.id == 1 })
+        #expect(sut.state.selectedArtistList.contains { $0.id == 3 })
+    }
+    
+    // MARK: - 최대 선택 토스트 테스트
+    
+    @Test("최대 선택 수를 초과하려고 하면 isMaxSelectionToastPresented가 true여야 한다")
+    func testExceedMaxSelectionFlagWhenAddingOverLimit() async {
+        let sut = ArtistSelectionStore()
+        await sut.send(.onAppear)
+        await sut.send(.toggle(id: 1))
+        await sut.send(.toggle(id: 2))
+        await sut.send(.toggle(id: 3))
+        
+        await sut.send(.toggle(id: 4))
+        
+        #expect(sut.state.isMaxSelectionToastPresented)
+    }
+    
+    @Test("선택이 유효하게 변경되면 isMaxSelectionToastPresented는 false여야 한다")
+    func testExceedMaxSelectionResetOnValidToggle() async {
+        let sut = ArtistSelectionStore()
+        await sut.send(.onAppear)
+        await sut.send(.toggle(id: 1))
+        await sut.send(.toggle(id: 2))
+        await sut.send(.toggle(id: 3))
+        await sut.send(.toggle(id: 4))
+        
+        await sut.send(.toggle(id: 3))  // 하나 제거
+        
+        #expect(!sut.state.isMaxSelectionToastPresented)
+    }
+    
+    @Test("resetMaxSelectionToast intent는 isMaxSelectionToastPresented를 false로 만든다")
+    func testResetMaxSelectionToastIntent() async {
+        let sut = ArtistSelectionStore()
+        await sut.send(.onAppear)
+        await sut.send(.toggle(id: 1))
+        await sut.send(.toggle(id: 2))
+        await sut.send(.toggle(id: 3))
+        await sut.send(.toggle(id: 4))
+        
+        await sut.send(.resetMaxSelectionToast)
+        
+        #expect(!sut.state.isMaxSelectionToastPresented)
+    }
+    
+    @Test("새 아티스트 선택 시 isMaxSelectionToastPresented는 false여야 한다")
+    func testAddingArtistResetsToastFlag() async {
+        let sut = ArtistSelectionStore()
+        await sut.send(.onAppear)
+        
+        await sut.send(.toggle(id: 1))
+        
+        #expect(!sut.state.isMaxSelectionToastPresented)
+    }
+}


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 선호 아티스트 모델을 선언하였습니다.
- MVI 로직에 대한 테스트 케이스를 작성하였습니다.
- UI를 구현하였습니다.

|    구현 내용    |   iPhone 16   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/bd26b064-8139-4d12-8edd-d081a13181fa" width=250> |

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 칩만 따로 올라오는 것을 구현하지 못했습니다. 2시간 넘게 투자해 보았으나 실패하고 인정하여 일단 기능 개발에 착수하려고 합니다.

## 🔗 연결된 이슈
- Resolved: #188
