### PR TITLE
[Feat] 관심 설정 등 API 로직 구현

### DIFF
--- a/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/FetchArtistList.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/FetchArtistList.swift
@@ -1,0 +1,31 @@
+//
+//  FetchArtistList.swift
+//  LivithNetwork
+//
+//  Created by 김진웅 on 2/4/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+public extension DTO.Response {
+    struct FetchArtistList: Decodable {
+        public let data: [Artist]
+        public let cursor: Int?
+        public let totalCount: Int?
+        
+        public struct Artist: Decodable {
+            public let id: Int
+            public let name: String
+            public let genreId: Int
+            public let imageURLString: String?
+            
+            enum CodingKeys: String, CodingKey {
+                case id
+                case name
+                case genreId
+                case imageURLString = "imgUrl"
+            }
+        }
+    }
+}

--- a/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/FetchGenreList.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/FetchGenreList.swift
@@ -1,0 +1,27 @@
+//
+//  FetchGenreList.swift
+//  LivithNetwork
+//
+//  Created by 김진웅 on 2/4/2026.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - 39. 장르 목록 조회
+
+public extension DTO.Response {
+    typealias FetchGenreList = [FetchGenre]
+    
+    struct FetchGenre: Decodable {
+        public let id: Int
+        public let name: String
+        public let imageURLString: String
+        
+        public enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case imageURLString = "imgUrl"
+        }
+    }
+}

--- a/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/FetchUserPreferredArtistList.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/FetchUserPreferredArtistList.swift
@@ -1,0 +1,29 @@
+//
+//  FetchUserPreferredArtistList.swift
+//  LivithNetwork
+//
+//  Created by 김진웅 on 2/4/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - 38. 유저 취향 아티스트 조회
+
+public extension DTO.Response {
+    typealias FetchUserPreferredArtistList = [UserPreferredArtist]
+    
+    struct UserPreferredArtist: Decodable {
+        public let id: Int
+        public let userId: Int
+        public let name: String
+        public let imageURLString: String?
+        
+        enum CodingKeys: String, CodingKey {
+            case id
+            case userId
+            case name
+            case imageURLString = "imgUrl"
+        }
+    }
+}

