### PR TITLE
[Feat] FCM 푸시 알림 기능 구현

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -35,7 +35,9 @@ let project = Project.make(
                 .data(.userData),
                 .user(.userFeature),
                 .widget(.widget),
-                .data(.preferenceData)
+                .data(.preferenceData),
+                .external(.firebaseCore),
+                .external(.firebaseMessaging)
             ]
         )
     ],

--- a/Projects/App/Resources/App-Info.plist
+++ b/Projects/App/Resources/App-Info.plist
@@ -2,8 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>APP_GROUP_ID</key>
+	<string>$(APP_GROUP_ID)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>라이빗</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -12,47 +16,10 @@
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
-	<key>CFBundleDisplayName</key>
-	<string>라이빗</string>
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
-	<key>CFBundleVersion</key>
-	<string>1</string>
-	<key>LSRequiresIPhoneOS</key>
-	<true/>
-	<key>UIApplicationSceneManifest</key>
-	<dict>
-		<key>UIApplicationSupportsMultipleScenes</key>
-		<false/>
-	</dict>
-	<key>UILaunchScreen</key>
-	<dict/>
-	<key>UISupportedInterfaceOrientations</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-	</array>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<!-- 카카오톡으로 로그인 -->
-		<string>kakaokompassauth</string>
-		<!-- 카카오톡 공유 -->
-		<string>kakaolink</string>
-		<!-- 카카오톡 채널 -->
-		<string>kakaoplus</string>
-	</array>
-	<key>NATIVE_APP_KEY</key>
-	<string>$(NATIVE_APP_KEY)</string>
-	<key>APP_GROUP_ID</key>
-	<string>$(APP_GROUP_ID)</string>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -71,6 +38,42 @@
 				<string>livith</string>
 			</array>
 		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+		<string>kakaoplus</string>
+	</array>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NATIVE_APP_KEY</key>
+	<string>$(NATIVE_APP_KEY)</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<false/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
 	</array>
 </dict>
 </plist>

--- a/Projects/App/Resources/GoogleService-Info.plist
+++ b/Projects/App/Resources/GoogleService-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyALPoce7roTdy6Oa46VtzqfuWl7MCtk5_I</string>
+	<key>GCM_SENDER_ID</key>
+	<string>864062841722</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.youz2me.livith</string>
+	<key>PROJECT_ID</key>
+	<string>livith-5327b</string>
+	<key>STORAGE_BUCKET</key>
+	<string>livith-5327b.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:864062841722:ios:bd06e5afffdfd563692cc3</string>
+</dict>
+</plist>

--- a/Projects/App/Resources/Livith-iOS.entitlements
+++ b/Projects/App/Resources/Livith-iOS.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>

