### PR TITLE
[Fix] 관심 콘서트 검색 시 발생 오류 수정

### DIFF
--- a/Projects/Core/LivithNetwork/Sources/Endpoint/SearchEndpoint.swift
+++ b/Projects/Core/LivithNetwork/Sources/Endpoint/SearchEndpoint.swift
@@ -24,7 +24,8 @@ public enum SearchEndpoint {
     case fetchRecommendedSearchResult(letter: String)
     case fetchConcertList(
         cursor: String?,
-        size: Int?
+        size: Int?,
+        id: Int?
     )
 }
 
@@ -69,10 +70,12 @@ extension SearchEndpoint: NetworkEndpoint {
             return ["letter": letter]
         case .fetchConcertList(
             cursor: let cursor,
-            size: let size):
+            size: let size,
+            id: let id):
             let params: [String: Any?] = [
                 "cursor": cursor,
-                "size": size
+                "size": size,
+                "id": id
             ]
 
             return params.compactMapValues { $0 }

--- a/Projects/Data/ConcertData/Sources/Repository/ConcertRepositoryImpl.swift
+++ b/Projects/Data/ConcertData/Sources/Repository/ConcertRepositoryImpl.swift
@@ -37,7 +37,7 @@ struct ConcertRepositoryImpl: ConcertRepository {
 
         do {
             let response: DTO.Response.FetchConcertList = try await searchService.request(
-                .fetchConcertList(cursor: cursor, size: 12)
+                .fetchConcertList(cursor: cursor, size: 12, id: concertID)
             )
             return mapper.toDomain(from: response)
         } catch {

--- a/Projects/HomeFeature/Sources/Interest/Store/InterestConcertSearchStore.swift
+++ b/Projects/HomeFeature/Sources/Interest/Store/InterestConcertSearchStore.swift
@@ -60,7 +60,7 @@ final class InterestConcertSearchStore: ObservableObject {
     @Injected private var userRepository: UserRepository
     @Injected private var searchRepository: SearchRepository
 
-    private var searchTask: Task<Void, Never>?
+    private var recommendKeywordTask: Task<Void, Never>?
     
     init() {
         performFetchConcertList()
@@ -75,7 +75,7 @@ final class InterestConcertSearchStore: ObservableObject {
 
             if text.isEmpty {
                 state.recommendKeywordList.removeAll()
-                searchTask?.cancel()
+                recommendKeywordTask?.cancel()
             } else {
                 performFetchRecommendKeywordList()
             }
@@ -188,8 +188,8 @@ private extension InterestConcertSearchStore {
     }
 
     func performFetchRecommendKeywordList() {
-        searchTask?.cancel()
-        searchTask = Task {
+        recommendKeywordTask?.cancel()
+        recommendKeywordTask = Task {
             guard await Task.wait(for: .milliseconds(400)) else { return }
 
             do {
@@ -211,7 +211,7 @@ private extension InterestConcertSearchStore {
                     sort: nil,
                     status: [],
                     keyword: state.searchText,
-                    cursor: isNextPage ? state.searchList.last?.id.description : nil,
+                    cursor: isNextPage ? nextCursor : nil,
                     size: nil
                 )
                 await send(._fetchSearchListResult(.success(result.concerts)))
@@ -267,5 +267,11 @@ private extension InterestConcertSearchStore {
                 await send(._imagePrefetchCompleted(nil))
             }
         }
+    }
+
+    var nextCursor: String? {
+        guard let lastConcert = state.searchList.last else { return nil }
+        let dateString = DateFormatterService.string(from: lastConcert.startDate, type: .dotDate)
+        return "{\"value\":\"\(dateString)\",\"id\":\(lastConcert.id)}"
     }
 }

--- a/Projects/HomeFeature/Sources/Interest/Store/InterestConcertSearchStore.swift
+++ b/Projects/HomeFeature/Sources/Interest/Store/InterestConcertSearchStore.swift
@@ -127,7 +127,6 @@ final class InterestConcertSearchStore: ObservableObject {
             switch result {
             case .success(let keywordList):
                 state.recommendKeywordList = keywordList
-                print("Fetched recommend keywords: \(keywordList)")
             case .failure(let error):
                 state.recommendKeywordList = []
                 state.errorMessage = error.localizedDescription


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 콘서트 목록 조회 시 동일 내용이 반복적으로 페이지네이션이 되는 오류를 수정했습니다. (API 쿼리 파라미터 추가)
- 콘서트 검색 시 서버 오류로 인식되어 토스트가 보여지는 오류를 수정했습니다. (API Cursor 형태 수정) 
- 스프린트 후 `cursor` 형태를 바꿀 것을 서버 개발자에게 요청하였습니다.
  
## 🔗 연결된 이슈
- Resolved: #202 