### PR TITLE
[Feat] 회원가입 플로우 구현

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -34,6 +34,7 @@ let project = Project.make(
                 .data(.userData),
                 .user(.userFeature),
                 .widget(.widget),
+                .data(.preferenceData)
             ]
         )
     ],

--- a/Projects/App/Sources/LivithApp+InjectDependency.swift
+++ b/Projects/App/Sources/LivithApp+InjectDependency.swift
@@ -16,6 +16,7 @@ import SearchData
 import SetlistData
 import SongData
 import UserData
+import PreferenceData
 
 extension LivithApp {
     func registerDependency() {
@@ -27,7 +28,8 @@ extension LivithApp {
                 SearchDataAssembler(),
                 SetlistDataAssembler(),
                 SongDataAssembler(),
-                UserDataAssembler()
+                UserDataAssembler(),
+                PreferenceDataAssembler()
             ]
         )
     }

--- a/Projects/App/Sources/View/AppRootView.swift
+++ b/Projects/App/Sources/View/AppRootView.swift
@@ -47,8 +47,8 @@ private extension AppRootView {
             LoginContentView(
                 onLoginCompleted: { transition(to: .main) },
                 onSignupCompleted: { nickname in
-                    transition(to: .main)
                     self.nickname = nickname
+                    transition(to: .main)
                     self.showWelcomeSheet = true
                 }
             )

--- a/Projects/Core/LivithNetwork/Sources/DTO/OnboardingFeature/FetchUserInfo.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/OnboardingFeature/FetchUserInfo.swift
@@ -19,30 +19,23 @@ public extension DTO.Response {
         public let email: String?
         public let nickname: String
         public let marketingConsent: Bool
-        
-        public init(
-            id: Int,
-            interestConcertID: Int?,
-            provider: String,
-            providerID: String,
-            email: String?,
-            nickname: String,
-            marketingConsent: Bool
-        ) {
-            self.id = id
-            self.interestConcertID = interestConcertID
-            self.provider = provider
-            self.providerID = providerID
-            self.email = email
-            self.nickname = nickname
-            self.marketingConsent = marketingConsent
-        }
+        public let preferredGenreList: [PreferenceInfo]
+        public let preferredArtistList: [PreferenceInfo]
         
         enum CodingKeys: String, CodingKey {
             case id
             case interestConcertID = "interestConcertId"
             case providerID = "providerId"
             case provider, email, nickname, marketingConsent
+            case preferredGenreList = "preferredGenres"
+            case preferredArtistList = "preferredArtists"
         }
+    }
+}
+
+public extension DTO.Response.FetchUserInfo {
+    struct PreferenceInfo: Codable {
+        public let id: Int
+        public let name: String
     }
 }