--- a/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/FetchUserPreferredArtistList.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/FetchUserPreferredArtistList.swift
@@ -15,13 +15,13 @@ public extension DTO.Response {
     
     struct UserPreferredArtist: Decodable {
         public let id: Int
-        public let userId: Int
+        public let genreID: Int
         public let name: String
         public let imageURLString: String?
         
         enum CodingKeys: String, CodingKey {
             case id
-            case userId
+            case genreID = "genreId"
             case name
             case imageURLString = "imgUrl"
         }

--- a/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/FetchUserPreferredGenreList.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/FetchUserPreferredGenreList.swift
@@ -15,13 +15,13 @@ public extension DTO.Response {
     
     struct UserPreferredGenre: Decodable {
         public let id: Int
-        public let userId: Int
+        public let userID: Int
         public let name: String
         public let imageURLString: String?
         
         enum CodingKeys: String, CodingKey {
             case id
-            case userId
+            case userID = "userId"
             case name
             case imageURLString = "imgUrl"
         }

--- a/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/FetchUserPreferredGenreList.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/FetchUserPreferredGenreList.swift
@@ -1,0 +1,29 @@
+//
+//  FetchUserPreferredGenreList.swift
+//  LivithNetwork
+//
+//  Created by 김진웅 on 2/4/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - 37. 유저 취향 장르 조회, 42. 유저 취향 장르 설정/변경
+
+public extension DTO.Response {
+    typealias FetchUserPreferredGenreList = [UserPreferredGenre]
+    
+    struct UserPreferredGenre: Decodable {
+        public let id: Int
+        public let userId: Int
+        public let name: String
+        public let imageURLString: String?
+        
+        enum CodingKeys: String, CodingKey {
+            case id
+            case userId
+            case name
+            case imageURLString = "imgUrl"
+        }
+    }
+}

--- a/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/SearchArtistList.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/SearchArtistList.swift
@@ -1,5 +1,5 @@
 //
-//  FetchArtistList.swift
+//  SearchArtistList.swift
 //  LivithNetwork
 //
 //  Created by 김진웅 on 2/4/26.
@@ -8,8 +8,10 @@
 
 import Foundation
 
+// MARK: - 40. 대표 아티스트 검색 결과 목록 조회
+
 public extension DTO.Response {
-    struct FetchArtistList: Decodable {
+    struct SearchArtistList: Decodable {
         public let data: [Artist]
         public let cursor: Int?
         public let totalCount: Int?

--- a/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/UpdateUserPreferredArtistList.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/UpdateUserPreferredArtistList.swift
@@ -25,6 +25,21 @@ public extension DTO.Request {
 }
 
 public extension DTO.Response {
-    /// API 명세상 조회 API와 동일한 응답
-    typealias UpdateUserPreferredArtistList = FetchUserPreferredArtistList
+    typealias UpdateUserPreferredArtistList = [UpdatedUserPreferredArtist]
+    
+    struct UpdatedUserPreferredArtist: Decodable {
+        public let id: Int
+        public let userID: Int
+        public let genreID: Int
+        public let name: String
+        public let imageURLString: String?
+        
+        enum CodingKeys: String, CodingKey {
+            case id
+            case userID = "userId"
+            case genreID = "genreId"
+            case name
+            case imageURLString = "imgUrl"
+        }
+    }
 }

--- a/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/UpdateUserPreferredArtistList.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/UpdateUserPreferredArtistList.swift
@@ -1,0 +1,30 @@
+//
+//  UpdateUserPreferredArtistList.swift
+//  LivithNetwork
+//
+//  Created by 김진웅 on 2/4/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - 43. 유저 취향 아티스트 설정/변경
+
+public extension DTO.Request {
+    struct UpdateUserPreferredArtistList: Encodable {
+        public let artistIDs: [Int]
+        
+        public init(artistIDs: [Int]) {
+            self.artistIDs = artistIDs
+        }
+        
+        enum CodingKeys: String, CodingKey {
+            case artistIDs = "artistIds"
+        }
+    }
+}
+
+public extension DTO.Response {
+    /// API 명세상 조회 API와 동일한 응답
+    typealias UpdateUserPreferredArtistList = FetchUserPreferredArtistList
+}

--- a/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/UpdateUserPreferredArtistList.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/UpdateUserPreferredArtistList.swift
@@ -12,14 +12,14 @@ import Foundation
 
 public extension DTO.Request {
     struct UpdateUserPreferredArtistList: Encodable {
-        public let artistIDs: [Int]
+        public let artistIDList: [Int]
         
         public init(artistIDs: [Int]) {
-            self.artistIDs = artistIDs
+            self.artistIDList = artistIDs
         }
         
         enum CodingKeys: String, CodingKey {
-            case artistIDs = "artistIds"
+            case artistIDList = "artistIds"
         }
     }
 }

--- a/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/UpdateUserPreferredGenreList.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/UpdateUserPreferredGenreList.swift
@@ -12,14 +12,14 @@ import Foundation
 
 public extension DTO.Request {
     struct UpdateUserPreferredGenreList: Encodable {
-        public let genreIDs: [Int]
+        public let genreIDList: [Int]
         
         public init(genreIDs: [Int]) {
-            self.genreIDs = genreIDs
+            self.genreIDList = genreIDs
         }
         
         enum CodingKeys: String, CodingKey {
-            case genreIDs = "genreIds"
+            case genreIDList = "genreIds"
         }
     }
 }

--- a/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/UpdateUserPreferredGenreList.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/UpdateUserPreferredGenreList.swift
@@ -1,0 +1,30 @@
+//
+//  UpdateUserPreferredGenreList.swift
+//  LivithNetwork
+//
+//  Created by 김진웅 on 2/4/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - 42. 유저 취향 장르 설정/변경
+
+public extension DTO.Request {
+    struct UpdateUserPreferredGenreList: Encodable {
+        public let genreIDs: [Int]
+        
+        public init(genreIDs: [Int]) {
+            self.genreIDs = genreIDs
+        }
+        
+        enum CodingKeys: String, CodingKey {
+            case genreIDs = "genreIds"
+        }
+    }
+}
+
+public extension DTO.Response {
+    /// API 명세상 조회 API와 동일한 응답
+    typealias UpdateUserPreferredGenreList = FetchUserPreferredGenreList
+}

--- a/Projects/Core/LivithNetwork/Sources/Endpoint/PreferenceEndpoint.swift
+++ b/Projects/Core/LivithNetwork/Sources/Endpoint/PreferenceEndpoint.swift
@@ -1,0 +1,79 @@
+//
+//  PreferenceEndpoint.swift
+//  LivithNetwork
+//
+//  Created by 김진웅 on 2/4/2026.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+public typealias PreferenceService = NetworkService<PreferenceEndpoint>
+
+public enum PreferenceEndpoint {
+    case fetchGenreList
+    case fetchArtistList(keyword: String?, size: Int?, cursor: String?)
+    case fetchUserPreferredGenreList
+    case fetchUserPreferredArtistList
+    case updateUserPreferredGenreList(genreIDs: [Int])
+    case updateUserPreferredArtistList(artistIDs: [Int])
+}
+
+extension PreferenceEndpoint: NetworkEndpoint {
+    public var path: String? {
+        switch self {
+        case .fetchGenreList:
+            return "/genres"
+        case .fetchArtistList:
+            return "/artists"
+        case .fetchUserPreferredGenreList, .updateUserPreferredGenreList:
+            return "/users/genre-preferences"
+        case .fetchUserPreferredArtistList, .updateUserPreferredArtistList:
+            return "/users/artist-preferences"
+        }
+    }
+    
+    public var method: HTTPMethod {
+        switch self {
+        case .fetchGenreList, .fetchArtistList, .fetchUserPreferredGenreList, .fetchUserPreferredArtistList:
+            return .get
+        case .updateUserPreferredGenreList, .updateUserPreferredArtistList:
+            return .put
+        }
+    }
+    
+    public var query: [String: Any]? {
+        switch self {
+        case .fetchArtistList(let keyword, let size, let cursor):
+            let query: [String: Any?] = [
+                "cursor": cursor,
+                "size": size,
+                "keyword": keyword
+            ]
+            return query.compactMapValues { $0 }
+        default:
+            return nil
+        }
+    }
+
+    public var body: Encodable? {
+        switch self {
+        case .updateUserPreferredGenreList(let genreIDs):
+            return DTO.Request.UpdateUserPreferredGenreList(genreIDs: genreIDs)
+        case .updateUserPreferredArtistList(let artistIDs):
+            return DTO.Request.UpdateUserPreferredArtistList(artistIDs: artistIDs)
+        default:
+            return nil
+        }
+    }
+    
+    public var requiresInterceptor: Bool {
+        switch self {
+        case .fetchGenreList, .fetchArtistList:
+            return false
+        case .fetchUserPreferredGenreList, .fetchUserPreferredArtistList,
+             .updateUserPreferredGenreList, .updateUserPreferredArtistList:
+            return true
+        }
+    }
+}

--- a/Projects/Core/LivithNetwork/Sources/Endpoint/PreferenceEndpoint.swift
+++ b/Projects/Core/LivithNetwork/Sources/Endpoint/PreferenceEndpoint.swift
@@ -25,7 +25,7 @@ extension PreferenceEndpoint: NetworkEndpoint {
         case .fetchGenreList:
             return "/genres"
         case .searchArtistList:
-            return "/artists"
+            return "/search/artists"
         case .fetchUserPreferredGenreList, .updateUserPreferredGenreList:
             return "/users/genre-preferences"
         case .fetchUserPreferredArtistList, .updateUserPreferredArtistList:

--- a/Projects/Core/LivithNetwork/Sources/Endpoint/PreferenceEndpoint.swift
+++ b/Projects/Core/LivithNetwork/Sources/Endpoint/PreferenceEndpoint.swift
@@ -12,7 +12,7 @@ public typealias PreferenceService = NetworkService<PreferenceEndpoint>
 
 public enum PreferenceEndpoint {
     case fetchGenreList
-    case fetchArtistList(keyword: String?, size: Int?, cursor: String?)
+    case searchArtistList(keyword: String?, size: Int?, cursor: String?)
     case fetchUserPreferredGenreList
     case fetchUserPreferredArtistList
     case updateUserPreferredGenreList(genreIDs: [Int])
@@ -24,7 +24,7 @@ extension PreferenceEndpoint: NetworkEndpoint {
         switch self {
         case .fetchGenreList:
             return "/genres"
-        case .fetchArtistList:
+        case .searchArtistList:
             return "/artists"
         case .fetchUserPreferredGenreList, .updateUserPreferredGenreList:
             return "/users/genre-preferences"
@@ -35,7 +35,7 @@ extension PreferenceEndpoint: NetworkEndpoint {
     
     public var method: HTTPMethod {
         switch self {
-        case .fetchGenreList, .fetchArtistList, .fetchUserPreferredGenreList, .fetchUserPreferredArtistList:
+        case .fetchGenreList, .searchArtistList, .fetchUserPreferredGenreList, .fetchUserPreferredArtistList:
             return .get
         case .updateUserPreferredGenreList, .updateUserPreferredArtistList:
             return .put
@@ -44,7 +44,7 @@ extension PreferenceEndpoint: NetworkEndpoint {
     
     public var query: [String: Any]? {
         switch self {
-        case .fetchArtistList(let keyword, let size, let cursor):
+        case .searchArtistList(let keyword, let size, let cursor):
             let query: [String: Any?] = [
                 "cursor": cursor,
                 "size": size,
@@ -69,7 +69,7 @@ extension PreferenceEndpoint: NetworkEndpoint {
     
     public var requiresInterceptor: Bool {
         switch self {
-        case .fetchGenreList, .fetchArtistList:
+        case .fetchGenreList, .searchArtistList:
             return false
         case .fetchUserPreferredGenreList, .fetchUserPreferredArtistList,
              .updateUserPreferredGenreList, .updateUserPreferredArtistList:

--- a/Projects/Core/LivithNetwork/Tests/PreferenceDTODecodingTests.swift
+++ b/Projects/Core/LivithNetwork/Tests/PreferenceDTODecodingTests.swift
@@ -134,13 +134,13 @@ struct PreferenceDTODecodingTests {
         
         let firstGenre = result[0]
         #expect(firstGenre.id == 1)
-        #expect(firstGenre.userId == 1)
+        #expect(firstGenre.userID == 1)
         #expect(firstGenre.name == "JPOP")
         #expect(firstGenre.imageURLString == "https://i.imgur.com/Odi5v7K.jpeg")
         
         let secondGenre = result[1]
         #expect(secondGenre.id == 2)
-        #expect(secondGenre.userId == 1)
+        #expect(secondGenre.userID == 1)
         #expect(secondGenre.name == "ROCK_METAL")
         #expect(secondGenre.imageURLString == "https://i.imgur.com/uCkAExC.jpeg")
     }
@@ -166,13 +166,13 @@ struct PreferenceDTODecodingTests {
         [
           {
             "id": 1,
-            "userId": 1,
+            "genreId": 1,
             "name": "Lisa",
             "imgUrl": "https://yt3.ggpht.com/n03wNjboLyFI5IZmagYapJASpYH6H7d9deJx4WGTRxwRKPOQaYgOSgudEuPBKl__Xz3LwjR11Q=s800-c-k-c0xffffffff-no-rj-mo"
           },
           {
             "id": 4,
-            "userId": 1,
+            "genreId": 2,
             "name": "Ado",
             "imgUrl": "https://yt3.ggpht.com/BKpE74RwbPJ8zLaad9Y2XoX7SmIEsoma1KB8dNzwtWwiOqgTNnYI_guEP1iAaTBrdk4nHakx=s800-c-k-c0xffffffff-no-rj-mo"
           }
@@ -187,13 +187,13 @@ struct PreferenceDTODecodingTests {
         
         let firstArtist = result[0]
         #expect(firstArtist.id == 1)
-        #expect(firstArtist.userId == 1)
+        #expect(firstArtist.genreID == 1)
         #expect(firstArtist.name == "Lisa")
         #expect(firstArtist.imageURLString != nil)
         
         let secondArtist = result[1]
         #expect(secondArtist.id == 4)
-        #expect(secondArtist.userId == 1)
+        #expect(secondArtist.genreID == 2)
         #expect(secondArtist.name == "Ado")
     }
     

--- a/Projects/Core/LivithNetwork/Tests/PreferenceDTODecodingTests.swift
+++ b/Projects/Core/LivithNetwork/Tests/PreferenceDTODecodingTests.swift
@@ -40,7 +40,7 @@ struct PreferenceDTODecodingTests {
         """.data(using: .utf8)!
         
         // When
-        let result = try JSONDecoder().decode(DTO.Response.FetchArtistList.self, from: json)
+        let result = try JSONDecoder().decode(DTO.Response.SearchArtistList.self, from: json)
         
         // Then
         #expect(result.data.count == 2)
@@ -70,7 +70,7 @@ struct PreferenceDTODecodingTests {
         """.data(using: .utf8)!
         
         // When
-        let result = try JSONDecoder().decode(DTO.Response.FetchArtistList.self, from: json)
+        let result = try JSONDecoder().decode(DTO.Response.SearchArtistList.self, from: json)
         
         // Then
         #expect(result.data.isEmpty)
@@ -97,7 +97,7 @@ struct PreferenceDTODecodingTests {
         """.data(using: .utf8)!
         
         // When
-        let result = try JSONDecoder().decode(DTO.Response.FetchArtistList.self, from: json)
+        let result = try JSONDecoder().decode(DTO.Response.SearchArtistList.self, from: json)
         
         // Then
         #expect(result.data.count == 1)

--- a/Projects/Core/LivithNetwork/Tests/PreferenceDTODecodingTests.swift
+++ b/Projects/Core/LivithNetwork/Tests/PreferenceDTODecodingTests.swift
@@ -1,0 +1,211 @@
+//
+//  PreferenceDTODecodingTests.swift
+//  LivithNetworkTests
+//
+//  Created by 김진웅 on 2/4/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+import Testing
+
+@testable import LivithNetwork
+
+struct PreferenceDTODecodingTests {
+    
+    // MARK: - FetchArtistList Tests
+    
+    @Test("FetchArtistList 디코딩이 정상적으로 되어야 한다")
+    func fetchArtistList_디코딩이_정상적으로_되어야_한다() throws {
+        // Given
+        let json = """
+        {
+          "data": [
+            {
+              "id": 1,
+              "name": "Lisa",
+              "genreId": 1,
+              "imgUrl": "https://yt3.ggpht.com/n03wNjboLyFI5IZmagYapJASpYH6H7d9deJx4WGTRxwRKPOQaYgOSgudEuPBKl__Xz3LwjR11Q=s800-c-k-c0xffffffff-no-rj-mo"
+            },
+            {
+              "id": 2,
+              "name": "YOASOBI",
+              "genreId": 1,
+              "imgUrl": "https://yt3.ggpht.com/WrZt7XVfe0ZoFRtYCxbOM0gSWp2baxrwxw4o1HQIPJZvamwJXHj6dLjbtJmn369lnl8GdY1k=s800-c-k-c0xffffffff-no-rj-mo"
+            }
+          ],
+          "cursor": 18,
+          "totalCount": 747
+        }
+        """.data(using: .utf8)!
+        
+        // When
+        let result = try JSONDecoder().decode(DTO.Response.FetchArtistList.self, from: json)
+        
+        // Then
+        #expect(result.data.count == 2)
+        #expect(result.cursor == 18)
+        #expect(result.totalCount == 747)
+        
+        let firstArtist = result.data[0]
+        #expect(firstArtist.id == 1)
+        #expect(firstArtist.name == "Lisa")
+        #expect(firstArtist.genreId == 1)
+        #expect(firstArtist.imageURLString != nil)
+        
+        let secondArtist = result.data[1]
+        #expect(secondArtist.id == 2)
+        #expect(secondArtist.name == "YOASOBI")
+    }
+    
+    @Test("FetchArtistList cursor가 nil일때 디코딩이 되어야 한다")
+    func fetchArtistList_cursor가_nil일때_디코딩이_되어야_한다() throws {
+        // Given
+        let json = """
+        {
+          "data": [],
+          "cursor": null,
+          "totalCount": 0
+        }
+        """.data(using: .utf8)!
+        
+        // When
+        let result = try JSONDecoder().decode(DTO.Response.FetchArtistList.self, from: json)
+        
+        // Then
+        #expect(result.data.isEmpty)
+        #expect(result.cursor == nil)
+        #expect(result.totalCount == 0)
+    }
+    
+    @Test("FetchArtistList imgUrl이 nil일때 디코딩이 되어야 한다")
+    func fetchArtistList_imgUrl이_nil일때_디코딩이_되어야_한다() throws {
+        // Given
+        let json = """
+        {
+          "data": [
+            {
+              "id": 1,
+              "name": "Test Artist",
+              "genreId": 2,
+              "imgUrl": null
+            }
+          ],
+          "cursor": 1,
+          "totalCount": 1
+        }
+        """.data(using: .utf8)!
+        
+        // When
+        let result = try JSONDecoder().decode(DTO.Response.FetchArtistList.self, from: json)
+        
+        // Then
+        #expect(result.data.count == 1)
+        #expect(result.data[0].imageURLString == nil)
+    }
+    
+    // MARK: - FetchUserPreferredGenreList Tests
+    
+    @Test("FetchUserPreferredGenreList 디코딩이 정상적으로 되어야 한다")
+    func fetchUserPreferredGenreList_디코딩이_정상적으로_되어야_한다() throws {
+        // Given
+        let json = """
+        [
+          {
+            "id": 1,
+            "userId": 1,
+            "name": "JPOP",
+            "imgUrl": "https://i.imgur.com/Odi5v7K.jpeg"
+          },
+          {
+            "id": 2,
+            "userId": 1,
+            "name": "ROCK_METAL",
+            "imgUrl": "https://i.imgur.com/uCkAExC.jpeg"
+          }
+        ]
+        """.data(using: .utf8)!
+        
+        // When
+        let result = try JSONDecoder().decode(DTO.Response.FetchUserPreferredGenreList.self, from: json)
+        
+        // Then
+        #expect(result.count == 2)
+        
+        let firstGenre = result[0]
+        #expect(firstGenre.id == 1)
+        #expect(firstGenre.userId == 1)
+        #expect(firstGenre.name == "JPOP")
+        #expect(firstGenre.imageURLString == "https://i.imgur.com/Odi5v7K.jpeg")
+        
+        let secondGenre = result[1]
+        #expect(secondGenre.id == 2)
+        #expect(secondGenre.userId == 1)
+        #expect(secondGenre.name == "ROCK_METAL")
+        #expect(secondGenre.imageURLString == "https://i.imgur.com/uCkAExC.jpeg")
+    }
+    
+    @Test("FetchUserPreferredGenreList 빈 배열일때 디코딩이 되어야 한다")
+    func fetchUserPreferredGenreList_빈_배열일때_디코딩이_되어야_한다() throws {
+        // Given
+        let json = "[]".data(using: .utf8)!
+        
+        // When
+        let result = try JSONDecoder().decode(DTO.Response.FetchUserPreferredGenreList.self, from: json)
+        
+        // Then
+        #expect(result.isEmpty)
+    }
+    
+    // MARK: - FetchUserPreferredArtistList Tests
+    
+    @Test("FetchUserPreferredArtistList 디코딩이 정상적으로 되어야 한다")
+    func fetchUserPreferredArtistList_디코딩이_정상적으로_되어야_한다() throws {
+        // Given
+        let json = """
+        [
+          {
+            "id": 1,
+            "userId": 1,
+            "name": "Lisa",
+            "imgUrl": "https://yt3.ggpht.com/n03wNjboLyFI5IZmagYapJASpYH6H7d9deJx4WGTRxwRKPOQaYgOSgudEuPBKl__Xz3LwjR11Q=s800-c-k-c0xffffffff-no-rj-mo"
+          },
+          {
+            "id": 4,
+            "userId": 1,
+            "name": "Ado",
+            "imgUrl": "https://yt3.ggpht.com/BKpE74RwbPJ8zLaad9Y2XoX7SmIEsoma1KB8dNzwtWwiOqgTNnYI_guEP1iAaTBrdk4nHakx=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        ]
+        """.data(using: .utf8)!
+        
+        // When
+        let result = try JSONDecoder().decode(DTO.Response.FetchUserPreferredArtistList.self, from: json)
+        
+        // Then
+        #expect(result.count == 2)
+        
+        let firstArtist = result[0]
+        #expect(firstArtist.id == 1)
+        #expect(firstArtist.userId == 1)
+        #expect(firstArtist.name == "Lisa")
+        #expect(firstArtist.imageURLString != nil)
+        
+        let secondArtist = result[1]
+        #expect(secondArtist.id == 4)
+        #expect(secondArtist.userId == 1)
+        #expect(secondArtist.name == "Ado")
+    }
+    
+    @Test("FetchUserPreferredArtistList 빈 배열일때 디코딩이 되어야 한다")
+    func fetchUserPreferredArtistList_빈_배열일때_디코딩이_되어야_한다() throws {
+        // Given
+        let json = "[]".data(using: .utf8)!
+        
+        // When
+        let result = try JSONDecoder().decode(DTO.Response.FetchUserPreferredArtistList.self, from: json)
+        
+        // Then
+        #expect(result.isEmpty)
+    }
+}

--- a/Projects/Core/Project.swift
+++ b/Projects/Core/Project.swift
@@ -25,6 +25,13 @@ let project = Project.make(
             settings: .environment
         ),
         .make(
+            target: .core(.livithNetworkTests),
+            product: .unitTests,
+            dependencies: [
+                .core(.livithNetwork)
+            ]
+        ),
+        .make(
             target: .core(.persistence),
             product: .framework,
             dependencies: [

--- a/Projects/Data/PreferenceData/Sources/Assembler/PreferenceDataAssembler.swift
+++ b/Projects/Data/PreferenceData/Sources/Assembler/PreferenceDataAssembler.swift
@@ -1,0 +1,41 @@
+//
+//  PreferenceDataAssembler.swift
+//  PreferenceData
+//
+//  Created by 김진웅 on 2/4/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+import DIContainer
+import Domain
+import LivithNetwork
+
+public struct PreferenceDataAssembler: DependencyAssembler {
+    public init() {}
+    
+    public func assemble(to container: any DependencyContainer) {
+        registerNetwork(to: container)
+        registerRepository(to: container)
+    }
+}
+
+// MARK: - Network Registration
+
+private extension PreferenceDataAssembler {
+    func registerNetwork(to container: any DependencyContainer) {
+        container.register(PreferenceService(), for: PreferenceService.self)
+    }
+}
+
+// MARK: - Repository Registration
+
+private extension PreferenceDataAssembler {
+    func registerRepository(to container: any DependencyContainer) {
+        let preferenceRepo = PreferenceRepositoryImpl(
+            preferenceService: container.resolve(PreferenceService.self)
+        )
+        container.register(preferenceRepo, for: PreferenceRepository.self)
+    }
+}

--- a/Projects/Data/PreferenceData/Sources/Mapper/PreferenceErrorMapper.swift
+++ b/Projects/Data/PreferenceData/Sources/Mapper/PreferenceErrorMapper.swift
@@ -1,0 +1,72 @@
+//
+//  PreferenceErrorMapper.swift
+//  PreferenceData
+//
+//  Created by 김진웅 on 2/4/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+import LivithNetwork
+
+struct PreferenceErrorMapper {
+    func mapToPreferenceError(_ error: Error) -> PreferenceError {
+        if error is CancellationError {
+            return .cancelled
+        }
+        
+        if let urlError = error as? URLError, urlError.code == .cancelled {
+            return .cancelled
+        }
+        
+        guard let networkError = error as? NetworkError else {
+            return .unknown
+        }
+        
+        return mapNetworkError(networkError)
+    }
+    
+    private func mapNetworkError(_ error: NetworkError) -> PreferenceError {
+        switch error {
+        case .noConnection(let underlyingError):
+            if let urlError = underlyingError as? URLError, urlError.code == .cancelled {
+                return .cancelled
+            }
+            return .noConnection
+            
+        case .serverError:
+            return .serverError
+            
+        case .noData, .decodingFailed, .invalidURL, .invalidRequest, .invalidResponse:
+            return .invalidResponse
+            
+        case .badRequest(let message):
+            return mapFromMessage(message)
+            
+        case .unauthorized:
+            return .unknown
+            
+        case .forbidden(let message):
+            return mapFromMessage(message)
+            
+        case .notFound(let message):
+            return mapFromMessage(message)
+            
+        case .clientError:
+            return .invalidResponse
+            
+        case .unknown(let underlyingError):
+            if let urlError = underlyingError as? URLError, urlError.code == .cancelled {
+                return .cancelled
+            }
+            return .unknown
+        }
+    }
+    
+    private func mapFromMessage(_ message: String?) -> PreferenceError {
+        guard let message else { return .unknown }
+        return PreferenceError.from(message: message)
+    }
+}

--- a/Projects/Data/PreferenceData/Sources/Mapper/PreferenceMapper.swift
+++ b/Projects/Data/PreferenceData/Sources/Mapper/PreferenceMapper.swift
@@ -54,7 +54,18 @@ struct PreferenceMapper {
             PreferredArtist(
                 id: artist.id,
                 name: artist.name,
-                genreID: 0, // User preferred artist doesn't have genreID in response
+                genreID: artist.genreID,
+                imageURL: artist.imageURLString.flatMap { URL(string: $0) }
+            )
+        }
+    }
+    
+    func toDomain(from dto: DTO.Response.UpdateUserPreferredArtistList) -> [PreferredArtist] {
+        dto.map { artist in
+            PreferredArtist(
+                id: artist.id,
+                name: artist.name,
+                genreID: artist.genreID,
                 imageURL: artist.imageURLString.flatMap { URL(string: $0) }
             )
         }

--- a/Projects/Data/PreferenceData/Sources/Mapper/PreferenceMapper.swift
+++ b/Projects/Data/PreferenceData/Sources/Mapper/PreferenceMapper.swift
@@ -23,7 +23,7 @@ struct PreferenceMapper {
         }
     }
     
-    func toDomain(from dto: DTO.Response.FetchArtistList) -> ArtistSearchResult {
+    func toDomain(from dto: DTO.Response.SearchArtistList) -> ArtistSearchResult {
         let artists = dto.data.map { artist in
             PreferredArtist(
                 id: artist.id,

--- a/Projects/Data/PreferenceData/Sources/Mapper/PreferenceMapper.swift
+++ b/Projects/Data/PreferenceData/Sources/Mapper/PreferenceMapper.swift
@@ -1,0 +1,62 @@
+//
+//  PreferenceMapper.swift
+//  PreferenceData
+//
+//  Created by 김진웅 on 2/4/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+import LivithNetwork
+
+struct PreferenceMapper {
+    func toDomain(from dto: DTO.Response.FetchGenreList) -> [PreferredGenre] {
+        dto.compactMap { genre -> PreferredGenre? in
+            guard let imageURL = URL(string: genre.imageURLString) else { return nil }
+            return PreferredGenre(
+                id: genre.id,
+                name: genre.name,
+                imageURL: imageURL
+            )
+        }
+    }
+    
+    func toDomain(from dto: DTO.Response.FetchArtistList) -> ArtistSearchResult {
+        let artists = dto.data.map { artist in
+            PreferredArtist(
+                id: artist.id,
+                name: artist.name,
+                genreID: artist.genreId,
+                imageURL: artist.imageURLString.flatMap { URL(string: $0) }
+            )
+        }
+        return ArtistSearchResult(
+            artists: artists,
+            cursor: dto.cursor,
+            totalCount: dto.totalCount
+        )
+    }
+    
+    func toDomain(from dto: DTO.Response.FetchUserPreferredGenreList) -> [PreferredGenre] {
+        dto.map { genre -> PreferredGenre in
+            return PreferredGenre(
+                id: genre.id,
+                name: genre.name,
+                imageURL: genre.imageURLString.flatMap { URL(string: $0) }
+            )
+        }
+    }
+    
+    func toDomain(from dto: DTO.Response.FetchUserPreferredArtistList) -> [PreferredArtist] {
+        dto.map { artist in
+            PreferredArtist(
+                id: artist.id,
+                name: artist.name,
+                genreID: 0, // User preferred artist doesn't have genreID in response
+                imageURL: artist.imageURLString.flatMap { URL(string: $0) }
+            )
+        }
+    }
+}

--- a/Projects/Data/PreferenceData/Sources/Repository/PreferenceRepositoryImpl.swift
+++ b/Projects/Data/PreferenceData/Sources/Repository/PreferenceRepositoryImpl.swift
@@ -35,7 +35,7 @@ struct PreferenceRepositoryImpl: PreferenceRepository {
         cursor: String?
     ) async throws(PreferenceError) -> ArtistSearchResult {
         do {
-            let response: DTO.Response.FetchArtistList = try await preferenceService.request(
+            let response: DTO.Response.SearchArtistList = try await preferenceService.request(
                 .searchArtistList(keyword: keyword, size: size, cursor: cursor)
             )
             return mapper.toDomain(from: response)

--- a/Projects/Data/PreferenceData/Sources/Repository/PreferenceRepositoryImpl.swift
+++ b/Projects/Data/PreferenceData/Sources/Repository/PreferenceRepositoryImpl.swift
@@ -1,0 +1,92 @@
+//
+//  PreferenceRepositoryImpl.swift
+//  PreferenceData
+//
+//  Created by 김진웅 on 2/4/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+import LivithNetwork
+
+struct PreferenceRepositoryImpl: PreferenceRepository {
+    private let preferenceService: PreferenceService
+    private let mapper: PreferenceMapper = .init()
+    private let errorMapper: PreferenceErrorMapper = .init()
+    
+    init(preferenceService: PreferenceService) {
+        self.preferenceService = preferenceService
+    }
+    
+    func fetchGenreList() async throws(PreferenceError) -> [PreferredGenre] {
+        do {
+            let response: DTO.Response.FetchGenreList = try await preferenceService.request(.fetchGenreList)
+            return mapper.toDomain(from: response)
+        } catch {
+            throw errorMapper.mapToPreferenceError(error)
+        }
+    }
+    
+    func searchArtistList(
+        keyword: String?,
+        size: Int?,
+        cursor: String?
+    ) async throws(PreferenceError) -> ArtistSearchResult {
+        do {
+            let response: DTO.Response.FetchArtistList = try await preferenceService.request(
+                .searchArtistList(keyword: keyword, size: size, cursor: cursor)
+            )
+            return mapper.toDomain(from: response)
+        } catch {
+            throw errorMapper.mapToPreferenceError(error)
+        }
+    }
+    
+    func fetchUserPreferredGenreList() async throws(PreferenceError) -> [PreferredGenre] {
+        do {
+            let response: DTO.Response.FetchUserPreferredGenreList = try await preferenceService.request(
+                .fetchUserPreferredGenreList
+            )
+            return mapper.toDomain(from: response)
+        } catch {
+            throw errorMapper.mapToPreferenceError(error)
+        }
+    }
+    
+    func fetchUserPreferredArtistList() async throws(PreferenceError) -> [PreferredArtist] {
+        do {
+            let response: DTO.Response.FetchUserPreferredArtistList = try await preferenceService.request(
+                .fetchUserPreferredArtistList
+            )
+            return mapper.toDomain(from: response)
+        } catch {
+            throw errorMapper.mapToPreferenceError(error)
+        }
+    }
+    
+    @discardableResult
+    func updateUserPreferredGenreList(genreIDs: [Int]) async throws(PreferenceError) -> [PreferredGenre] {
+        do {
+            let response: DTO.Response.UpdateUserPreferredGenreList = try await preferenceService.request(
+                .updateUserPreferredGenreList(genreIDs: genreIDs)
+            )
+            return mapper.toDomain(from: response)
+        } catch {
+            throw errorMapper.mapToPreferenceError(error)
+        }
+    }
+    
+    @discardableResult
+    func updateUserPreferredArtistList(artistIDs: [Int]) async throws(PreferenceError) -> [PreferredArtist] {
+        do {
+            let response: DTO.Response.UpdateUserPreferredArtistList = try await preferenceService.request(
+                .updateUserPreferredArtistList(artistIDs: artistIDs)
+            )
+            return mapper.toDomain(from: response)
+        } catch {
+            throw errorMapper.mapToPreferenceError(error)
+        }
+    }
+}

--- a/Projects/Data/PreferenceData/Tests/PreferenceMapperTests.swift
+++ b/Projects/Data/PreferenceData/Tests/PreferenceMapperTests.swift
@@ -55,7 +55,7 @@ struct PreferenceMapperTests {
         }
         """.data(using: .utf8)!
         
-        let dto = try! JSONDecoder().decode(DTO.Response.FetchArtistList.self, from: json)
+        let dto = try! JSONDecoder().decode(DTO.Response.SearchArtistList.self, from: json)
         
         // When
         let result = mapper.toDomain(from: dto)

--- a/Projects/Data/PreferenceData/Tests/PreferenceMapperTests.swift
+++ b/Projects/Data/PreferenceData/Tests/PreferenceMapperTests.swift
@@ -1,0 +1,90 @@
+//
+//  PreferenceMapperTests.swift
+//  PreferenceDataTests
+//
+//  Created by 김진웅 on 2/4/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import PreferenceData
+@testable import LivithNetwork
+@testable import Domain
+
+@Suite("PreferenceMapper Tests")
+struct PreferenceMapperTests {
+    let mapper = PreferenceMapper()
+    
+    @Test("FetchGenreList를 PreferredGenre 배열로 변환")
+    func fetchGenreListToDomain() {
+        // Given
+        let json = """
+        [
+            {"id": 1, "name": "JPOP", "imgUrl": "https://example.com/jpop.png"},
+            {"id": 2, "name": "ROCK_METAL", "imgUrl": "https://example.com/rock.png"}
+        ]
+        """.data(using: .utf8)!
+        
+        let dto = try! JSONDecoder().decode(DTO.Response.FetchGenreList.self, from: json)
+        
+        // When
+        let result = mapper.toDomain(from: dto)
+        
+        // Then
+        #expect(result.count == 2)
+        #expect(result[0].id == 1)
+        #expect(result[0].name == "JPOP")
+        #expect(result[0].displayName == "J-POP")
+        #expect(result[1].name == "ROCK_METAL")
+        #expect(result[1].displayName == "락/메탈")
+    }
+    
+    @Test("FetchArtistList를 ArtistSearchResult로 변환")
+    func fetchArtistListToDomain() {
+        // Given
+        let json = """
+        {
+            "data": [
+                {"id": 1, "name": "YOASOBI", "genreId": 1, "imgUrl": "https://example.com/yoasobi.png"},
+                {"id": 2, "name": "ONE OK ROCK", "genreId": 2, "imgUrl": null}
+            ],
+            "cursor": 3,
+            "totalCount": 100
+        }
+        """.data(using: .utf8)!
+        
+        let dto = try! JSONDecoder().decode(DTO.Response.FetchArtistList.self, from: json)
+        
+        // When
+        let result = mapper.toDomain(from: dto)
+        
+        // Then
+        #expect(result.artists.count == 2)
+        #expect(result.cursor == 3)
+        #expect(result.totalCount == 100)
+        #expect(result.artists[0].name == "YOASOBI")
+        #expect(result.artists[0].genreID == 1)
+        #expect(result.artists[1].imageURL == nil)
+    }
+    
+    @Test("FetchUserPreferredGenreList를 PreferredGenre 배열로 변환")
+    func fetchUserPreferredGenreListToDomain() {
+        // Given
+        let json = """
+        [
+            {"id": 1, "userId": 123, "name": "JPOP", "imgUrl": "https://example.com/jpop.png"}
+        ]
+        """.data(using: .utf8)!
+        
+        let dto = try! JSONDecoder().decode(DTO.Response.FetchUserPreferredGenreList.self, from: json)
+        
+        // When
+        let result = mapper.toDomain(from: dto)
+        
+        // Then
+        #expect(result.count == 1)
+        #expect(result[0].id == 1)
+        #expect(result[0].name == "JPOP")
+    }
+}

--- a/Projects/Data/PreferenceData/Tests/PreferenceMapperTests.swift
+++ b/Projects/Data/PreferenceData/Tests/PreferenceMapperTests.swift
@@ -8,6 +8,7 @@
 
 import Testing
 import Foundation
+
 @testable import PreferenceData
 @testable import LivithNetwork
 @testable import Domain

--- a/Projects/Data/Project.swift
+++ b/Projects/Data/Project.swift
@@ -65,6 +65,23 @@ let project = Project.make(
             ]
         ),
         .make(
+            target: .data(.preferenceData),
+            product: .framework,
+            dependencies: [
+                .domain(.domain),
+                .core(.diContainer),
+                .core(.livithFoundation),
+                .core(.livithNetwork)
+            ]
+        ),
+        .make(
+            target: .data(.preferenceDataTests),
+            product: .unitTests,
+            dependencies: [
+                .data(.preferenceData)
+            ]
+        ),
+        .make(
             target: .data(.searchData),
             product: .framework,
             dependencies: [

--- a/Projects/Domain/Sources/Entity/Preference/ArtistSearchResult.swift
+++ b/Projects/Domain/Sources/Entity/Preference/ArtistSearchResult.swift
@@ -1,0 +1,25 @@
+//
+//  ArtistSearchResult.swift
+//  Domain
+//
+//  Created by 김진웅 on 2/4/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+public struct ArtistSearchResult {
+    public let artists: [PreferredArtist]
+    public let cursor: Int?
+    public let totalCount: Int?
+    
+    public init(
+        artists: [PreferredArtist],
+        cursor: Int?,
+        totalCount: Int?
+    ) {
+        self.artists = artists
+        self.cursor = cursor
+        self.totalCount = totalCount
+    }
+}

--- a/Projects/Domain/Sources/Entity/Preference/PreferredGenre.swift
+++ b/Projects/Domain/Sources/Entity/Preference/PreferredGenre.swift
@@ -11,9 +11,9 @@ import Foundation
 public struct PreferredGenre: Hashable, Identifiable {
     public let id: Int
     public let name: String
-    public let imageURL: URL
+    public let imageURL: URL?
     
-    public init(id: Int, name: String, imageURL: URL) {
+    public init(id: Int, name: String, imageURL: URL?) {
         self.id = id
         self.name = name
         self.imageURL = imageURL

--- a/Projects/Domain/Sources/Error/PreferenceError.swift
+++ b/Projects/Domain/Sources/Error/PreferenceError.swift
@@ -1,0 +1,111 @@
+//
+//  PreferenceError.swift
+//  Domain
+//
+//  Created by 김진웅 on 2/4/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+public enum PreferenceError: DomainError {
+    // MARK: - Common
+    case noConnection
+    case serverError
+    case invalidResponse
+    case unknown
+    case cancelled
+    
+    // MARK: - User
+    case userNotFound
+    case withdrawn
+    
+    // MARK: - Cursor/Pagination
+    case invalidCursor
+    case invalidSize
+    
+    // MARK: - Genre
+    case genreNotFound
+    case minGenreRequired
+    case maxGenreExceeded
+    case invalidGenreID
+    
+    // MARK: - Artist
+    case artistNotFound
+    case maxArtistExceeded
+    case invalidArtistID
+    
+    public var errorDescription: String? {
+        switch self {
+        case .noConnection:
+            return "네트워크 연결을 확인해주세요."
+        case .serverError:
+            return "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요."
+        case .invalidResponse:
+            return "데이터를 불러오는데 실패했습니다."
+        case .unknown:
+            return "알 수 없는 오류가 발생했습니다."
+        case .cancelled:
+            return "요청이 취소되었습니다."
+        case .userNotFound:
+            return "해당 유저가 존재하지 않습니다."
+        case .withdrawn:
+            return "탈퇴한 회원입니다."
+        case .invalidCursor:
+            return "잘못된 커서 값입니다."
+        case .invalidSize:
+            return "잘못된 사이즈 값입니다."
+        case .genreNotFound:
+            return "해당 장르를 찾을 수 없습니다."
+        case .minGenreRequired:
+            return "최소 1개의 장르는 선택해야 합니다."
+        case .maxGenreExceeded:
+            return "최대 3개의 장르만 선택할 수 있습니다."
+        case .invalidGenreID:
+            return "장르 ID는 숫자여야 합니다."
+        case .artistNotFound:
+            return "해당 아티스트를 찾을 수 없습니다."
+        case .maxArtistExceeded:
+            return "최대 3개의 아티스트만 선택할 수 있습니다."
+        case .invalidArtistID:
+            return "아티스트 ID는 숫자여야 합니다."
+        }
+    }
+    
+    public static func from(message: String) -> PreferenceError {
+        switch message {
+        // User
+        case "해당 유저가 존재하지 않습니다.":
+            return .userNotFound
+        case "탈퇴한 회원입니다.":
+            return .withdrawn
+            
+        // Cursor/Pagination
+        case "cursor must not be less than 1":
+            return .invalidCursor
+        case "size must not be less than 1":
+            return .invalidSize
+            
+        // Genre
+        case "해당 장르를 찾을 수 없습니다.":
+            return .genreNotFound
+        case "최소 1개의 장르는 선택해야 합니다.":
+            return .minGenreRequired
+        case "최대 3개의 장르만 선택할 수 있습니다.":
+            return .maxGenreExceeded
+        case "장르 ID는 숫자여야 합니다.":
+            return .invalidGenreID
+            
+        // Artist
+        case "해당 아티스트를 찾을 수 없습니다.":
+            return .artistNotFound
+        case "최대 3개의 아티스트만 선택할 수 있습니다.":
+            return .maxArtistExceeded
+        case "아티스트 ID는 숫자여야 합니다.":
+            return .invalidArtistID
+            
+        default:
+            return .unknown
+        }
+    }
+}

--- a/Projects/Domain/Sources/Repository/PreferenceRepository.swift
+++ b/Projects/Domain/Sources/Repository/PreferenceRepository.swift
@@ -1,0 +1,24 @@
+//
+//  PreferenceRepository.swift
+//  Domain
+//
+//  Created by 김진웅 on 2/4/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+public protocol PreferenceRepository {
+    func fetchGenreList() async throws(PreferenceError) -> [PreferredGenre]
+    func searchArtistList(
+        keyword: String?,
+        size: Int?,
+        cursor: String?
+    ) async throws(PreferenceError) -> ArtistSearchResult
+    func fetchUserPreferredGenreList() async throws(PreferenceError) -> [PreferredGenre]
+    func fetchUserPreferredArtistList() async throws(PreferenceError) -> [PreferredArtist]
+    @discardableResult
+    func updateUserPreferredGenreList(genreIDs: [Int]) async throws(PreferenceError) -> [PreferredGenre]
+    @discardableResult
+    func updateUserPreferredArtistList(artistIDs: [Int]) async throws(PreferenceError) -> [PreferredArtist]
+}

--- a/Tuist/ProjectDescriptionHelpers/Module/Module+Constant.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module/Module+Constant.swift
@@ -88,6 +88,8 @@ public enum DataModule: String {
     case commentDataTests = "CommentDataTests"
     case concertData = "ConcertData"
     case concertDataTests = "ConcertDataTests"
+    case preferenceData = "PreferenceData"
+    case preferenceDataTests = "PreferenceDataTests"
     case searchData = "SearchData"
     case searchDataTests = "SearchDataTests"
     case setlistData = "SetlistData"

--- a/Tuist/ProjectDescriptionHelpers/Module/Module+Constant.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module/Module+Constant.swift
@@ -13,6 +13,7 @@ public enum CoreModule: String {
     case diContainer = "DIContainer"
     case persistence = "Persistence"
     case livithNetwork = "LivithNetwork"
+    case livithNetworkTests = "LivithNetworkTests"
     case livithFoundation = "LivithFoundation"
     case socialAuth = "SocialAuth"
     case coordinator = "Coordinator"

--- a/Tuist/ProjectDescriptionHelpers/Module/Module+TargetID.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module/Module+TargetID.swift
@@ -126,6 +126,7 @@ private extension TargetID {
             .authDataTests: "AuthData",
             .commentDataTests: "CommentData",
             .concertDataTests: "ConcertData",
+            .preferenceDataTests: "PreferenceData",
             .searchDataTests: "SearchData",
             .setlistDataTests: "SetlistData",
             .songDataTests: "SongData",

--- a/Tuist/ProjectDescriptionHelpers/Module/Module+TargetID.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module/Module+TargetID.swift
@@ -58,7 +58,7 @@ public enum TargetID {
         case .app:
             return ["Sources/**"]
         case .core(let module):
-            return ["\(module.rawValue)/Sources/**"]
+            return coreModuleTestSourcePath(module) ?? ["\(module.rawValue)/Sources/**"]
         case .login:
             return ["Sources/**"]
         case .search:
@@ -112,6 +112,15 @@ public enum TargetID {
 // MARK: - Helpers
 
 private extension TargetID {
+    func coreModuleTestSourcePath(_ module: CoreModule) -> SourceFilesList? {
+        let testModuleMappings: [CoreModule: String] = [
+            .livithNetworkTests: "LivithNetwork"
+        ]
+
+        guard let parentModule = testModuleMappings[module] else { return nil }
+        return ["\(parentModule)/Tests/**"]
+    }
+
     func dataModuleTestSourcePath(_ module: DataModule) -> SourceFilesList? {
         let testModuleMappings: [DataModule: String] = [
             .authDataTests: "AuthData",


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 취향 선택 및 변경 API와 DTO를 추가하였습니다.
- 취향 선택 및 변경과 관련하여 도메인 및 데이터 모듈을 수정, 구현하였습니다.

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 회원가입 플로우를 구현하기에 앞서, 중간 PR로서 취향 선택 및 변경 API 로직을 구성하였습니다.

## 🔗 연결된 이슈
- Resolved: #197 