--- a/Projects/App/Sources/LivithApp+InjectDependency.swift
+++ b/Projects/App/Sources/LivithApp+InjectDependency.swift
@@ -23,10 +23,10 @@ extension LivithApp {
     func registerDependency() {
         DIContainer.shared.register(
             assemblers: [
+                NotificationDataAssembler(),
                 AuthDataAssembler(),
                 CommentDataAssembler(),
                 ConcertDataAssembler(),
-                NotificationDataAssembler(),
                 SearchDataAssembler(),
                 SetlistDataAssembler(),
                 SongDataAssembler(),

--- a/Projects/App/Sources/LivithApp.swift
+++ b/Projects/App/Sources/LivithApp.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
+import FirebaseCore
 import KakaoSDKCommon
+
 import LivithFoundation
 
 @main
@@ -11,6 +13,7 @@ struct LivithApp: App {
 
     init() {
         registerDependency()
+        initializeFirebase()
         initializeKakaoSDK()
     }
 
@@ -19,11 +22,20 @@ struct LivithApp: App {
             AppRootView()
                 .task {
                     await NotificationService.shared.requestAuthorization()
+                    NotificationService.shared.registerForRemoteNotifications()
                 }
                 .onOpenURL { url in
                     DeepLinkService.shared.handle(url: url)
                 }
         }
+    }
+}
+
+// MARK: - Firebase
+
+private extension LivithApp {
+    func initializeFirebase() {
+        FirebaseApp.configure()
     }
 }
 

--- a/Projects/App/Sources/Service/NotificationService.swift
+++ b/Projects/App/Sources/Service/NotificationService.swift
@@ -9,8 +9,16 @@
 import UIKit
 import UserNotifications
 
+import DIContainer
+import Domain
+import Persistence
+
+import FirebaseMessaging
+
 final class NotificationService: NSObject {
     static let shared = NotificationService()
+
+    @Injected private var notificationRepository: NotificationRepository
 
     private override init() {
         super.init()
@@ -18,6 +26,11 @@ final class NotificationService: NSObject {
 
     func configure() {
         UNUserNotificationCenter.current().delegate = self
+        Messaging.messaging().delegate = self
+    }
+
+    func registerForRemoteNotifications() {
+        UIApplication.shared.registerForRemoteNotifications()
     }
 
     func requestAuthorization() async {
@@ -25,16 +38,30 @@ final class NotificationService: NSObject {
         _ = try? await UNUserNotificationCenter.current().requestAuthorization(options: options)
     }
 
-    func registerForRemoteNotifications() {
-        UIApplication.shared.registerForRemoteNotifications()
-    }
-
     func handleDeviceToken(_ deviceToken: Data) {
-        // TODO: FCM 토큰 등록
+        Messaging.messaging().apnsToken = deviceToken
     }
 
     func handleRegistrationError(_ error: Error) {
         print("Failed to register for remote notifications: \(error.localizedDescription)")
+    }
+
+    func getFCMToken() async -> String? {
+        try? await Messaging.messaging().token()
+    }
+
+    func registerFCMTokenToServer() {
+        Task {
+            guard let token = await getFCMToken() else { return }
+            try? await notificationRepository.registerFCMToken(token)
+        }
+    }
+
+    func registerFCMTokenIfLoggedIn() {
+        let storage = UserDefaultsStorage()
+        let isLoggedIn: Bool = (try? storage.fetch(for: .currentUser) as User) != nil
+        guard isLoggedIn else { return }
+        registerFCMTokenToServer()
     }
 }
 
@@ -57,5 +84,15 @@ extension NotificationService: UNUserNotificationCenterDelegate {
         let userInfo = response.notification.request.content.userInfo
         DeepLinkService.shared.handle(userInfo: userInfo)
         completionHandler()
+    }
+}
+
+// MARK: - MessagingDelegate
+
+extension NotificationService: MessagingDelegate {
+    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        guard let fcmToken else { return }
+        print("FCM Token: \(fcmToken)")
+        registerFCMTokenIfLoggedIn()
     }
 }

--- a/Projects/Core/LivithNetwork/Sources/DTO/NotificationFeature/RegisterFCMToken.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/NotificationFeature/RegisterFCMToken.swift
@@ -1,0 +1,27 @@
+//
+//  RegisterFCMToken.swift
+//  LivithNetwork
+//
+//  Created by Youjin Lee on 2/7/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+public extension DTO.Request {
+    struct RegisterFCMToken: Encodable {
+        let token: String
+
+        public init(token: String) {
+            self.token = token
+        }
+    }
+
+    struct DeleteFCMToken: Encodable {
+        let token: String
+
+        public init(token: String) {
+            self.token = token
+        }
+    }
+}

--- a/Projects/Core/LivithNetwork/Sources/Endpoint/NotificationEndpoint.swift
+++ b/Projects/Core/LivithNetwork/Sources/Endpoint/NotificationEndpoint.swift
@@ -19,6 +19,8 @@ public enum NotificationEndpoint {
     case updateConsent(request: DTO.Request.UpdateNotificationConsent)
     case updateMarketingConsent
     case fetchSettings
+    case registerFCMToken(request: DTO.Request.RegisterFCMToken)
+    case deleteFCMToken(request: DTO.Request.DeleteFCMToken)
 }
 
 extension NotificationEndpoint: NetworkEndpoint {
@@ -36,6 +38,8 @@ extension NotificationEndpoint: NetworkEndpoint {
             return "/notifications/marketing-consent"
         case .fetchSettings:
             return "/notifications/settings"
+        case .registerFCMToken, .deleteFCMToken:
+            return "/notifications/fcm-token"
         }
     }
 
@@ -54,7 +58,11 @@ extension NotificationEndpoint: NetworkEndpoint {
 
     public var body: (any Encodable)? {
         switch self {
-        case .updateConsent(request: let request):
+        case .updateConsent(let request):
+            return request
+        case .registerFCMToken(let request):
+            return request
+        case .deleteFCMToken(let request):
             return request
         default:
             return .none
@@ -65,10 +73,12 @@ extension NotificationEndpoint: NetworkEndpoint {
         switch self {
         case .fetchList, .fetchUnreadCount, .fetchSettings:
             return .get
-        case .updateConsent, .updateMarketingConsent:
+        case .updateConsent, .updateMarketingConsent, .registerFCMToken:
             return .post
         case .markAsRead:
             return .patch
+        case .deleteFCMToken:
+            return .delete
         }
     }
 

--- a/Projects/Data/AuthData/Sources/Assembler/AuthDataAssembler.swift
+++ b/Projects/Data/AuthData/Sources/Assembler/AuthDataAssembler.swift
@@ -34,6 +34,7 @@ private extension AuthDataAssembler {
             onboardingService: container.resolve(OnboardingService.self),
             userService: container.resolve(UserService.self),
             notificationService: container.resolve(NotificationService.self),
+            notificationRepository: container.resolve(NotificationRepository.self),
             userdefaultsStorage: container.resolve(UserDefaultsStorage.self),
             tokenService: container.resolve(TokenService.self),
             widgetImageStorage: container.resolve(WidgetImageStorage.self)

--- a/Projects/Data/AuthData/Sources/Repository/AuthRepositoryImpl.swift
+++ b/Projects/Data/AuthData/Sources/Repository/AuthRepositoryImpl.swift
@@ -14,11 +14,14 @@ import LivithNetwork
 import SocialAuth
 import Persistence
 
+import FirebaseMessaging
+
 struct AuthRepositoryImpl: AuthRepository {
     private let socialAuthService: SocialAuthService
     private let onboardingService: OnboardingService
     private let userService: UserService
     private let notificationService: NotificationService
+    private let notificationRepository: NotificationRepository
     private let userdefaultsStorage: UserDefaultsStorage
     private let tokenService: TokenService
     private let widgetImageStorage: WidgetImageStorage
@@ -30,6 +33,7 @@ struct AuthRepositoryImpl: AuthRepository {
         onboardingService: OnboardingService,
         userService: UserService,
         notificationService: NotificationService,
+        notificationRepository: NotificationRepository,
         userdefaultsStorage: UserDefaultsStorage,
         tokenService: TokenService,
         widgetImageStorage: WidgetImageStorage
@@ -38,6 +42,7 @@ struct AuthRepositoryImpl: AuthRepository {
         self.onboardingService = onboardingService
         self.userService = userService
         self.notificationService = notificationService
+        self.notificationRepository = notificationRepository
         self.userdefaultsStorage = userdefaultsStorage
         self.tokenService = tokenService
         self.widgetImageStorage = widgetImageStorage
@@ -152,11 +157,22 @@ private extension AuthRepositoryImpl {
     }
     
     func handleLogout() async {
+        await deleteFCMToken()
         try? await tokenService.removeToken()
         userdefaultsStorage.remove(for: .currentUser)
         userdefaultsStorage.remove(for: .interestConcert)
         widgetImageStorage.remove(forKey: "interestConcertPoster")
         WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    func registerFCMToken() async {
+        guard let fcmToken = try? await Messaging.messaging().token() else { return }
+        try? await notificationRepository.registerFCMToken(fcmToken)
+    }
+
+    func deleteFCMToken() async {
+        guard let fcmToken = try? await Messaging.messaging().token() else { return }
+        try? await notificationRepository.deleteFCMToken(fcmToken)
     }
     
     func handleSignup(response: DTO.Response.Signup, tempUser: TempUser) async throws {
@@ -164,10 +180,12 @@ private extension AuthRepositoryImpl {
             accessToken: response.accessToken,
             refreshToken: response.refreshToken
         )
-        
+
         let user = mapper.toDomain(from: response.user)
         try? userdefaultsStorage.save(user, for: .currentUser)
         try? userdefaultsStorage.save(tempUser.provider.description, for: .lastLoginPlatform)
+
+        await registerFCMToken()
     }
     
     func getCredential(for provider: SocialLoginProvider) async throws -> SocialAuthCredential {
@@ -206,7 +224,9 @@ private extension AuthRepositoryImpl {
                 user = mapper.toDomain(from: userInfoResponse)
             }
             try? userdefaultsStorage.save(user, for: .currentUser)
-            
+
+            await registerFCMToken()
+
             return .existingUser(nickname: user.nickname)
         }
     }

--- a/Projects/Data/NotificationData/Sources/Assembler/NotificationDataAssembler.swift
+++ b/Projects/Data/NotificationData/Sources/Assembler/NotificationDataAssembler.swift
@@ -17,8 +17,17 @@ public struct NotificationDataAssembler: DependencyAssembler {
     public init() {}
 
     public func assemble(to container: any DependencyContainer) {
+        registerPersistence(to: container)
         registerNetwork(to: container)
         registerNotificationRepository(to: container)
+    }
+}
+
+// MARK: - Persistence Registration
+
+private extension NotificationDataAssembler {
+    func registerPersistence(to container: any DependencyContainer) {
+        container.register(UserDefaultsStorage(), for: UserDefaultsStorage.self)
     }
 }
 

--- a/Projects/Data/NotificationData/Sources/Mock/MockNotificationRepository.swift
+++ b/Projects/Data/NotificationData/Sources/Mock/MockNotificationRepository.swift
@@ -54,6 +54,10 @@ public struct MockNotificationRepository: NotificationRepository {
             recommendAlert: true
         )
     }
+
+    public func registerFCMToken(_ token: String) async throws(NotificationError) {}
+
+    public func deleteFCMToken(_ token: String) async throws(NotificationError) {}
 }
 
 // MARK: - Mock Notification Data

--- a/Projects/Data/NotificationData/Sources/Repository/NotificationRepositoryImpl.swift
+++ b/Projects/Data/NotificationData/Sources/Repository/NotificationRepositoryImpl.swift
@@ -128,4 +128,28 @@ struct NotificationRepositoryImpl: NotificationRepository {
             throw notificationError
         }
     }
+
+    func registerFCMToken(_ token: String) async throws(NotificationError) {
+        do {
+            let request = DTO.Request.RegisterFCMToken(token: token)
+            let _: DTO.Response.EmptyResponse = try await notificationService.request(
+                .registerFCMToken(request: request)
+            )
+        } catch {
+            let notificationError: NotificationError = errorMapper.mapToNotificationError(error)
+            throw notificationError
+        }
+    }
+
+    func deleteFCMToken(_ token: String) async throws(NotificationError) {
+        do {
+            let request = DTO.Request.DeleteFCMToken(token: token)
+            let _: DTO.Response.EmptyResponse = try await notificationService.request(
+                .deleteFCMToken(request: request)
+            )
+        } catch {
+            let notificationError: NotificationError = errorMapper.mapToNotificationError(error)
+            throw notificationError
+        }
+    }
 }

--- a/Projects/Data/Project.swift
+++ b/Projects/Data/Project.swift
@@ -20,7 +20,8 @@ let project = Project.make(
                 .core(.livithNetwork),
                 .core(.livithFoundation),
                 .core(.persistence),
-                .core(.diContainer)
+                .core(.diContainer),
+                .external(.firebaseMessaging)
             ]
         ),
         .make(

--- a/Projects/Domain/Sources/Repository/NotificationRepository.swift
+++ b/Projects/Domain/Sources/Repository/NotificationRepository.swift
@@ -18,4 +18,6 @@ public protocol NotificationRepository {
     ) async throws(NotificationError) -> NotificationConsentResult
     func updateMarketingConsent() async throws(NotificationError) -> NotificationConsentResult
     func fetchNotificationSettings() async throws(NotificationError) -> NotificationSettings
+    func registerFCMToken(_ token: String) async throws(NotificationError)
+    func deleteFCMToken(_ token: String) async throws(NotificationError)
 }

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "e05b91eb831ad1932f248ff21a2beeafa39f6ed9db2fa3d6ae178ae77105dd82",
+  "originHash" : "66a3eb4688aa00890e7bbd018cee9ed507c80213c1b59fb975b8d6d8ff4e8e3b",
   "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
+      }
+    },
     {
       "identity" : "alamofire",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,87 @@
       "state" : {
         "revision" : "7be73f6c2b5cd90e40798b06ebd5da8f9f79cf88",
         "version" : "5.11.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "9b3aed4fa6226125305b82d4d86c715bef250785",
+        "version" : "12.9.0"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "35b601a60fbbea2de3ea461f604deaaa4d8bbd0c",
+        "version" : "3.2.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "2ffd220823f3716904733162e9ae685545c276d1",
+        "version" : "12.8.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
+        "version" : "1.69.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
       }
     },
     {
@@ -26,6 +116,33 @@
       "state" : {
         "revision" : "d30a5fad881137e2267f96a8e3fc35c58999bb94",
         "version" : "8.6.2"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -1,22 +1,21 @@
 // swift-tools-version: 6.0
-import PackageDescription
+@preconcurrency import PackageDescription
 
 #if TUIST
-    import struct ProjectDescription.PackageSettings
+@preconcurrency import ProjectDescription
 
-    let packageSettings = PackageSettings(
-        // Customize the product types for specific package product
-        // Default is .staticFramework
-        // productTypes: ["Alamofire": .framework,]
-        productTypes: [
-            "Kingfisher": .framework,
-            "KakaoSDKCommon": .framework,
-            "KakaoSDKAuth": .framework,
-            "KakaoSDKUser": .framework,
-            "Alamofire": .framework,
-            "YouTubePlayerKit": .framework
-        ]
-    )
+let packageSettings = PackageSettings(
+    productTypes: [
+        "Kingfisher": .framework,
+        "KakaoSDKCommon": .framework,
+        "KakaoSDKAuth": .framework,
+        "KakaoSDKUser": .framework,
+        "Alamofire": .framework,
+        "YouTubePlayerKit": .framework,
+        "FirebaseCore": .staticLibrary,
+        "FirebaseMessaging": .staticLibrary
+    ]
+)
 #endif
 
 let package = Package(
@@ -25,6 +24,7 @@ let package = Package(
         .package(url: "https://github.com/Alamofire/Alamofire", .upToNextMajor(from: "5.10.2")),
         .package(url: "https://github.com/onevcat/Kingfisher", .upToNextMajor(from: "8.2.0")),
         .package(url: "https://github.com/kakao/kakao-ios-sdk", .upToNextMajor(from: "2.26.0")),
-        .package(url: "https://github.com/SvenTiigi/YouTubePlayerKit", .upToNextMajor(from: "1.9.0"))
+        .package(url: "https://github.com/SvenTiigi/YouTubePlayerKit", .upToNextMajor(from: "1.9.0")),
+        .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: "12.9.0")
     ]
 )

--- a/Tuist/ProjectDescriptionHelpers/Module/Module+Constant.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module/Module+Constant.swift
@@ -128,4 +128,6 @@ public enum ExternalDependency: String {
     case kakaoSDKAuth = "KakaoSDKAuth"
     case kakaoSDKUser = "KakaoSDKUser"
     case youTubePlayerKit = "YouTubePlayerKit"
+    case firebaseCore = "FirebaseCore"
+    case firebaseMessaging = "FirebaseMessaging"
 }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- Firebase SDK를 추가하고 FCM을 연동했어요.
- FCM 토큰 등록/삭제 API를 구현했어요.
- 로그인/회원가입 시 FCM 토큰을 서버에 등록하고, 로그아웃/회원탈퇴 시 삭제하도록 구현했어요.
- 앱 시작 시 로그인 상태면 FCM 토큰을 서버에 등록하도록 구현했어요.

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 토큰 등록/삭제 시점
- 메인 엔트리(시작, 로그인, 회원가입)에서는 무조건 FCM 토큰을 등록하도록 했고, 메인 아웃(로그아웃, 회원탈퇴)시에도 토큰을 삭제하도록 구현했습니다.

| 시점 | 동작 |
|------|------|
| 앱 시작 (로그인 상태) | didReceiveRegistrationToken → registerFCMTokenIfLoggedIn → 서버 전송 |
| 로그인 성공 | handleLoginResponse → registerFCMToken → 서버 전송 |
| 회원가입 성공 | handleSignup → registerFCMToken → 서버 전송 |
| 로그아웃 | handleLogout → deleteFCMToken → 서버에서 삭제 |
| 회원탈퇴 | handleWithdraw → deleteFCMToken → 서버에서 삭제 |

## 🔗 연결된 이슈
- Resolved: #213 