--- a/Projects/Core/LivithNetwork/Sources/DTO/OnboardingFeature/Signup.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/OnboardingFeature/Signup.swift
@@ -13,12 +13,34 @@ import Foundation
 public extension DTO.Request {
     struct Signup: Encodable {
         public let nickname: String
-        public let marketingConsent: Bool
-        public let providerID: String
-        public let provider: String
+        public let preferredArtistIDList: [Int]
+        public let preferredGenreIDList: [Int]
         public let email: String?
+        public let provider: String
+        public let providerID: String
+        public let marketingConsent: Bool
+        
+        public init(
+            nickname: String,
+            preferredArtistIDList: [Int],
+            preferredGenreIDList: [Int],
+            email: String?,
+            provider: String,
+            providerID: String,
+            marketingConsent: Bool
+        ) {
+            self.nickname = nickname
+            self.preferredArtistIDList = preferredArtistIDList
+            self.preferredGenreIDList = preferredGenreIDList
+            self.email = email
+            self.provider = provider
+            self.providerID = providerID
+            self.marketingConsent = marketingConsent
+        }
         
         enum CodingKeys: String, CodingKey {
+            case preferredArtistIDList = "preferredArtistIds"
+            case preferredGenreIDList = "preferredGenreIds"
             case nickname, marketingConsent, provider, email
             case providerID = "providerId"
         }

--- a/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/FetchUserPreferredArtistList.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/PreferenceFeature/FetchUserPreferredArtistList.swift
@@ -15,12 +15,14 @@ public extension DTO.Response {
     
     struct UserPreferredArtist: Decodable {
         public let id: Int
+        public let userID: Int
         public let genreID: Int
         public let name: String
         public let imageURLString: String?
         
         enum CodingKeys: String, CodingKey {
             case id
+            case userID = "userId"
             case genreID = "genreId"
             case name
             case imageURLString = "imgUrl"

--- a/Projects/Core/LivithNetwork/Sources/Endpoint/OnboardingEndpoint.swift
+++ b/Projects/Core/LivithNetwork/Sources/Endpoint/OnboardingEndpoint.swift
@@ -13,7 +13,7 @@ public typealias OnboardingService = NetworkService<OnboardingEndpoint>
 public enum OnboardingEndpoint {
     case appleLogin(identityToken: String)
     case kakaoLogin(accessToken: String)
-    case signup(nickname: String, marketingConsent: Bool, providerID: String, provider: String, email: String?)
+    case signup(DTO.Request.Signup)
     case checkNicknameDuplicate(nickname: String)
     case fetchUserInfo
 }
@@ -60,14 +60,8 @@ extension OnboardingEndpoint: NetworkEndpoint {
             return DTO.Request.AppleLogin(identityToken: identityToken)
         case .kakaoLogin(let accessToken):
             return DTO.Request.KakaoLogin(accessToken: accessToken)
-        case .signup(let nickname, let marketingConsent, let providerID, let provider, let email):
-            return DTO.Request.Signup(
-                nickname: nickname,
-                marketingConsent: marketingConsent,
-                providerID: providerID,
-                provider: provider,
-                email: email
-            )
+        case .signup(let requestDTO):
+            return requestDTO
         case .checkNicknameDuplicate:
             return nil
         case .fetchUserInfo:

--- a/Projects/Core/LivithNetwork/Tests/OnboardingFeatureDTOTests.swift
+++ b/Projects/Core/LivithNetwork/Tests/OnboardingFeatureDTOTests.swift
@@ -1,0 +1,71 @@
+//
+//  OnboardingFeatureDTOTests.swift
+//  LivithNetworkTests
+//
+//  Created by antigravity on 2/5/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+import Testing
+
+@testable import LivithNetwork
+
+struct OnboardingFeatureDTOTests {
+    
+    @Test("FetchUserInfo 디코딩이 정상적으로 되어야 한다")
+    func fetchUserInfo_디코딩이_정상적으로_되어야_한다() throws {
+        // Given
+        let json = """
+        {
+            "id": 1,
+            "interestConcertId": null,
+            "provider": "kakao",
+            "providerId": "test_provider_id",
+            "email": null,
+            "nickname": "dev",
+            "marketingConsent": true,
+            "preferredGenres": [
+              {
+                "id": 1,
+                "name": "JPOP"
+              },
+              {
+                "id": 2,
+                "name": "ROCK_METAL"
+              },
+              {
+                "id": 3,
+                "name": "RAP_HIPHOP"
+              }
+            ],
+            "preferredArtists": [
+              {
+                "id": 1,
+                "name": "Lisa"
+              },
+              {
+                "id": 2,
+                "name": "YOASOBI"
+              },
+              {
+                "id": 3,
+                "name": "米津玄師"
+              }
+            ]
+          }
+        """.data(using: .utf8)!
+        
+        // When
+        let result = try JSONDecoder().decode(DTO.Response.FetchUserInfo.self, from: json)
+        
+        // Then
+        #expect(result.id == 1)
+        #expect(result.nickname == "dev")
+        #expect(result.preferredGenreList.count == 3)
+        #expect(result.preferredArtistList.count == 3)
+        
+        #expect(result.preferredGenreList[0].name == "JPOP")
+        #expect(result.preferredArtistList[1].name == "YOASOBI")
+    }
+}

--- a/Projects/Core/LivithNetwork/Tests/PreferenceDTODecodingTests.swift
+++ b/Projects/Core/LivithNetwork/Tests/PreferenceDTODecodingTests.swift
@@ -13,10 +13,10 @@ import Testing
 
 struct PreferenceDTODecodingTests {
     
-    // MARK: - FetchArtistList Tests
+    // MARK: - SearchArtistList Tests
     
-    @Test("FetchArtistList 디코딩이 정상적으로 되어야 한다")
-    func fetchArtistList_디코딩이_정상적으로_되어야_한다() throws {
+    @Test("SearchArtistList 디코딩이 정상적으로 되어야 한다")
+    func searchArtistList_디코딩이_정상적으로_되어야_한다() throws {
         // Given
         let json = """
         {
@@ -58,8 +58,8 @@ struct PreferenceDTODecodingTests {
         #expect(secondArtist.name == "YOASOBI")
     }
     
-    @Test("FetchArtistList cursor가 nil일때 디코딩이 되어야 한다")
-    func fetchArtistList_cursor가_nil일때_디코딩이_되어야_한다() throws {
+    @Test("SearchArtistList cursor가 nil일때 디코딩이 되어야 한다")
+    func searchArtistList_cursor가_nil일때_디코딩이_되어야_한다() throws {
         // Given
         let json = """
         {
@@ -78,8 +78,8 @@ struct PreferenceDTODecodingTests {
         #expect(result.totalCount == 0)
     }
     
-    @Test("FetchArtistList imgUrl이 nil일때 디코딩이 되어야 한다")
-    func fetchArtistList_imgUrl이_nil일때_디코딩이_되어야_한다() throws {
+    @Test("SearchArtistList imgUrl이 nil일때 디코딩이 되어야 한다")
+    func searchArtistList_imgUrl이_nil일때_디코딩이_되어야_한다() throws {
         // Given
         let json = """
         {
@@ -164,19 +164,21 @@ struct PreferenceDTODecodingTests {
         // Given
         let json = """
         [
-          {
-            "id": 1,
-            "genreId": 1,
-            "name": "Lisa",
-            "imgUrl": "https://yt3.ggpht.com/n03wNjboLyFI5IZmagYapJASpYH6H7d9deJx4WGTRxwRKPOQaYgOSgudEuPBKl__Xz3LwjR11Q=s800-c-k-c0xffffffff-no-rj-mo"
-          },
-          {
-            "id": 4,
-            "genreId": 2,
-            "name": "Ado",
-            "imgUrl": "https://yt3.ggpht.com/BKpE74RwbPJ8zLaad9Y2XoX7SmIEsoma1KB8dNzwtWwiOqgTNnYI_guEP1iAaTBrdk4nHakx=s800-c-k-c0xffffffff-no-rj-mo"
-          }
-        ]
+            {
+              "id": 1,
+              "userId": 1,
+              "genreId": 1,
+              "name": "Lisa",
+              "imgUrl": "https://yt3.ggpht.com/n03wNjboLyFI5IZmagYapJASpYH6H7d9deJx4WGTRxwRKPOQaYgOSgudEuPBKl__Xz3LwjR11Q=s800-c-k-c0xffffffff-no-rj-mo"
+            },
+            {
+              "id": 4,
+              "userId": 1,
+              "genreId": 4,
+              "name": "Ado",
+              "imgUrl": "https://yt3.ggpht.com/BKpE74RwbPJ8zLaad9Y2XoX7SmIEsoma1KB8dNzwtWwiOqgTNnYI_guEP1iAaTBrdk4nHakx=s800-c-k-c0xffffffff-no-rj-mo"
+            }
+          ]
         """.data(using: .utf8)!
         
         // When
@@ -187,13 +189,15 @@ struct PreferenceDTODecodingTests {
         
         let firstArtist = result[0]
         #expect(firstArtist.id == 1)
+        #expect(firstArtist.userID == 1)
         #expect(firstArtist.genreID == 1)
         #expect(firstArtist.name == "Lisa")
         #expect(firstArtist.imageURLString != nil)
         
         let secondArtist = result[1]
         #expect(secondArtist.id == 4)
-        #expect(secondArtist.genreID == 2)
+        #expect(secondArtist.userID == 1)
+        #expect(secondArtist.genreID == 4)
         #expect(secondArtist.name == "Ado")
     }
     

--- a/Projects/Data/AuthData/Sources/Repository/AuthRepositoryImpl.swift
+++ b/Projects/Data/AuthData/Sources/Repository/AuthRepositoryImpl.swift
@@ -70,16 +70,23 @@ struct AuthRepositoryImpl: AuthRepository {
         }
     }
     
-    func signup(tempUser: TempUser, marketingConsent: Bool, nickname: String) async throws(AuthError) {
+    func signup(_ signup: Signup) async throws(AuthError) {
         do {
-            let response: DTO.Response.Signup = try await onboardingService.request(
-                .signup(
-                    nickname: nickname,
-                    marketingConsent: marketingConsent,
-                    providerID: tempUser.providerID,
-                    provider: tempUser.provider.description,
-                    email: tempUser.email
-                )
+            let request: DTO.Request.Signup = .init(
+                nickname: signup.nickname.value,
+                preferredArtistIDList: signup.preferredArtistIDList,
+                preferredGenreIDList: signup.preferredGenreIDList,
+                email: signup.email,
+                provider: signup.provider.description,
+                providerID: signup.providerID,
+                marketingConsent: signup.isMarketingAgreed
+            )
+            let response: DTO.Response.Signup = try await onboardingService.request(.signup(request))
+            
+            let tempUser = TempUser(
+                provider: signup.provider,
+                providerID: signup.providerID,
+                email: signup.email
             )
             
             try await handleSignup(response: response, tempUser: tempUser)

--- a/Projects/Data/AuthData/Sources/Repository/AuthRepositoryImpl.swift
+++ b/Projects/Data/AuthData/Sources/Repository/AuthRepositoryImpl.swift
@@ -70,7 +70,7 @@ struct AuthRepositoryImpl: AuthRepository {
         }
     }
     
-    func signup(_ signup: Signup) async throws(AuthError) {
+    func signup(_ signup: SignupInfo) async throws(AuthError) {
         do {
             let request: DTO.Request.Signup = .init(
                 nickname: signup.nickname.value,

--- a/Projects/Data/AuthData/Tests/AuthMapperTests.swift
+++ b/Projects/Data/AuthData/Tests/AuthMapperTests.swift
@@ -69,7 +69,9 @@ final class AuthMapperTests: XCTestCase {
           "providerId": "provider123",
           "email": "test@example.com",
           "nickname": "테스트유저",
-          "marketingConsent": true
+          "marketingConsent": true,
+          "preferredGenres": [],
+          "preferredArtists": []
         }
         """.data(using: .utf8)!
         
@@ -98,7 +100,9 @@ final class AuthMapperTests: XCTestCase {
           "providerId": "apple456",
           "email": null,
           "nickname": "애플유저",
-          "marketingConsent": false
+          "marketingConsent": false,
+          "preferredGenres": [],
+          "preferredArtists": []
         }
         """.data(using: .utf8)!
         

--- a/Projects/Data/UserData/Tests/UserMapperTests.swift
+++ b/Projects/Data/UserData/Tests/UserMapperTests.swift
@@ -93,7 +93,9 @@ final class UserMapperTests: XCTestCase {
             "providerId": "001234.abcd1234",
             "email": "user@icloud.com",
             "nickname": "테스트유저",
-            "marketingConsent": true
+            "marketingConsent": true,
+            "preferredGenres": [],
+            "preferredArtists": []
         }
         """.data(using: .utf8)!
 
@@ -122,7 +124,9 @@ final class UserMapperTests: XCTestCase {
             "providerId": "9876543210",
             "email": null,
             "nickname": "익명",
-            "marketingConsent": false
+            "marketingConsent": false,
+            "preferredGenres": [],
+            "preferredArtists": []
         }
         """.data(using: .utf8)!
 
@@ -172,7 +176,6 @@ final class UserMapperTests: XCTestCase {
         XCTAssertEqual(result.title, "제이크 밀러 첫 단독 내한공연 JAKE MILLER BALANCE TOUR")
         XCTAssertEqual(result.artist, "JAKE MILLER (제이크 밀러)")
         XCTAssertEqual(result.status, .completed)
-        XCTAssertEqual(result.daysLeft, -16)
         XCTAssertEqual(result.posterURL.absoluteString, "http://www.kopis.or.kr/upload/pfmPoster/PF_PF268438_250703_114113.gif")
         XCTAssertEqual(result.venue, "무신사 개러지")
         XCTAssertEqual(result.ticketingOffice, "NOL 티켓")
@@ -212,7 +215,6 @@ final class UserMapperTests: XCTestCase {
         XCTAssertEqual(result.title, "버스커버스커 공연")
         XCTAssertEqual(result.artist, "버스커버스커")
         XCTAssertEqual(result.status, .ongoing)
-        XCTAssertEqual(result.daysLeft, 0)
         XCTAssertEqual(result.posterURL.absoluteString, "https://example.com/busker.jpg")
         XCTAssertEqual(result.venue, "홍대 놀이터")
         XCTAssertNil(result.ticketingOffice)
@@ -251,7 +253,6 @@ final class UserMapperTests: XCTestCase {
         XCTAssertEqual(result.title, "제이크 밀러 첫 단독 내한공연 JAKE MILLER BALANCE TOUR")
         XCTAssertEqual(result.artist, "JAKE MILLER (제이크 밀러)")
         XCTAssertEqual(result.status, .completed)
-        XCTAssertEqual(result.daysLeft, 0)  // DTO에 daysLeft가 없으므로 항상 0
         XCTAssertEqual(result.posterURL.absoluteString, "http://www.kopis.or.kr/upload/pfmPoster/PF_PF268438_250703_114113.gif")
         XCTAssertEqual(result.venue, "무신사 개러지")
         XCTAssertEqual(result.ticketingOffice, "NOL 티켓")
@@ -290,7 +291,6 @@ final class UserMapperTests: XCTestCase {
         XCTAssertEqual(result.title, "무료 버스킹 공연")
         XCTAssertEqual(result.artist, "인디 밴드")
         XCTAssertEqual(result.status, .upcoming)
-        XCTAssertEqual(result.daysLeft, 0)
         XCTAssertEqual(result.posterURL.absoluteString, "https://example.com/busking.jpg")
         XCTAssertEqual(result.venue, "신촌 연세로")
         XCTAssertNil(result.ticketingOffice)

--- a/Projects/Domain/Sources/Entity/Auth/Nickname.swift
+++ b/Projects/Domain/Sources/Entity/Auth/Nickname.swift
@@ -1,0 +1,36 @@
+//
+//  Nickname.swift
+//  Domain
+//
+//  Created by 김진웅 on 2/5/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+public struct Nickname: Hashable {
+    
+    // MARK: - Constants
+    
+    private static let pattern = "^[a-zA-Z0-9가-힣]{1,10}$"
+    
+    // MARK: - Properties
+    
+    public let value: String
+    
+    // MARK: - Initializer
+    
+    public init(_ value: String) throws {
+        guard !value.isEmpty else {
+            throw AuthError.emptyNickname
+        }
+        
+        guard let regex = try? Regex(Self.pattern),
+              value.wholeMatch(of: regex) != nil 
+        else {
+            throw AuthError.invalidNickname
+        }
+        
+        self.value = value
+    }
+}

--- a/Projects/Domain/Sources/Entity/Auth/Nickname.swift
+++ b/Projects/Domain/Sources/Entity/Auth/Nickname.swift
@@ -12,7 +12,7 @@ public struct Nickname: Hashable {
     
     // MARK: - Constants
     
-    private static let pattern = "^[a-zA-Z0-9가-힣]{1,10}$"
+    private static let regex: Regex = /^[a-zA-Z0-9가-힣]{1,10}$/
     
     // MARK: - Properties
     
@@ -25,9 +25,7 @@ public struct Nickname: Hashable {
             throw AuthError.emptyNickname
         }
         
-        guard let regex = try? Regex(Self.pattern),
-              value.wholeMatch(of: regex) != nil 
-        else {
+        guard value.wholeMatch(of: Self.regex) != nil else {
             throw AuthError.invalidNickname
         }
         

--- a/Projects/Domain/Sources/Entity/Auth/Signup.swift
+++ b/Projects/Domain/Sources/Entity/Auth/Signup.swift
@@ -1,0 +1,59 @@
+//
+//  Signup.swift
+//  Domain
+//
+//  Created by 김진웅 on 2/5/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+public struct Signup: Hashable {
+    
+    // MARK: - Constants
+    
+    private static let maxGenreCount = 3
+    private static let maxArtistCount = 3
+    
+    // MARK: - Properties
+    
+    public let provider: SocialLoginProvider
+    public let providerID: String
+    public let email: String?
+    public let nickname: Nickname
+    public let isMarketingAgreed: Bool
+    public let preferredGenreIDList: [Int]
+    public let preferredArtistIDList: [Int]
+    
+    // MARK: - Initializer
+    
+    public init(
+        provider: SocialLoginProvider,
+        providerID: String,
+        email: String?,
+        nickname: Nickname,
+        isMarketingAgreed: Bool,
+        preferredGenreIDList: [Int],
+        preferredArtistIDList: [Int]
+    ) throws {
+        guard !preferredGenreIDList.isEmpty else {
+            throw AuthError.emptyGenreList
+        }
+        guard preferredGenreIDList.count <= Self.maxGenreCount else {
+            throw AuthError.genreExceedsLimit
+        }
+        
+        guard preferredArtistIDList.count <= Self.maxArtistCount else {
+            throw AuthError.artistExceedsLimit
+        }
+        
+        self.provider = provider
+        self.providerID = providerID
+        self.email = email
+        self.nickname = nickname
+        self.isMarketingAgreed = isMarketingAgreed
+        self.preferredGenreIDList = preferredGenreIDList
+        self.preferredArtistIDList = preferredArtistIDList
+    }
+}
+

--- a/Projects/Domain/Sources/Entity/Auth/SignupInfo.swift
+++ b/Projects/Domain/Sources/Entity/Auth/SignupInfo.swift
@@ -1,5 +1,5 @@
 //
-//  Signup.swift
+//  SignupInfo.swift
 //  Domain
 //
 //  Created by 김진웅 on 2/5/26.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct Signup: Hashable {
+public struct SignupInfo: Hashable {
     
     // MARK: - Constants
     

--- a/Projects/Domain/Sources/Error/AuthError.swift
+++ b/Projects/Domain/Sources/Error/AuthError.swift
@@ -18,10 +18,18 @@ public enum AuthError: DomainError {
     case duplicateNickname
     case nicknameTooLong
     case emptyNickname
+    case invalidNickname
     case userNotFound
     case alreadyWithdrawn
     case emptyReason
     case cancelled
+    
+    // 회원가입 - 장르/아티스트 검증
+    case emptyGenreList
+    case genreNotFound
+    case genreExceedsLimit
+    case artistNotFound
+    case artistExceedsLimit
     
     public var errorDescription: String? {
         switch self {
@@ -43,6 +51,8 @@ public enum AuthError: DomainError {
             return "닉네임은 10자 이내여야 해요."
         case .emptyNickname:
             return "닉네임을 입력해주세요."
+        case .invalidNickname:
+            return "닉네임 형식이 올바르지 않아요."
         case .userNotFound:
             return "해당 유저를 찾을 수 없어요."
         case .alreadyWithdrawn:
@@ -51,6 +61,16 @@ public enum AuthError: DomainError {
             return "탈퇴 사유를 선택해주세요."
         case .cancelled:
             return "요청이 취소되었습니다."
+        case .emptyGenreList:
+            return "최소 1개의 장르는 선택해야 합니다."
+        case .genreNotFound:
+            return "해당 장르를 찾을 수 없습니다."
+        case .genreExceedsLimit:
+            return "최대 3개의 장르만 선택할 수 있습니다."
+        case .artistNotFound:
+            return "해당 아티스트를 찾을 수 없습니다."
+        case .artistExceedsLimit:
+            return "최대 3개의 아티스트만 선택할 수 있습니다."
         }
     }
     
@@ -72,8 +92,19 @@ public enum AuthError: DomainError {
             return .alreadyWithdrawn
         case "reason should not be empty":
             return .emptyReason
+        case "최소 1개의 장르는 선택해야 합니다.":
+            return .emptyGenreList
+        case "해당 장르를 찾을 수 없습니다.":
+            return .genreNotFound
+        case "최대 3개의 장르만 선택할 수 있습니다.":
+            return .genreExceedsLimit
+        case "해당 아티스를 찾을 수 없습니다.":
+            return .artistNotFound
+        case "최대 3개의 아티스트만 선택할 수 있습니다.":
+            return .artistExceedsLimit
         default:
             return .unknown
         }
     }
 }
+

--- a/Projects/Domain/Sources/Repository/AuthRepository.swift
+++ b/Projects/Domain/Sources/Repository/AuthRepository.swift
@@ -12,7 +12,7 @@ public protocol AuthRepository {
     func withdraw(reason: String) async throws(AuthError)
     func logout() async throws(AuthError)
     func checkNicknameDuplicate(nickname: String) async throws(AuthError) -> Bool
-    func signup(_ signup: Signup) async throws(AuthError)
+    func signup(_ signup: SignupInfo) async throws(AuthError)
     func kakaoLogin() async throws(AuthError) -> LoginStatus
     func appleLogin() async throws(AuthError) -> LoginStatus
     func fetchLastLoginPlatform() async throws(AuthError) -> SocialLoginProvider

--- a/Projects/Domain/Sources/Repository/AuthRepository.swift
+++ b/Projects/Domain/Sources/Repository/AuthRepository.swift
@@ -12,7 +12,7 @@ public protocol AuthRepository {
     func withdraw(reason: String) async throws(AuthError)
     func logout() async throws(AuthError)
     func checkNicknameDuplicate(nickname: String) async throws(AuthError) -> Bool
-    func signup(tempUser: TempUser, marketingConsent: Bool, nickname: String) async throws(AuthError)
+    func signup(_ signup: Signup) async throws(AuthError)
     func kakaoLogin() async throws(AuthError) -> LoginStatus
     func appleLogin() async throws(AuthError) -> LoginStatus
     func fetchLastLoginPlatform() async throws(AuthError) -> SocialLoginProvider

--- a/Projects/LoginFeature/Project.swift
+++ b/Projects/LoginFeature/Project.swift
@@ -19,7 +19,8 @@ let project = Project.make(
                 .shared(.nicknameEditFeature),
                 .designSystem(.designSystem),
                 .core(.coordinator),
-                .core(.diContainer)
+                .core(.diContainer),
+                .shared(.preferenceFeature)
             ]
         )
     ]

--- a/Projects/LoginFeature/Sources/Coordinator/LoginCoordinator.swift
+++ b/Projects/LoginFeature/Sources/Coordinator/LoginCoordinator.swift
@@ -59,11 +59,11 @@ final class LoginCoordinator: Coordinator {
                     .environment(\.loginCoordinator, self)
             )
             
-        case .safari(let url):
-            let safariView = SafariView(url: url) { [weak self] in
-                self?.dismiss()
-            }.ignoresSafeArea()
-            return UIHostingController(rootView: safariView)
+        case .preferredArtist(let builder):
+            return UIHostingController(
+                rootView: PreferredArtistSettingView(builder: builder)
+                    .environment(\.loginCoordinator, self)
+            )
         }
     }
     
@@ -75,4 +75,3 @@ final class LoginCoordinator: Coordinator {
         onSignupCompleted(nickname)
     }
 }
-

--- a/Projects/LoginFeature/Sources/Coordinator/LoginCoordinator.swift
+++ b/Projects/LoginFeature/Sources/Coordinator/LoginCoordinator.swift
@@ -53,12 +53,10 @@ final class LoginCoordinator: Coordinator {
                     .environment(\.loginCoordinator, self)
             )
             
+        case .preferredGenre(let builder):
             return UIHostingController(
-                rootView: NicknameSettingView(
-                    marketingConsent: marketingConsent,
-                    tempUser: tempUser
-                )
-                .environment(\.loginCoordinator, self)
+                rootView: PreferredGenreSettingView(builder: builder)
+                    .environment(\.loginCoordinator, self)
             )
             
         case .safari(let url):

--- a/Projects/LoginFeature/Sources/Coordinator/LoginCoordinator.swift
+++ b/Projects/LoginFeature/Sources/Coordinator/LoginCoordinator.swift
@@ -18,8 +18,6 @@ final class LoginCoordinator: Coordinator {
     
     let navigationController: UINavigationController
     
-    private var tempUser: Domain.TempUser?
-    
     private let onLoginCompleted: (() -> Void)
     private let onSignupCompleted: ((String) -> Void)
     
@@ -44,14 +42,17 @@ final class LoginCoordinator: Coordinator {
             return UIHostingController(rootView: LoginView().environment(\.loginCoordinator, self))
             
         case .terms(let tempUser):
-            self.tempUser = tempUser
-            return UIHostingController(rootView: TermsView().environment(\.loginCoordinator, self))
+            return UIHostingController(
+                rootView: TermsView(tempUser: tempUser)
+                    .environment(\.loginCoordinator, self)
+            )
             
-        case .nickname(let marketingConsent):
-            guard let tempUser = tempUser else {
-                return UIHostingController(rootView: EmptyView())
-            }
-
+        case .nickname(let builder):
+            return UIHostingController(
+                rootView: NicknameSettingView(builder: builder)
+                    .environment(\.loginCoordinator, self)
+            )
+            
             return UIHostingController(
                 rootView: NicknameSettingView(
                     marketingConsent: marketingConsent,

--- a/Projects/LoginFeature/Sources/Coordinator/LoginRoute.swift
+++ b/Projects/LoginFeature/Sources/Coordinator/LoginRoute.swift
@@ -15,6 +15,5 @@ import Domain
 enum LoginRoute: Route {
     case login
     case terms(TempUser)
-    case nickname(Bool)
-    case safari(URL)
+    case nickname(SignupBuilder)
 }

--- a/Projects/LoginFeature/Sources/Coordinator/LoginRoute.swift
+++ b/Projects/LoginFeature/Sources/Coordinator/LoginRoute.swift
@@ -16,4 +16,6 @@ enum LoginRoute: Route {
     case login
     case terms(TempUser)
     case nickname(SignupBuilder)
+    case preferredGenre(SignupBuilder)
+    case preferredArtist(SignupBuilder)
 }

--- a/Projects/LoginFeature/Sources/Onboarding/Model/SignupBuilder.swift
+++ b/Projects/LoginFeature/Sources/Onboarding/Model/SignupBuilder.swift
@@ -1,0 +1,78 @@
+//
+//  SignupBuilder.swift
+//  LoginFeature
+//
+//  Created by 김진웅 on 2/5/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+
+struct SignupBuilder: Hashable {
+    let tempUser: TempUser
+    let isMarketingAgreed: Bool
+    let nickname: String
+    let preferredGenreList: [PreferredGenre]
+    
+    private init(
+        tempUser: TempUser,
+        isMarketingAgreed: Bool,
+        nickname: String,
+        preferredGenreList: [PreferredGenre]
+    ) {
+        self.tempUser = tempUser
+        self.isMarketingAgreed = isMarketingAgreed
+        self.nickname = nickname
+        self.preferredGenreList = preferredGenreList
+    }
+    
+    // MARK: - Builder Methods
+    
+    /// Step 1: 약관 동의 후 시작
+    static func start(tempUser: TempUser, isMarketingAgreed: Bool) -> SignupBuilder {
+        SignupBuilder(
+            tempUser: tempUser,
+            isMarketingAgreed: isMarketingAgreed,
+            nickname: "",
+            preferredGenreList: []
+        )
+    }
+    
+    /// Step 2: 닉네임 설정
+    func withNickname(_ nickname: String) -> SignupBuilder {
+        SignupBuilder(
+            tempUser: tempUser,
+            isMarketingAgreed: isMarketingAgreed,
+            nickname: nickname,
+            preferredGenreList: preferredGenreList
+        )
+    }
+    
+    /// Step 3: 선호 장르 설정
+    func withPreferredGenreList(_ genres: [PreferredGenre]) -> SignupBuilder {
+        SignupBuilder(
+            tempUser: tempUser,
+            isMarketingAgreed: isMarketingAgreed,
+            nickname: nickname,
+            preferredGenreList: genres
+        )
+    }
+    
+    /// Step 4: 최종 빌드 - 회원가입 요청 데이터 생성
+    func build(preferredArtistList: [PreferredArtist]) throws -> Signup {
+        let validatedNickname = try Nickname(nickname)
+        
+        return try Signup(
+            provider: tempUser.provider,
+            providerID: tempUser.providerID,
+            email: tempUser.email,
+            nickname: validatedNickname,
+            isMarketingAgreed: isMarketingAgreed,
+            preferredGenreIDList: preferredGenreList.map { $0.id },
+            preferredArtistIDList: preferredArtistList.map { $0.id }
+        )
+    }
+}
+

--- a/Projects/LoginFeature/Sources/Onboarding/Model/SignupBuilder.swift
+++ b/Projects/LoginFeature/Sources/Onboarding/Model/SignupBuilder.swift
@@ -61,10 +61,10 @@ struct SignupBuilder: Hashable {
     }
     
     /// Step 4: 최종 빌드 - 회원가입 요청 데이터 생성
-    func build(preferredArtistList: [PreferredArtist]) throws -> Signup {
+    func build(preferredArtistList: [PreferredArtist]) throws -> SignupInfo {
         let validatedNickname = try Nickname(nickname)
         
-        return try Signup(
+        return try SignupInfo(
             provider: tempUser.provider,
             providerID: tempUser.providerID,
             email: tempUser.email,

--- a/Projects/LoginFeature/Sources/Onboarding/Store/SignupStore.swift
+++ b/Projects/LoginFeature/Sources/Onboarding/Store/SignupStore.swift
@@ -66,11 +66,7 @@ private extension SignupStore {
             do {
                 let signup = try builder.build(preferredArtistList: preferredArtistList)
                 
-                try await authRepository.signup(
-                    tempUser: builder.tempUser,
-                    marketingConsent: builder.isMarketingAgreed,
-                    nickname: signup.nickname.value
-                )
+                try await authRepository.signup(signup)
                 
                 await send(._signupResult(.success(())))
             } catch {
@@ -80,7 +76,7 @@ private extension SignupStore {
     }
     
     func getErrorMessage(from error: Error) -> String {
-        let unknownMessage = AuthError.unknown.errorDescription ?? ""
+        let unknownMessage = AuthError.unknown.errorDescription ?? "로그인에서 다시 시도 주세요"
         guard let authError = error as? AuthError else { return error.localizedDescription }
         return authError.errorDescription ?? unknownMessage
     }

--- a/Projects/LoginFeature/Sources/Onboarding/Store/SignupStore.swift
+++ b/Projects/LoginFeature/Sources/Onboarding/Store/SignupStore.swift
@@ -1,0 +1,87 @@
+//
+//  SignupStore.swift
+//  LoginFeature
+//
+//  Created by 김진웅 on 2/5/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+import DIContainer
+import Domain
+
+enum SignupIntent {
+    case submit([PreferredArtist])
+    case _signupResult(Result<Void, Error>)
+}
+
+struct SignupState: Equatable {
+    enum Result: Equatable {
+        case idle
+        case success
+        case failure(String)
+    }
+    
+    var isSubmitting: Bool = false
+    var result: Result = .idle
+}
+
+final class SignupStore: ObservableObject {
+    @Published private(set) var state = SignupState()
+    
+    @Injected private var authRepository: AuthRepository
+    
+    private let builder: SignupBuilder
+    
+    init(builder: SignupBuilder) {
+        self.builder = builder
+    }
+    
+    @MainActor
+    func send(_ intent: SignupIntent) {
+        switch intent {
+        case .submit(let preferredArtistList):
+            state.isSubmitting = true
+            state.result = .idle
+            performSignup(preferredArtistList: preferredArtistList)
+            
+        case ._signupResult(let result):
+            state.isSubmitting = false
+            switch result {
+            case .success:
+                state.result = .success
+            case .failure(let error):
+                state.result = .failure(getErrorMessage(from: error))
+            }
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private extension SignupStore {
+    func performSignup(preferredArtistList: [PreferredArtist]) {
+        Task {
+            do {
+                let signup = try builder.build(preferredArtistList: preferredArtistList)
+                
+                try await authRepository.signup(
+                    tempUser: builder.tempUser,
+                    marketingConsent: builder.isMarketingAgreed,
+                    nickname: signup.nickname.value
+                )
+                
+                await send(._signupResult(.success(())))
+            } catch {
+                await send(._signupResult(.failure(error)))
+            }
+        }
+    }
+    
+    func getErrorMessage(from error: Error) -> String {
+        let unknownMessage = AuthError.unknown.errorDescription ?? ""
+        guard let authError = error as? AuthError else { return error.localizedDescription }
+        return authError.errorDescription ?? unknownMessage
+    }
+}

--- a/Projects/LoginFeature/Sources/Onboarding/View/NicknameSettingView.swift
+++ b/Projects/LoginFeature/Sources/Onboarding/View/NicknameSettingView.swift
@@ -18,27 +18,18 @@ struct NicknameSettingView: View {
     @State private var isSignupFailureModalPresented: Bool = false
     @State private var signupFailureMessage: String = ""
 
-    private let marketingConsent: Bool
-    private let tempUser: TempUser
+    private let builder: SignupBuilder
 
-    init(marketingConsent: Bool, tempUser: TempUser) {
-        self.marketingConsent = marketingConsent
-        self.tempUser = tempUser
+    init(builder: SignupBuilder) {
+        self.builder = builder
     }
 
     var body: some View {
-        // TODO: - 회원가입 API 연결 취향 설정 이후로 빼기
-        NicknameEditView(
-            config: .signup(marketingConsent: marketingConsent, tempUser: tempUser),
-            onDismiss: { coordinator?.pop() },
-            onSubmitSuccess: { nickname in
-                coordinator?.completeSignup(with: nickname)
-            },
-            onSubmitFailure: { message in
-                signupFailureMessage = message
-                isSignupFailureModalPresented = true
-            }
-        )
+        NicknameEditView(config: .signup) {
+            coordinator?.pop()
+        } onSubmitSuccess: { nickname in
+            coordinator?.push(to: .preferredGenre(builder.withNickname(nickname)))
+        }
         .crossDissolve(isPresented: $isSignupFailureModalPresented, dismissOnTapOutside: false) {
             LivithModal(
                 type: .error(title: "오류가 발생했어요!", message: signupFailureMessage),

--- a/Projects/LoginFeature/Sources/Onboarding/View/PreferredArtistSettingView.swift
+++ b/Projects/LoginFeature/Sources/Onboarding/View/PreferredArtistSettingView.swift
@@ -1,0 +1,70 @@
+//
+//  PreferredArtistSettingView.swift
+//  LoginFeature
+//
+//  Created by 김진웅 on 2/5/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import SwiftUI
+
+import Domain
+import LivithDesignSystem
+import PreferenceFeature
+
+struct PreferredArtistSettingView: View {
+    @Environment(\.loginCoordinator) private var coordinator
+    @StateObject private var store: SignupStore
+    
+    @State private var isSignupFailureModalPresented: Bool = false
+    @State private var signupFailureMessage: String = ""
+    
+    private let builder: SignupBuilder
+    
+    init(builder: SignupBuilder) {
+        self.builder = builder
+        self._store = StateObject(wrappedValue: SignupStore(builder: builder))
+    }
+    
+    var body: some View {
+        ArtistEditView(
+            config: .onboarding(),
+            isSubmitting: store.state.isSubmitting
+        ) {
+            coordinator?.pop()
+        } onSkip: {
+            store.send(.submit([]))
+        } onSubmit: { selectedArtistList in
+            store.send(.submit(selectedArtistList))
+        }
+        .onChange(of: store.state.result) { _, newValue in
+            handleSignupResult(newValue)
+        }
+        .crossDissolve(isPresented: $isSignupFailureModalPresented, dismissOnTapOutside: false) {
+            LivithModal(
+                type: .error(title: "오류가 발생했어요!", message: signupFailureMessage),
+                confirmTitle: "로그인으로 돌아가기",
+                onConfirm: {
+                    isSignupFailureModalPresented = false
+                    coordinator?.popToRoot()
+                }
+            )
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private extension PreferredArtistSettingView {
+    func handleSignupResult(_ result: SignupState.Result) {
+        switch result {
+        case .idle:
+            break
+        case .success:
+            coordinator?.completeSignup(with: builder.nickname)
+        case .failure(let message):
+            signupFailureMessage = message
+            isSignupFailureModalPresented = true
+        }
+    }
+}

--- a/Projects/LoginFeature/Sources/Onboarding/View/PreferredGenreSettingView.swift
+++ b/Projects/LoginFeature/Sources/Onboarding/View/PreferredGenreSettingView.swift
@@ -1,0 +1,32 @@
+//
+//  PreferredGenreSettingView.swift
+//  LoginFeature
+//
+//  Created by 김진웅 on 2/5/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import SwiftUI
+
+import Domain
+import PreferenceFeature
+
+struct PreferredGenreSettingView: View {
+    @Environment(\.loginCoordinator) private var coordinator
+    
+    private let builder: SignupBuilder
+    
+    init(builder: SignupBuilder) {
+        self.builder = builder
+    }
+    
+    var body: some View {
+        GenreEditView(mode: .onboarding()) {
+            coordinator?.pop()
+        } onSubmit: { selectedGenreList in
+            let updated = builder.withPreferredGenreList(selectedGenreList)
+            coordinator?.push(to: .preferredArtist(updated))
+        }
+    }
+}
+

--- a/Projects/LoginFeature/Sources/Onboarding/View/TermsView.swift
+++ b/Projects/LoginFeature/Sources/Onboarding/View/TermsView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+import Domain
 import LivithDesignSystem
 
 struct TermsView: View {
@@ -17,12 +18,18 @@ struct TermsView: View {
     @State private var showSafari = false
     @State private var safariURL: URL?
     
+    private let tempUser: TempUser
+    
+    init(tempUser: TempUser) {
+        self.tempUser = tempUser
+    }
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             navigationBar
 
             stepIndicator
-                .padding(.top, 20)
+                .padding(.top, 10)
                 .padding(.horizontal, 16)
 
             title
@@ -164,11 +171,9 @@ private extension TermsView {
         )
     }
     
-    
-    
     var nextButton: some View {
         LivithButton(Literals.nextButtonText, variant: .primary) {
-            coordinator?.push(to: .nickname(isMarketingAgreed))
+            coordinator?.push(to: .nickname(.start(tempUser: tempUser, isMarketingAgreed: isMarketingAgreed)))
         }
         .disabled(!canProceed)
     }

--- a/Projects/LoginFeature/Sources/Onboarding/View/TermsView.swift
+++ b/Projects/LoginFeature/Sources/Onboarding/View/TermsView.swift
@@ -121,16 +121,7 @@ private extension TermsView {
             isRequired: true,
             isChecked: isTermsAgreed,
             action: { store.send(.toggleTermsAgreement) },
-            trailingView: AnyView(
-                Button {
-                    safariURL = URL(string: Literals.termsURLString)
-                    showSafari = true
-                } label: {
-                    Text(Literals.moreButtonText)
-                        .notosans(.caption2Semibold)
-                        .foregroundStyle(Color.livithColor(.white100))
-                }
-            )
+            trailingView: AnyView(moreButton(urlString: Literals.termsURLString))
         )
     }
 
@@ -140,16 +131,7 @@ private extension TermsView {
             isRequired: true,
             isChecked: isPrivacyAgreed,
             action: { store.send(.togglePrivacyAgreement) },
-            trailingView: AnyView(
-                Button {
-                    safariURL = URL(string: Literals.privacyURLString)
-                    showSafari = true
-                } label: {
-                    Text(Literals.moreButtonText)
-                        .notosans(.caption2Semibold)
-                        .foregroundStyle(Color.livithColor(.white100))
-                }
-            )
+            trailingView: AnyView(moreButton(urlString: Literals.privacyURLString))
         )
     }
 
@@ -158,16 +140,7 @@ private extension TermsView {
             Literals.marketingAgreementText,
             isChecked: isMarketingAgreed,
             action: { store.send(.toggleMarketingAgreement) },
-            trailingView: AnyView(
-                Button {
-                    safariURL = URL(string: Literals.marketingURLString)
-                    showSafari = true
-                } label: {
-                    Text(Literals.moreButtonText)
-                        .notosans(.caption2Semibold)
-                        .foregroundStyle(Color.livithColor(.white100))
-                }
-            )
+            trailingView: AnyView(moreButton(urlString: Literals.marketingURLString))
         )
     }
     
@@ -176,6 +149,17 @@ private extension TermsView {
             coordinator?.push(to: .nickname(.start(tempUser: tempUser, isMarketingAgreed: isMarketingAgreed)))
         }
         .disabled(!canProceed)
+    }
+    
+    func moreButton(urlString: String) -> some View {
+        Button {
+            safariURL = URL(string: urlString)
+            showSafari = true
+        } label: {
+            Text(Literals.moreButtonText)
+                .notosans(.caption2Semibold)
+                .foregroundStyle(Color.livithColor(.white100))
+        }
     }
 }
 
@@ -202,9 +186,8 @@ private extension TermsView {
         static let marketingAgreementText = "마케팅 활용 / 광고성 정보 수신 동의"
         static let moreButtonText = "더보기 >"
         static let nextButtonText = "다음"
-        static let termsURLString = "https://youz2me.notion.site/Livith-v-25-04-13-1d402dd0e5fc80eaacd9d3dfdc7d0aa0?pvs=4"
-        // TODO: 실제 링크로 연결 필요
-        static let privacyURLString = "https://youz2me.notion.site/Livith-v-25-04-13-1d402dd0e5fc80eaacd9d3dfdc7d0aa0?pvs=4"
-        static let marketingURLString = "https://youz2me.notion.site/Livith-v-25-04-13-1d402dd0e5fc80eaacd9d3dfdc7d0aa0?pvs=4"
+        static let termsURLString = "https://youz2me.notion.site/Livith-v-25-04-13-1d402dd0e5fc80eaacd9d3dfdc7d0aa0"
+        static let privacyURLString = "https://youz2me.notion.site/v-26-02-03-2fb02dd0e5fc806ca182ecaf18099979"
+        static let marketingURLString = "https://youz2me.notion.site/v-26-02-03-2fb02dd0e5fc80af9708cf5e39f44f77"
     }
 }

--- a/Projects/LoginFeature/Sources/Onboarding/View/TermsView.swift
+++ b/Projects/LoginFeature/Sources/Onboarding/View/TermsView.swift
@@ -14,39 +14,42 @@ struct TermsView: View {
     @StateObject private var store = TermsStore()
     @Environment(\.loginCoordinator) private var coordinator
     @Environment(\.openURL) private var openURL
+    @State private var showSafari = false
+    @State private var safariURL: URL?
     
     var body: some View {
-        ZStack {
-            Color.livithColor(.black100)
-                .ignoresSafeArea()
+        VStack(alignment: .leading, spacing: 0) {
+            navigationBar
 
-            VStack(alignment: .leading, spacing: 0) {
-                navigationBar
+            stepIndicator
+                .padding(.top, 20)
+                .padding(.horizontal, 16)
 
-                stepIndicator
-                    .padding(.top, 20)
-                    .padding(.horizontal, 16)
+            title
+                .padding(.top, 32)
+                .padding(.horizontal, 16)
 
-                title
-                    .padding(.top, 32)
-                    .padding(.horizontal, 16)
+            allAgreeButton
+                .padding(.top, 20)
+                .padding(.horizontal, 16)
 
-                allAgreeButton
-                    .padding(.top, 20)
-                    .padding(.horizontal, 16)
+            termsSection
+                .padding(.top, 20)
+                .padding(.horizontal, 20)
 
-                termsSection
-                    .padding(.top, 20)
-                    .padding(.horizontal, 20)
+            Spacer()
 
-                Spacer()
-
-                nextButton
-                    .padding(.bottom, 50)
-                    .padding(.horizontal, 16)
+            nextButton
+                .padding(.bottom, 50)
+                .padding(.horizontal, 16)
+        }
+        .background(Color.livithColor(.black100))
+        .ignoresSafeArea(.all, edges: .bottom)
+        .sheet(isPresented: $showSafari) {
+            if let url = safariURL {
+                SafariView(url: url)
             }
         }
-        .ignoresSafeArea(.all, edges: .bottom)
     }
 }
 
@@ -60,7 +63,7 @@ private extension TermsView {
     }
     
     var stepIndicator: some View {
-        StepIndicatorView(currentStep: 1, totalSteps: 2)
+        StepIndicatorView(currentStep: 1, totalSteps: 4)
     }
     
     var title: some View {
@@ -113,8 +116,8 @@ private extension TermsView {
             action: { store.send(.toggleTermsAgreement) },
             trailingView: AnyView(
                 Button {
-                    guard let url = URL(string: Literals.termsURLString) else { return }
-                    coordinator?.present(to: .safari(url))
+                    safariURL = URL(string: Literals.termsURLString)
+                    showSafari = true
                 } label: {
                     Text(Literals.moreButtonText)
                         .notosans(.caption2Semibold)
@@ -132,8 +135,8 @@ private extension TermsView {
             action: { store.send(.togglePrivacyAgreement) },
             trailingView: AnyView(
                 Button {
-                    guard let url = URL(string: Literals.privacyURLString) else { return }
-                    coordinator?.present(to: .safari(url))
+                    safariURL = URL(string: Literals.privacyURLString)
+                    showSafari = true
                 } label: {
                     Text(Literals.moreButtonText)
                         .notosans(.caption2Semibold)
@@ -150,8 +153,8 @@ private extension TermsView {
             action: { store.send(.toggleMarketingAgreement) },
             trailingView: AnyView(
                 Button {
-                    guard let url = URL(string: Literals.marketingURLString) else { return }
-                    coordinator?.present(to: .safari(url))
+                    safariURL = URL(string: Literals.marketingURLString)
+                    showSafari = true
                 } label: {
                     Text(Literals.moreButtonText)
                         .notosans(.caption2Semibold)

--- a/Projects/Shared/NicknameEditFeature/Sources/NicknameEditConfig.swift
+++ b/Projects/Shared/NicknameEditFeature/Sources/NicknameEditConfig.swift
@@ -6,10 +6,8 @@
 //  Copyright © 2026 Livith. All rights reserved.
 //
 
-import Domain
-
 public enum NicknameEditConfig {
-    case signup(marketingConsent: Bool, tempUser: TempUser)
+    case signup
     case update
 
     public var navigationTitle: String {
@@ -25,7 +23,7 @@ public enum NicknameEditConfig {
 
     public var submitButtonText: String {
         switch self {
-        case .signup: return "가입 완료"
+        case .signup: return "다음"
         case .update: return "닉네임 변경"
         }
     }

--- a/Projects/Shared/NicknameEditFeature/Sources/NicknameEditStore.swift
+++ b/Projects/Shared/NicknameEditFeature/Sources/NicknameEditStore.swift
@@ -79,14 +79,13 @@ private extension NicknameEditStore {
             state.validationState = .idle
             return
         }
-
-        guard let regex = try? Regex("^[a-zA-Z0-9가-힣]{1,10}$"),
-              state.nickname.wholeMatch(of: regex) != nil else {
+        
+        do {
+            _ = try Nickname(state.nickname)
+            state.validationState = .valid
+        } catch {
             state.validationState = .invalid
-            return
         }
-
-        state.validationState = .valid
     }
 
     func performDuplicateCheck() {
@@ -104,12 +103,8 @@ private extension NicknameEditStore {
         Task {
             do {
                 switch config {
-                case .signup(let marketingConsent, let tempUser):
-                    try await authRepository.signup(
-                        tempUser: tempUser,
-                        marketingConsent: marketingConsent,
-                        nickname: state.nickname
-                    )
+                case .signup:
+                    break // 회원가입 API는 PreferredArtistSettingView에서 호출
                 case .update:
                     try await userRepository.updateNickname(state.nickname)
                 }

--- a/Projects/Shared/NicknameEditFeature/Sources/NicknameEditView.swift
+++ b/Projects/Shared/NicknameEditFeature/Sources/NicknameEditView.swift
@@ -99,7 +99,7 @@ private extension NicknameEditView {
     }
 
     var stepIndicator: some View {
-        StepIndicatorView(currentStep: 2, totalSteps: 2)
+        StepIndicatorView(currentStep: 2, totalSteps: 4)
     }
 
     var title: some View {

--- a/Projects/Shared/NicknameEditFeature/Sources/NicknameEditView.swift
+++ b/Projects/Shared/NicknameEditFeature/Sources/NicknameEditView.swift
@@ -52,7 +52,7 @@ public struct NicknameEditView: View {
 
                 if config.showStepIndicator {
                     stepIndicator
-                        .padding(.top, 20)
+                        .padding(.top, 10)
                         .padding(.horizontal, 16)
                 }
 

--- a/Projects/Shared/NicknameEditFeature/Tests/NicknameEditStoreTests.swift
+++ b/Projects/Shared/NicknameEditFeature/Tests/NicknameEditStoreTests.swift
@@ -229,8 +229,7 @@ struct NicknameEditStoreTests {
     @Test("signup 제출 성공하면 success 상태여야 한다")
     func signupSuccessShouldBeSuccess() async {
         mockAuthRepository.signupResult = .success(())
-        let tempUser = TempUser(provider: .kakao, providerID: "123", email: "test@test.com")
-        let sut = NicknameEditStore(config: .signup(marketingConsent: true, tempUser: tempUser))
+        let sut = NicknameEditStore(config: .signup)
         sut.updateNickname("테스트")
 
         sut.submit()
@@ -238,26 +237,7 @@ struct NicknameEditStoreTests {
 
         #expect(sut.state.submitResult == .success)
         #expect(sut.state.isSubmitting == false)
-        #expect(mockAuthRepository.signupCallCount == 1)
-        #expect(mockAuthRepository.lastSignupNickname == "테스트")
-    }
-
-    @Test("signup 제출 실패하면 failure 상태여야 한다")
-    func signupFailureShouldBeFailure() async {
-        mockAuthRepository.signupResult = .failure(.serverError)
-        let tempUser = TempUser(provider: .kakao, providerID: "123", email: nil)
-        let sut = NicknameEditStore(config: .signup(marketingConsent: false, tempUser: tempUser))
-        sut.updateNickname("테스트")
-
-        sut.submit()
-        try? await Task.sleep(for: .milliseconds(100))
-
-        if case .failure = sut.state.submitResult {
-            #expect(true)
-        } else {
-            Issue.record("Expected failure state")
-        }
-        #expect(sut.state.isSubmitting == false)
+        #expect(mockAuthRepository.signupCallCount == 0)
     }
 
     // MARK: - Submit Tests (Update)

--- a/Projects/Shared/NicknameEditFeature/Tests/NicknameEditStoreTests.swift
+++ b/Projects/Shared/NicknameEditFeature/Tests/NicknameEditStoreTests.swift
@@ -35,7 +35,7 @@ final class MockAuthRepository: AuthRepository {
         }
     }
 
-    func signup(_ signup: Signup) async throws(AuthError) {
+    func signup(_ signup: SignupInfo) async throws(AuthError) {
         signupCallCount += 1
         lastSignupNickname = signup.nickname.value
         switch signupResult {

--- a/Projects/Shared/NicknameEditFeature/Tests/NicknameEditStoreTests.swift
+++ b/Projects/Shared/NicknameEditFeature/Tests/NicknameEditStoreTests.swift
@@ -35,9 +35,9 @@ final class MockAuthRepository: AuthRepository {
         }
     }
 
-    func signup(tempUser: TempUser, marketingConsent: Bool, nickname: String) async throws(AuthError) {
+    func signup(_ signup: Signup) async throws(AuthError) {
         signupCallCount += 1
-        lastSignupNickname = nickname
+        lastSignupNickname = signup.nickname.value
         switch signupResult {
         case .success:
             return

--- a/Projects/Shared/PreferenceFeature/Sources/Artist/Model/ArtistEditConfig.swift
+++ b/Projects/Shared/PreferenceFeature/Sources/Artist/Model/ArtistEditConfig.swift
@@ -8,7 +8,10 @@
 
 import Foundation
 
+import Domain
+
 public struct ArtistEditConfig {
+    public let initialSelection: [PreferredArtist]
     public let stepIndicator: (current: Int, total: Int)?
     public let navigationTitle: String
     public let title: String
@@ -16,12 +19,14 @@ public struct ArtistEditConfig {
     public let submitTitle: String
     
     public init(
+        initialSelection: [PreferredArtist] = [],
         stepIndicator: (current: Int, total: Int)? = nil,
         navigationTitle: String,
         title: String,
         subtitle: String? = nil,
         submitTitle: String
     ) {
+        self.initialSelection = initialSelection
         self.stepIndicator = stepIndicator
         self.navigationTitle = navigationTitle
         self.title = title
@@ -51,8 +56,9 @@ public extension ArtistEditConfig {
         )
     }
     
-    static func edit() -> ArtistEditConfig {
+    static func edit(selectedArtists: [PreferredArtist]) -> ArtistEditConfig {
         ArtistEditConfig(
+            initialSelection: selectedArtists,
             stepIndicator: nil,
             navigationTitle: "아티스트 변경",
             title: "선호하는 아티스트를\n3명 선택해 주세요",

--- a/Projects/Shared/PreferenceFeature/Sources/Artist/Store/ArtistSelectionStore.swift
+++ b/Projects/Shared/PreferenceFeature/Sources/Artist/Store/ArtistSelectionStore.swift
@@ -93,6 +93,7 @@ public final class ArtistSelectionStore: ObservableObject {
             switch result {
             case .success(let artists):
                 state.artistList = artists
+                state.hasNextPage = true
             case .failure(let error):
                 state.errorMessage = error.localizedDescription
                 state.isErrorToastPresented = true

--- a/Projects/Shared/PreferenceFeature/Sources/Artist/View/ArtistEditView.swift
+++ b/Projects/Shared/PreferenceFeature/Sources/Artist/View/ArtistEditView.swift
@@ -19,19 +19,21 @@ public struct ArtistEditView: View {
     @State private var isSearchFocused: Bool = false
     
     private let config: ArtistEditConfig
+    private let isSubmitting: Bool
     private let onBack: () -> Void
     private let onSkip: (() -> Void)?
     private let onSubmit: ([PreferredArtist]) -> Void
     
     public init(
         config: ArtistEditConfig,
-        selectedArtists: [PreferredArtist] = [],
+        isSubmitting: Bool = false,
         onBack: @escaping () -> Void,
         onSkip: (() -> Void)? = nil,
         onSubmit: @escaping ([PreferredArtist]) -> Void
     ) {
-        self._store = StateObject(wrappedValue: ArtistSelectionStore(selectedArtists: selectedArtists))
+        self._store = StateObject(wrappedValue: ArtistSelectionStore(selectedArtists: config.initialSelection))
         self.config = config
+        self.isSubmitting = isSubmitting
         self.onBack = onBack
         self.onSkip = onSkip
         self.onSubmit = onSubmit
@@ -134,10 +136,10 @@ private extension ArtistEditView {
     }
     
     var submitButton: some View {
-        LivithButton(config.submitTitle) {
+        LivithButton(config.submitTitle, isLoading: isSubmitting) {
             onSubmit(store.state.selectedArtistList)
         }
-        .disabled(store.state.selectedArtistList.isEmpty)
+        .disabled(store.state.selectedArtistList.isEmpty || isSubmitting)
     }
 }
 

--- a/Projects/Shared/PreferenceFeature/Sources/Artist/View/ArtistSelectionView.swift
+++ b/Projects/Shared/PreferenceFeature/Sources/Artist/View/ArtistSelectionView.swift
@@ -70,6 +70,7 @@ private extension ArtistSelectionView {
                         .padding(2)
                 }
                 .scrollIndicators(.hidden)
+                .scrollDismissesKeyboard(.immediately)
                 
                 if !store.state.selectedArtistList.isEmpty {
                     selectedArtistChips

--- a/Projects/Shared/PreferenceFeature/Sources/Genre/Model/GenreEditConfig.swift
+++ b/Projects/Shared/PreferenceFeature/Sources/Genre/Model/GenreEditConfig.swift
@@ -8,7 +8,10 @@
 
 import Foundation
 
+import Domain
+
 public struct GenreEditConfig {
+    public let initialSelection: [PreferredGenre]
     public let stepIndicator: (current: Int, total: Int)?
     public let navigationTitle: String
     public let title: String
@@ -16,12 +19,14 @@ public struct GenreEditConfig {
     public let submitTitle: String
     
     public init(
+        initialSelection: [PreferredGenre] = [],
         stepIndicator: (current: Int, total: Int)? = nil,
         navigationTitle: String,
         title: String,
         subtitle: String? = nil,
         submitTitle: String
     ) {
+        self.initialSelection = initialSelection
         self.stepIndicator = stepIndicator
         self.navigationTitle = navigationTitle
         self.title = title
@@ -53,8 +58,9 @@ public extension GenreEditConfig {
         )
     }
     
-    static func edit() -> GenreEditConfig {
+    static func edit(selectedGenres: [PreferredGenre]) -> GenreEditConfig {
         GenreEditConfig(
+            initialSelection: selectedGenres,
             stepIndicator: nil,
             navigationTitle: "장르 변경",
             title: "선호하는 장르를\n3개 선택해 주세요",

--- a/Projects/Shared/PreferenceFeature/Sources/Genre/View/GenreEditView.swift
+++ b/Projects/Shared/PreferenceFeature/Sources/Genre/View/GenreEditView.swift
@@ -18,17 +18,19 @@ public struct GenreEditView: View {
     @StateObject private var selectionStore: GenreSelectionStore
     
     private let config: GenreEditConfig
+    private let isSubmitting: Bool
     private let onBack: () -> Void
     private let onSubmit: ([PreferredGenre]) -> Void
     
     public init(
         mode: GenreEditConfig,
-        selectedGenres: [PreferredGenre] = [],
+        isSubmitting: Bool = false,
         onBack: @escaping () -> Void,
         onSubmit: @escaping ([PreferredGenre]) -> Void
     ) {
-        self._selectionStore = StateObject(wrappedValue: GenreSelectionStore(selectedGenres: selectedGenres))
+        self._selectionStore = StateObject(wrappedValue: GenreSelectionStore(selectedGenres: mode.initialSelection))
         self.config = mode
+        self.isSubmitting = isSubmitting
         self.onBack = onBack
         self.onSubmit = onSubmit
     }
@@ -57,7 +59,7 @@ public struct GenreEditView: View {
                 
                 Spacer()
                 
-                LivithButton(config.submitTitle) {
+                LivithButton(config.submitTitle, isLoading: isSubmitting) {
                     onSubmit(selectionStore.state.selectedGenreList)
                 }
                 .disabled(selectionStore.state.selectedGenreList.isEmpty)
@@ -105,7 +107,7 @@ private extension GenreEditView {
     }
 }
 
-// MARK: - Constants & Literals
+// MARK: - Constants
 
 private extension GenreEditView {
     enum Constants {
@@ -114,36 +116,4 @@ private extension GenreEditView {
         static let indicatorTopPadding: CGFloat = 10
         static let bottomPadding: CGFloat = 16
     }
-}
-
-// MARK: - Preview
-
-#Preview {
-    GenreEditView(
-        mode: .onboarding(),
-        onBack: { print("뒤로가기 눌림") },
-        onSubmit: { selectedGenres in
-            print("다음이 눌림: \(selectedGenres.map(\.displayName))")
-        }
-    )
-}
-
-#Preview {
-    GenreEditView(
-        mode: .home(),
-        onBack: { print("뒤로가기 눌림") },
-        onSubmit: { selectedGenres in
-            print("다음이 눌림: \(selectedGenres.map(\.displayName))")
-        }
-    )
-}
-
-#Preview {
-    GenreEditView(
-        mode: .edit(),
-        onBack: { print("뒤로가기 눌림") },
-        onSubmit: { selectedGenres in
-            print("다음이 눌림: \(selectedGenres.map(\.displayName))")
-        }
-    )
 }

--- a/Projects/Shared/PreferenceFeature/Tests/ArtistSelectionStoreTests.swift
+++ b/Projects/Shared/PreferenceFeature/Tests/ArtistSelectionStoreTests.swift
@@ -246,4 +246,37 @@ struct ArtistSelectionStoreTests {
         #expect(sut.state.artistList.count == 1)
         #expect(sut.state.hasNextPage) // 검색 시 hasNextPage true 리셋 (구현 확인 필요: 현재 구현엔 리셋 로직 누락 가능성 있음)
     }
+
+    @Test("리스트 재조회(검색 등) 시 페이지네이션 상태가 초기화되어야 한다")
+    func testRefetchingListResetsPaginationState() async throws {
+        // Given
+        // 1. 초기 상태: 리스트가 있고, 페이징 끝에 도달하여 hasNextPage가 false인 상태를 만든다.
+        let initialArtists = [PreferredArtist(id: 1, name: "A", genreID: 1, imageURL: nil)]
+        container.preferenceRepository.artistSearchResultStub = ArtistSearchResult(artists: initialArtists, cursor: nil, totalCount: 1)
+        
+        let sut = ArtistSelectionStore()
+        sut.send(.onAppear)
+        try await Task.sleep(nanoseconds: 100_000_000)
+        
+        // loadMore 호출 -> 빈 결과 -> hasNextPage = false
+        container.preferenceRepository.artistSearchResultStub = ArtistSearchResult(artists: [], cursor: nil, totalCount: 1)
+        sut.send(.loadMore)
+        try await Task.sleep(nanoseconds: 100_000_000)
+        
+        #expect(!sut.state.hasNextPage)
+        
+        // When
+        // 2. 리스트를 처음부터 다시 로드 (검색어 변경 등)
+        let newArtists = [PreferredArtist(id: 2, name: "B", genreID: 1, imageURL: nil)]
+        container.preferenceRepository.artistSearchResultStub = ArtistSearchResult(artists: newArtists, cursor: nil, totalCount: 2)
+        
+        // 검색 실행 (또는 onAppear 재호출 등, 여기선 search로 시뮬레이션)
+        sut.send(.search(keyword: "B"))
+        try await Task.sleep(nanoseconds: 500_000_000)
+        
+        // Then
+        // 3. hasNextPage가 true로 돌아왔는지 확인
+        #expect(sut.state.artistList.first?.name == "B")
+        #expect(sut.state.hasNextPage)
+    }
 }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 회원가입 플로우를 구현하였습니다.

|    구현 내용    |   iPhone 16   |
| :-------------: | :----------: |
| 1. 약관동의 | <img src = "https://github.com/user-attachments/assets/ee298154-824b-4b00-9e49-99a9abc80cdd"> |
| 2. 닉네임 | <img src = "https://github.com/user-attachments/assets/d8f1a717-1888-40d2-8de5-c15defeaa9ea"> |
| 3. 장르선택 | <img src = "https://github.com/user-attachments/assets/fa1c3060-834a-404c-819c-afaa8620de71"> |
| 4. 아티스트선택 | <img src = "https://github.com/user-attachments/assets/2238ee93-8c30-4e71-aeb7-59ddf830aa86"> |

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- User 도메인 모델에는 선호 장르 및 선호 아티스트를 추가하지 않았습니다.
    - 별도의 API가 존재하며, 동시에 User에 종속되어야 할 필요성을 못 느꼈습니다.
    - 로컬로 저장되어야 할 필요도 없다고 생각했습니다.

## 🔗 연결된 이슈
- Resolved: #197
