### PR TITLE
[Fix] 5차 스프린트 qa 반영

### DIFF
--- a/Projects/HomeFeature/Sources/Home/Store/HomeStore.swift
+++ b/Projects/HomeFeature/Sources/Home/Store/HomeStore.swift
@@ -42,6 +42,12 @@ enum HomeIntent {
 }
 
 struct HomeState {
+    enum Route {
+        case concertSection
+        case interestedConcert
+    }
+
+    var route: Route = .concertSection
     var user: User? = nil
     var toastMessage: String = ""
     var errorMessage: String = ""
@@ -112,6 +118,7 @@ final class HomeStore: ObservableObject {
             switch result {
             case .success(let user):
                 state.user = user
+                state.route = user.interestConcertID == nil ? .concertSection : .interestedConcert
             case .failure(let error):
                 state.errorMessage = getErrorMessage(from: error)
             }

--- a/Projects/HomeFeature/Sources/Home/Store/HomeStore.swift
+++ b/Projects/HomeFeature/Sources/Home/Store/HomeStore.swift
@@ -36,7 +36,6 @@ enum HomeIntent {
     enum ConcertSectionIntent {
         case onAppear
         case onRefresh
-        case collapsePreferenceBanner
         case _concertSectionDataResult(Result<HomeState.ConcertSectionState.Data, Error>)
     }
 }
@@ -69,7 +68,6 @@ struct HomeState {
         var isLoading: Bool = false
         var isInitialLoad: Bool = true
         var shouldShowPreferenceBanner: Bool = false
-        var isPreferenceBannerExpanded: Bool = true
         var recommendedConcertList: [Concert] = []
         var errorMessage: String = ""
     }
@@ -250,8 +248,6 @@ private extension HomeStore {
             performFetchConcertSectionData()
         case .onRefresh:
             performFetchConcertSectionData()
-        case .collapsePreferenceBanner:
-            state.sections.isPreferenceBannerExpanded = false
         case ._concertSectionDataResult(let result):
             handleConcertSectionDataResult(result)
         }

--- a/Projects/HomeFeature/Sources/Home/Store/HomeStore.swift
+++ b/Projects/HomeFeature/Sources/Home/Store/HomeStore.swift
@@ -50,9 +50,9 @@ struct HomeState {
     var user: User? = nil
     var toastMessage: String = ""
     var errorMessage: String = ""
+    var hasNewNotice: Bool = false
     var interestConcert: InterestConcertState = .init()
     var sections: ConcertSectionState = .init()
-    var hasNewNotice: Bool = false
     
     struct InterestConcertState {
         var concert: Concert? = nil

--- a/Projects/HomeFeature/Sources/Home/Store/HomeStore.swift
+++ b/Projects/HomeFeature/Sources/Home/Store/HomeStore.swift
@@ -139,7 +139,7 @@ private extension HomeStore {
     func handleInterestConcertIntent(_ intent: HomeIntent.InterestConcertIntent) {
         switch intent {
         case .onDelete:
-            executeDeleteInterestConcert()
+            performDeleteInterestConcert()
         case .onRefresh:
             executeRefreshInterestConcert()
         case .onAppear:
@@ -155,10 +155,6 @@ private extension HomeStore {
         case ._deleteInterestConcertResult(let result):
             handleDeleteInterestConcertResult(result)
         }
-    }
-    
-    func executeDeleteInterestConcert() {
-        performDeleteInterestConcert()
     }
     
     func executeRefreshInterestConcert() {
@@ -240,29 +236,18 @@ private extension HomeStore {
     func handleConcertSectionIntent(_ intent: HomeIntent.ConcertSectionIntent) {
         switch intent {
         case .onAppear:
-            executeConcertSectionOnAppear()
+            if state.sections.isInitialLoad {
+                state.sections.isLoading = true
+                state.sections.isInitialLoad = false
+            }
+            performFetchConcertSectionData()
         case .onRefresh:
-            executeRefreshSections()
+            performFetchConcertSectionData()
         case .collapsePreferenceBanner:
             state.sections.isPreferenceBannerExpanded = false
         case ._concertSectionDataResult(let result):
             handleConcertSectionDataResult(result)
         }
-    }
-    
-    func executeConcertSectionOnAppear() {
-        if state.sections.isInitialLoad {
-            state.sections.isInitialLoad = false
-            state.sections.isLoading = true
-            performFetchConcertSectionData()
-        } else {
-            performFetchConcertSectionRecommendations()
-        }
-    }
-    
-    func executeRefreshSections() {
-        performFetchConcertSectionData()
-        performFetchUserInterestedConcert()
     }
     
     func handleConcertSectionDataResult(
@@ -395,18 +380,6 @@ private extension HomeStore {
             } catch {
                 send(.concertSection(._concertSectionDataResult(.failure(error))))
             }
-        }
-    }
-    
-    func performFetchConcertSectionRecommendations() {
-        cancellables[.refreshSections]?.cancel()
-        cancellables[.refreshSections] = Task {
-            let recommendations = await fetchRecommendationsIfNeeded()
-            let data = (
-                sections: state.sections.sectionList,
-                recommended: recommendations
-            )
-            send(.concertSection(._concertSectionDataResult(.success(data))))
         }
     }
 }

--- a/Projects/HomeFeature/Sources/Home/View/HomeConcertSectionView.swift
+++ b/Projects/HomeFeature/Sources/Home/View/HomeConcertSectionView.swift
@@ -15,6 +15,7 @@ import LivithDesignSystem
 struct HomeConcertSectionView: View {
     @Environment(\.homeCoordinator) private var coordinator
     @ObservedObject private var store: HomeStore
+    @State private var isPreferenceBannerExpanded: Bool = true
     
     init(store: HomeStore) {
         self.store = store
@@ -44,7 +45,10 @@ struct HomeConcertSectionView: View {
             .ignoresSafeArea(edges: .bottom)
         }
         .background(.livithColor(.black90))
-        .onAppear { store.send(.concertSection(.onAppear)) }
+        .onAppear {
+            isPreferenceBannerExpanded = true
+            store.send(.concertSection(.onAppear))
+        }
     }
 }
 
@@ -67,10 +71,7 @@ private extension HomeConcertSectionView {
         VStack(spacing: .zero) {
             if sectionState.shouldShowPreferenceBanner {
                 PreferenceBannerView(
-                    isExpanded: Binding(
-                        get: { sectionState.isPreferenceBannerExpanded },
-                        set: { _ in store.send(.concertSection(.collapsePreferenceBanner)) }
-                    ),
+                    isExpanded: $isPreferenceBannerExpanded,
                     onTapBanner: { coordinator?.push(to: .preferredGenreUpdate) }
                 )
                 .padding(.horizontal, 16)

--- a/Projects/HomeFeature/Sources/Home/View/HomeConcertSectionView.swift
+++ b/Projects/HomeFeature/Sources/Home/View/HomeConcertSectionView.swift
@@ -113,17 +113,11 @@ private extension HomeConcertSectionView {
         }
     }
     
-    @ViewBuilder
     var concertSection: some View {
-        if !sectionState.isLoading && sectionState.sectionList.isEmpty {
-            LivithEmptyView(text: emptyMessage)
+        ForEach(sectionState.sectionList, id: \.id) { section in
+            concertSectionRow(for: section)
                 .padding(.top, Constants.sectionTopPadding)
-        } else {
-            ForEach(sectionState.sectionList, id: \.id) { section in
-                concertSectionRow(for: section)
-                    .padding(.top, Constants.sectionTopPadding)
-                    .padding(.leading, Constants.sectionLeadingPadding)
-            }
+                .padding(.leading, Constants.sectionLeadingPadding)
         }
     }
 }

--- a/Projects/HomeFeature/Sources/Home/View/HomeView.swift
+++ b/Projects/HomeFeature/Sources/Home/View/HomeView.swift
@@ -23,7 +23,7 @@ struct HomeView: View {
     }
     
     var body: some View {
-        content()
+        content
             .background(.livithColor(.black90))
             .onAppear {
                 store.send(.onAppear)
@@ -57,14 +57,15 @@ struct HomeView: View {
     }
     
     @ViewBuilder
-    private func content() -> some View {
-        if store.state.user?.interestConcertID != nil {
+    private var content: some View {
+        switch store.state.route {
+        case .concertSection:
+            HomeConcertSectionView(store: store)
+        case .interestedConcert:
             HomeInterestConcertView(
                 store: store,
                 isTabBarHidden: $isTabBarHidden
             )
-        } else {
-            HomeConcertSectionView(store: store)
         }
     }
 }

--- a/Projects/HomeFeature/Sources/Home/View/Subview/RecommendedConcertSectionView.swift
+++ b/Projects/HomeFeature/Sources/Home/View/Subview/RecommendedConcertSectionView.swift
@@ -41,7 +41,7 @@ private extension RecommendedConcertSectionView {
             
             Spacer()
             
-            if !concertList.isEmpty {
+            if concertList.count > Constants.maxVisibleConcertCount {
                 Button(action: onSeeAllTap) {
                     Image.livithIcon(.rightLineDefault)
                         .resizable()
@@ -55,7 +55,7 @@ private extension RecommendedConcertSectionView {
     var concertListView: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(alignment: .top, spacing: 12) {
-                ForEach(concertList) { concert in
+                ForEach(concertList.prefix(Constants.maxVisibleConcertCount)) { concert in
                     LivithCard(
                         imageURL: concert.posterURL,
                         title: concert.title,
@@ -80,6 +80,7 @@ private extension RecommendedConcertSectionView {
 
 private extension RecommendedConcertSectionView {
     enum Constants {
+        static let maxVisibleConcertCount = 10
         static let iconSize: CGFloat = 24
         static let emptyViewRatio: CGFloat = 343 / 160
     }

--- a/Projects/HomeFeature/Sources/PreferenceUpdate/View/GenreUpdateView.swift
+++ b/Projects/HomeFeature/Sources/PreferenceUpdate/View/GenreUpdateView.swift
@@ -10,15 +10,36 @@ import SwiftUI
 
 import Domain
 import PreferenceFeature
+import LivithDesignSystem
 import Coordinator
 
 struct GenreUpdateView: View {
     @Environment(\.homeCoordinator) private var coordinator
+    @State private var isDiscardChangesModalPresented: Bool = false
+
     var body: some View {
-        GenreEditView(config: .genreHome()) { _ in
-            coordinator?.pop()
+        GenreEditView(config: .genreHome()) { isModified in
+            if isModified {
+                isDiscardChangesModalPresented = true
+            } else {
+                coordinator?.pop()
+            }
         } onSubmit: { genreList in
             coordinator?.push(to: .preferredAritstUpdate(selectedGenreList: genreList))
+        }
+        .crossDissolve(isPresented: $isDiscardChangesModalPresented, dismissOnTapOutside: false) {
+            LivithDangerModal(
+                message: "선택된 아티스트나 장르가 해제돼요.\n이전 페이지로 돌아가시나요?",
+                confirmTitle: "뒤로 갈게요",
+                cancelTitle: "잘못 눌렀어요",
+                type: .confirm(onConfirm: {
+                    isDiscardChangesModalPresented = false
+                    coordinator?.pop()
+                }),
+                onCancel: {
+                    isDiscardChangesModalPresented = false
+                }
+            )
         }
     }
 }

--- a/Projects/HomeFeature/Tests/HomeStoreTests.swift
+++ b/Projects/HomeFeature/Tests/HomeStoreTests.swift
@@ -25,10 +25,10 @@ struct HomeStoreTests {
     
     // MARK: - 초기 상태 테스트
     
-    @Test("초기 상태에서 userName은 빈 문자열이어야 한다")
-    func testInitialUserNameState() {
+    @Test("초기 상태에서 user는 nil이어야 한다")
+    func testInitialUserState() {
         let sut = HomeStore()
-        #expect(sut.state.userName == "")
+        #expect(sut.state.user == nil)
     }
     
     @Test("초기 상태에서 interestConcert는 nil이어야 한다")
@@ -70,7 +70,7 @@ struct HomeStoreTests {
         try await Task.sleep(nanoseconds: 100_000_000)
         
         // Then
-        #expect(sut.state.userName == "홍길동")
+        #expect(sut.state.user?.nickname == "홍길동")
     }
     
     @Test("onAppear 시 관심 공연이 있으면 스케줄과 셋리스트가 로드되어야 한다")

--- a/Projects/HomeFeature/Tests/HomeStoreTests.swift
+++ b/Projects/HomeFeature/Tests/HomeStoreTests.swift
@@ -30,7 +30,9 @@ struct HomeStoreTests {
         let sut = HomeStore()
         #expect(sut.state.user == nil)
     }
-    
+
+    // MARK: - onAppear 테스트
+
     @Test("onAppear 시 유저 정보와 읽지 않은 알림 수를 조회해야 한다")
     func testOnAppearFetchesUserAndUnreadNotificationCount() async throws {
         // Given
@@ -50,6 +52,8 @@ struct HomeStoreTests {
         #expect(sut.state.hasNewNotice)
     }
 
+    // MARK: - Route 결정 테스트
+
     @Test("유저 조회 결과에서 interestedConcertID가 nil이면 route는 concertSection이어야 한다")
     func testUserResultWithNilInterestConcertIDSetsConcertSectionRoute() {
         let sut = HomeStore()
@@ -68,6 +72,60 @@ struct HomeStoreTests {
         sut.send(._fetchUserResult(.success(user)))
 
         #expect(sut.state.route == .interestedConcert)
+    }
+
+    // MARK: - ConcertSection 상태 테스트
+
+    @Test("concertSection onAppear 시 섹션/추천 데이터가 로드되어야 한다")
+    func testConcertSectionOnAppearLoadsSectionsAndRecommendations() async throws {
+        // Given
+        let sut = HomeStore()
+        let section = makeMockSection(id: 1)
+        let recommended = [makeMockConcert(id: 10), makeMockConcert(id: 11)]
+        let user = makeMockUser(hasPreferences: true)
+
+        container.concertRepository.homeSectionListStub = [section]
+        container.concertRepository.recommendedConcertListStub = recommended
+        sut.send(._fetchUserResult(.success(user)))
+
+        // When
+        sut.send(.concertSection(.onAppear))
+
+        // Then (immediate)
+        #expect(sut.state.sections.isLoading)
+        #expect(!sut.state.sections.isInitialLoad)
+
+        // Then (after async)
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(container.concertRepository.fetchHomeConcertSectionListCallCount == 1)
+        #expect(container.concertRepository.fetchRecommendedConcertListCallCount == 1)
+        #expect(sut.state.sections.sectionList.count == 1)
+        #expect(sut.state.sections.sectionList.first?.id == section.id)
+        #expect(sut.state.sections.recommendedConcertList.count == 2)
+        #expect(!sut.state.sections.shouldShowPreferenceBanner)
+        #expect(!sut.state.sections.isLoading)
+    }
+
+    @Test("concertSection onAppear 시 hasPreferences가 false면 추천을 조회하지 않고 배너를 표시해야 한다")
+    func testConcertSectionOnAppearShowsPreferenceBannerWhenUserHasNoPreferences() async throws {
+        // Given
+        let sut = HomeStore()
+        let section = makeMockSection(id: 2)
+        let user = makeMockUser(hasPreferences: false)
+
+        container.concertRepository.homeSectionListStub = [section]
+        sut.send(._fetchUserResult(.success(user)))
+
+        // When
+        sut.send(.concertSection(.onAppear))
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then
+        #expect(container.concertRepository.fetchHomeConcertSectionListCallCount == 1)
+        #expect(container.concertRepository.fetchRecommendedConcertListCallCount == 0)
+        #expect(sut.state.sections.sectionList.count == 1)
+        #expect(sut.state.sections.shouldShowPreferenceBanner)
+        #expect(sut.state.sections.recommendedConcertList.isEmpty)
     }
 }
 

--- a/Projects/HomeFeature/Tests/HomeStoreTests.swift
+++ b/Projects/HomeFeature/Tests/HomeStoreTests.swift
@@ -127,6 +127,119 @@ struct HomeStoreTests {
         #expect(sut.state.sections.shouldShowPreferenceBanner)
         #expect(sut.state.sections.recommendedConcertList.isEmpty)
     }
+
+    // MARK: - InterestConcert 상태 테스트
+
+    @Test("interestConcert onAppear 시 관심 공연과 상세 데이터를 로드해야 한다")
+    func testInterestConcertOnAppearLoadsConcertAndDetailState() async throws {
+        // Given
+        let sut = HomeStore()
+        let concert = makeMockConcert(id: 100)
+        let schedule = makeMockSchedule(id: 200)
+        let setlist = makeMockSetlist(id: 300)
+        let songs = [makeMockSong(id: 400, orderIndex: 1), makeMockSong(id: 401, orderIndex: 2)]
+
+        container.userRepository.interestedConcertStub = concert
+        container.concertRepository.scheduleListStub = [schedule]
+        container.concertRepository.mainSetlistStub = setlist
+        container.setlistRepository.setlistSongsStub = songs
+
+        // When
+        sut.send(.interestConcert(.onAppear))
+        try await Task.sleep(nanoseconds: 150_000_000)
+
+        // Then
+        #expect(container.userRepository.fetchInterestedConcertCallCount == 1)
+        #expect(container.concertRepository.fetchConcertScheduleListCallCount == 1)
+        #expect(container.concertRepository.fetchMainSetlistCallCount == 1)
+        #expect(container.setlistRepository.fetchSetlistSongsCallCount == 1)
+        #expect(sut.state.interestConcert.concert?.id == concert.id)
+        #expect(sut.state.interestConcert.scheduleList.count == 1)
+        #expect(sut.state.interestConcert.scheduleList.first?.id == schedule.id)
+        #expect(sut.state.interestConcert.setlist?.id == setlist.id)
+        #expect(sut.state.interestConcert.songList.count == 2)
+    }
+
+    @Test("interestConcert onRefresh 시 현재 concert가 없으면 관심 공연을 다시 조회해야 한다")
+    func testInterestConcertOnRefreshWithoutConcertFetchesInterestedConcert() async throws {
+        // Given
+        let sut = HomeStore()
+        container.userRepository.interestedConcertStub = nil
+
+        // When
+        sut.send(.interestConcert(.onRefresh))
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then
+        #expect(container.userRepository.fetchInterestedConcertCallCount == 1)
+    }
+
+    @Test("관심 공연 조회 결과가 nil이면 상세 상태를 초기화해야 한다")
+    func testFetchUserInterestConcertResultNilClearsDetailState() {
+        // Given
+        let sut = HomeStore()
+        sut.send(.interestConcert(._fetchScheduleListResult(.success([makeMockSchedule(id: 1)]))))
+        sut.send(.interestConcert(._fetchMainSetlistResult(.success(makeMockSetlist(id: 2)))))
+        sut.send(.interestConcert(._fetchSetlistSongListResult(.success([makeMockSong(id: 3)]))))
+
+        // When
+        sut.send(.interestConcert(._fetchUserInterestConcertResult(.success(nil))))
+
+        // Then
+        #expect(sut.state.interestConcert.concert == nil)
+        #expect(sut.state.interestConcert.scheduleList.isEmpty)
+        #expect(sut.state.interestConcert.setlist == nil)
+        #expect(sut.state.interestConcert.songList.isEmpty)
+    }
+
+    @Test("관심 공연 삭제 성공 결과를 받으면 상태를 비우고 토스트를 표시해야 한다")
+    func testDeleteInterestConcertResultSuccessClearsStateAndShowsToast() {
+        // Given
+        let sut = HomeStore()
+        sut.send(.interestConcert(._fetchScheduleListResult(.success([makeMockSchedule(id: 10)]))))
+        sut.send(.interestConcert(._fetchMainSetlistResult(.success(makeMockSetlist(id: 11)))))
+        sut.send(.interestConcert(._fetchSetlistSongListResult(.success([makeMockSong(id: 12)]))))
+
+        // When
+        sut.send(.interestConcert(._deleteInterestConcertResult(.success(()))))
+
+        // Then
+        #expect(sut.state.interestConcert.concert == nil)
+        #expect(sut.state.interestConcert.scheduleList.isEmpty)
+        #expect(sut.state.interestConcert.setlist == nil)
+        #expect(sut.state.interestConcert.songList.isEmpty)
+        #expect(sut.state.toastMessage == "관심 공연을 삭제했어요")
+    }
+
+    // MARK: - Toast 상태 테스트
+
+    @Test("onToastDisappear 호출 시 toastMessage는 비워져야 한다")
+    func testOnToastDisappearClearsToastMessage() {
+        // Given
+        let sut = HomeStore()
+        sut.send(.interestConcert(._deleteInterestConcertResult(.success(()))))
+        #expect(!sut.state.toastMessage.isEmpty)
+
+        // When
+        sut.send(.onToastDisappear)
+
+        // Then
+        #expect(sut.state.toastMessage.isEmpty)
+    }
+
+    @Test("onErrorToastDisappear 호출 시 errorMessage는 비워져야 한다")
+    func testOnErrorToastDisappearClearsErrorMessage() {
+        // Given
+        let sut = HomeStore()
+        sut.send(._fetchUserResult(.failure(UserError.serverError)))
+        #expect(!sut.state.errorMessage.isEmpty)
+
+        // When
+        sut.send(.onErrorToastDisappear)
+
+        // Then
+        #expect(sut.state.errorMessage.isEmpty)
+    }
 }
 
 // MARK: - Helpers

--- a/Projects/HomeFeature/Tests/HomeStoreTests.swift
+++ b/Projects/HomeFeature/Tests/HomeStoreTests.swift
@@ -31,37 +31,11 @@ struct HomeStoreTests {
         #expect(sut.state.user == nil)
     }
     
-    @Test("초기 상태에서 interestConcert는 nil이어야 한다")
-    func testInitialInterestConcertState() {
-        let sut = HomeStore()
-        #expect(sut.state.interestConcert.concert == nil)
-    }
-    
-    @Test("초기 상태에서 scheduleList는 비어있어야 한다")
-    func testInitialScheduleListState() {
-        let sut = HomeStore()
-        #expect(sut.state.interestConcert.scheduleList.isEmpty)
-    }
-    
-    @Test("초기 상태에서 shouldShowPreferenceBanner는 false이어야 한다")
-    func testInitialPreferenceBannerState() {
-        let sut = HomeStore()
-        #expect(sut.state.sections.shouldShowPreferenceBanner == false)
-    }
-    
-    @Test("초기 상태에서 recommendedConcerts는 비어있어야 한다")
-    func testInitialRecommendedConcertsState() {
-        let sut = HomeStore()
-        #expect(sut.state.sections.recommendedConcertList.isEmpty)
-    }
-    
-    // MARK: - onAppear 테스트
-    
-    @Test("onAppear 시 사용자 정보가 로드되어야 한다")
-    func testOnAppearLoadsUser() async throws {
+    @Test("onAppear 시 유저 정보와 읽지 않은 알림 수를 조회해야 한다")
+    func testOnAppearFetchesUserAndUnreadNotificationCount() async throws {
         // Given
         container.userRepository.userStub = makeMockUser(nickname: "홍길동")
-        container.userRepository.interestedConcertStub = nil
+        container.notificationRepository.unreadNotificationCountStub = 3
         
         let sut = HomeStore()
         
@@ -70,422 +44,30 @@ struct HomeStoreTests {
         try await Task.sleep(nanoseconds: 100_000_000)
         
         // Then
+        #expect(container.userRepository.fetchUserCallCount == 1)
+        #expect(container.notificationRepository.fetchUnreadNotificationCountCallCount == 1)
         #expect(sut.state.user?.nickname == "홍길동")
+        #expect(sut.state.hasNewNotice)
     }
-    
-    @Test("onAppear 시 관심 공연이 있으면 스케줄과 셋리스트가 로드되어야 한다")
-    func testOnAppearLoadsInterestConcertWithDetails() async throws {
-        // Given
-        let concert = makeMockConcert()
-        container.userRepository.userStub = makeMockUser()
-        container.userRepository.interestedConcertStub = concert
-        container.concertRepository.scheduleListStub = [makeMockSchedule()]
-        container.concertRepository.mainSetlistStub = makeMockSetlist()
-        container.setlistRepository.setlistSongsStub = [makeMockSong()]
-        
+
+    @Test("유저 조회 결과에서 interestedConcertID가 nil이면 route는 concertSection이어야 한다")
+    func testUserResultWithNilInterestConcertIDSetsConcertSectionRoute() {
         let sut = HomeStore()
-        
-        // When
-        sut.send(.onAppear)
-        try await Task.sleep(nanoseconds: 150_000_000)
-        
-        // Then
-        #expect(sut.state.interestConcert.concert?.id == concert.id)
-        #expect(!sut.state.interestConcert.scheduleList.isEmpty)
-        #expect(sut.state.interestConcert.setlist != nil)
-        #expect(!sut.state.interestConcert.songList.isEmpty)
+        let user = makeMockUser(interestConcertID: nil)
+
+        sut.send(._fetchUserResult(.success(user)))
+
+        #expect(sut.state.route == .concertSection)
     }
-    
-    @Test("onAppear 사용자 정보 로드 실패 시 에러 메시지가 설정되어야 한다")
-    func testOnAppearUserLoadFailure() async throws {
-        // Given
-        container.userRepository.errorStub = .serverError
-        
+
+    @Test("유저 조회 결과에서 interestedConcertID가 있으면 route는 interestedConcert여야 한다")
+    func testUserResultWithInterestConcertIDSetsInterestedConcertRoute() {
         let sut = HomeStore()
-        
-        // When
-        sut.send(.onAppear)
-        try await Task.sleep(nanoseconds: 100_000_000)
-        
-        // Then
-        #expect(container.userRepository.fetchUserCallCount > 0)
-        #expect(!sut.state.errorMessage.isEmpty)
-    }
-    
-    // MARK: - 토스트 관리 테스트
-    
-    @Test("onErrorToastDisappear 시 에러 메시지가 초기화되어야 한다")
-    func testOnErrorToastDisappear() async throws {
-        // Given
-        container.userRepository.errorStub = .serverError
-        let sut = HomeStore()
-        sut.send(.onAppear)
-        try await Task.sleep(nanoseconds: 100_000_000)
-        
-        // Precondition
-        #expect(!sut.state.errorMessage.isEmpty)
-        
-        // When
-        sut.send(.onErrorToastDisappear)
-        
-        // Then
-        #expect(sut.state.errorMessage.isEmpty)
-    }
-    
-    @Test("onToastDisappear 시 토스트 메시지가 초기화되어야 한다")
-    func testOnToastDisappear() async throws {
-        // Given
-        container.userRepository.userStub = makeMockUser()
-        container.userRepository.interestedConcertStub = makeMockConcert()
-        
-        let sut = HomeStore()
-        sut.send(.interestConcert(.onDelete))
-        try await Task.sleep(nanoseconds: 100_000_000)
-        
-        // Precondition
-        #expect(!sut.state.toastMessage.isEmpty)
-        
-        // When
-        sut.send(.onToastDisappear)
-        
-        // Then
-        #expect(sut.state.toastMessage.isEmpty)
-    }
-    
-    // MARK: - 관심 공연 삭제 테스트
-    
-    @Test("onDelete 성공 시 관심 공연이 삭제되고 토스트가 표시되어야 한다")
-    func testOnDeleteSuccess() async throws {
-        // Given
-        container.userRepository.userStub = makeMockUser()
-        container.userRepository.interestedConcertStub = makeMockConcert()
-        
-        let concert = makeMockConcert()
-        let schedule = makeMockSchedule()
-        let setlist = makeMockSetlist()
-        let song = makeMockSong()
-        
-        let sut = HomeStore()
-        sut.send(.interestConcert(._fetchUserInterestConcertResult(.success(concert))))
-        sut.send(.interestConcert(._fetchScheduleListResult(.success([schedule]))))
-        sut.send(.interestConcert(._fetchMainSetlistResult(.success(setlist))))
-        sut.send(.interestConcert(._fetchSetlistSongListResult(.success([song]))))
-        
-        // Precondition
-        #expect(sut.state.interestConcert.concert != nil)
-        #expect(!sut.state.interestConcert.scheduleList.isEmpty)
-        #expect(sut.state.interestConcert.setlist != nil)
-        #expect(!sut.state.interestConcert.songList.isEmpty)
-        
-        // When
-        sut.send(.interestConcert(.onDelete))
-        try await Task.sleep(nanoseconds: 100_000_000)
-        
-        // Then
-        #expect(sut.state.interestConcert.concert == nil)
-        #expect(sut.state.interestConcert.scheduleList.isEmpty)
-        #expect(sut.state.interestConcert.setlist == nil)
-        #expect(sut.state.interestConcert.songList.isEmpty)
-        #expect(sut.state.toastMessage == "관심 공연을 삭제했어요")
-    }
-    
-    @Test("onDelete 실패 시 에러 메시지가 설정되어야 한다")
-    func testOnDeleteFailure() async throws {
-        // Given
-        container.userRepository.errorStub = .serverError
-        
-        let sut = HomeStore()
-        
-        // When
-        sut.send(.interestConcert(.onDelete))
-        try await Task.sleep(nanoseconds: 100_000_000)
-        
-        // Then
-        #expect(!sut.state.errorMessage.isEmpty)
-    }
-    
-    // MARK: - 관심 공연 새로고침 테스트
-    
-    @Test("관심 공연이 있을 때 onRefreshInterestConcert 시 스케줄과 셋리스트가 새로고침되어야 한다")
-    func testOnRefreshInterestConcertWithExistingConcert() async throws {
-        // Given
-        let concert = makeMockConcert()
-        container.userRepository.userStub = makeMockUser()
-        container.userRepository.interestedConcertStub = concert
-        container.concertRepository.scheduleListStub = [makeMockSchedule()]
-        container.concertRepository.mainSetlistStub = makeMockSetlist()
-        container.setlistRepository.setlistSongsStub = [makeMockSong()]
-        
-        let sut = HomeStore()
-        sut.send(.onAppear)
-        try await Task.sleep(nanoseconds: 150_000_000)
-        
-        // Reset call counts
-        container.concertRepository.fetchConcertScheduleListCallCount = 0
-        container.concertRepository.fetchMainSetlistCallCount = 0
-        
-        // When
-        sut.send(.interestConcert(.onRefresh))
-        try await Task.sleep(nanoseconds: 100_000_000)
-        
-        // Then
-        #expect(container.concertRepository.fetchConcertScheduleListCallCount > 0)
-        #expect(container.concertRepository.fetchMainSetlistCallCount > 0)
-    }
-    
-    @Test("관심 공연이 없을 때 onRefreshInterestConcert 시 관심 공연을 다시 로드해야 한다")
-    func testOnRefreshInterestConcertWithNoConcert() async throws {
-        // Given
-        container.userRepository.userStub = makeMockUser()
-        container.userRepository.interestedConcertStub = nil
-        
-        let sut = HomeStore()
-        
-        // Reset call count
-        container.userRepository.fetchInterestedConcertCallCount = 0
-        
-        // When
-        sut.send(.interestConcert(.onRefresh))
-        try await Task.sleep(nanoseconds: 100_000_000)
-        
-        // Then
-        #expect(container.userRepository.fetchInterestedConcertCallCount > 0)
-    }
-    
-    // MARK: - 섹션 새로고침 테스트
-    
-    @Test("onRefreshSections 시 isSectionsLoading이 true가 되어야 한다")
-    func testOnRefreshSectionsLoading() async throws {
-        // Given
-        container.userRepository.userStub = makeMockUser()
-        container.concertRepository.homeSectionListStub = [makeMockSection()]
-        
-        let sut = HomeStore()
-        
-        // When
-        sut.send(.concertSection(.onRefresh))
-        
-        // Then - 즉시 체크
-        #expect(sut.state.sections.isLoading == true)
-    }
-    
-    @Test("섹션 로드 성공 시 sectionList가 업데이트되고 로딩이 false가 되어야 한다")
-    func testOnRefreshSectionsSuccess() async throws {
-        // Given
-        container.userRepository.userStub = makeMockUser()
-        container.concertRepository.homeSectionListStub = [makeMockSection()]
-        
-        let sut = HomeStore()
-        try await Task.sleep(nanoseconds: 100_000_000)
-        container.concertRepository.fetchHomeConcertSectionListCallCount = 0
-        
-        // When
-        sut.send(.concertSection(.onRefresh))
-        try await Task.sleep(nanoseconds: 100_000_000)
-        
-        // Then
-        #expect(container.concertRepository.fetchHomeConcertSectionListCallCount > 0)
-        #expect(!sut.state.sections.sectionList.isEmpty)
-        #expect(sut.state.sections.isLoading == false)
-    }
-    
-    @Test("콘서트 섹션 onAppear 최초 로드 시 로딩이 true에서 false로 전환되어야 한다")
-    func testConcertSectionOnAppearInitialLoadTogglesLoading() async throws {
-        // Given
-        container.userRepository.userStub = makeMockUser()
-        container.concertRepository.homeSectionListStub = [makeMockSection()]
-        
-        let sut = HomeStore()
-        
-        // When
-        sut.send(.concertSection(.onAppear))
-        
-        // Then - 즉시 체크
-        #expect(sut.state.sections.isLoading == true)
-        
-        // When - 비동기 완료 대기
-        try await Task.sleep(nanoseconds: 150_000_000)
-        
-        // Then
-        #expect(sut.state.sections.isLoading == false)
-    }
-    
-    @Test("콘서트 섹션 onAppear 재호출 시 섹션 조회는 수행하지 않아야 한다")
-    func testConcertSectionOnAppearSkipsSectionFetchAfterInitialLoad() async throws {
-        // Given
-        container.userRepository.userStub = makeMockUser()
-        container.concertRepository.homeSectionListStub = [makeMockSection()]
-        
-        let sut = HomeStore()
-        
-        // First onAppear
-        sut.send(.concertSection(.onAppear))
-        try await Task.sleep(nanoseconds: 150_000_000)
-        
-        // Reset call count
-        container.concertRepository.fetchHomeConcertSectionListCallCount = 0
-        
-        // When - second onAppear
-        sut.send(.concertSection(.onAppear))
-        try await Task.sleep(nanoseconds: 100_000_000)
-        
-        // Then
-        #expect(container.concertRepository.fetchHomeConcertSectionListCallCount == 0)
-    }
-    
-    // MARK: - Preference 배너 테스트
-    
-    @Test("hasPreferences가 false이면 배너를 표시해야 한다")
-    func testShowPreferenceBannerWhenHasPreferencesFalse() async throws {
-        // Given
-        container.userRepository.userStub = makeMockUser(hasPreferences: false)
-        
-        let sut = HomeStore()
-        sut.send(._fetchUserResult(.success(makeMockUser(hasPreferences: false))))
-        
-        // When
-        try await Task.sleep(nanoseconds: 100_000_000)
-        
-        // Then
-        #expect(sut.state.sections.shouldShowPreferenceBanner == true)
-    }
-    
-    @Test("hasPreferences가 true이면 배너를 표시하지 않아야 한다")
-    func testHidePreferenceBannerWhenHasPreferencesTrue() async throws {
-        // Given
-        container.userRepository.userStub = makeMockUser(hasPreferences: true)
-        
-        let sut = HomeStore()
-        sut.send(._fetchUserResult(.success(makeMockUser(hasPreferences: true))))
-        
-        // When
-        try await Task.sleep(nanoseconds: 100_000_000)
-        
-        // Then
-        #expect(sut.state.sections.shouldShowPreferenceBanner == false)
-    }
-    
-    @Test("추천 로드 실패 시에도 배너는 hasPreferences 기준으로 유지되어야 한다")
-    func testPreferenceBannerWhenRecommendationFetchFails() async throws {
-        // Given
-        container.userRepository.userStub = makeMockUser(hasPreferences: true)
-        container.concertRepository.errorStub = ConcertError.serverError
-        
-        let sut = HomeStore()
-        sut.send(._fetchUserResult(.success(makeMockUser(hasPreferences: true))))
-        
-        // When
-        try await Task.sleep(nanoseconds: 100_000_000)
-        
-        // Then
-        #expect(sut.state.sections.shouldShowPreferenceBanner == false)
-        #expect(sut.state.sections.errorMessage.isEmpty)
-    }
-    
-    @Test("onAppear 시 hasPreferences에 따라 배너가 설정되어야 한다")
-    func testCheckShowBannerOnAppear() async throws {
-        // Given
-        container.userRepository.userStub = makeMockUser(hasPreferences: false)
-        container.userRepository.interestedConcertStub = nil
-        container.concertRepository.homeSectionListStub = []
-        
-        let sut = HomeStore()
-        
-        // When
-        sut.send(.onAppear)
-        try await Task.sleep(nanoseconds: 100_000_000)
-        
-        // Then
-        #expect(container.concertRepository.fetchRecommendedConcertListCallCount == 0)
-        #expect(sut.state.sections.shouldShowPreferenceBanner == true)
-    }
-    
-    // MARK: - 추천 콘서트 테스트
-    
-    @Test("hasPreferences가 true이면 추천 콘서트가 로드되어야 한다")
-    func testFetchRecommendedConcertWhenHasPreferencesTrue() async throws {
-        // Given
-        let mockRecommendedConcerts = [makeMockConcert(id: 1), makeMockConcert(id: 2)]
-        
-        container.userRepository.userStub = makeMockUser(hasPreferences: true)
-        container.concertRepository.recommendedConcertListStub = mockRecommendedConcerts
-        
-        let sut = HomeStore()
-        
-        // When
-        sut.send(.onAppear)
-        try await Task.sleep(nanoseconds: 100_000_000)
-        
-        // Then
-        #expect(container.concertRepository.fetchRecommendedConcertListCallCount > 0)
-        #expect(!sut.state.sections.recommendedConcertList.isEmpty)
-        #expect(sut.state.sections.recommendedConcertList.count == 2)
-    }
-    
-    @Test("hasPreferences가 false이면 추천 콘서트가 로드되지 않아야 한다")
-    func testFetchRecommendedConcertWhenHasPreferencesFalse() async throws {
-        // Given
-        container.userRepository.userStub = makeMockUser(hasPreferences: false)
-        container.concertRepository.recommendedConcertListStub = []
-        
-        let sut = HomeStore()
-        
-        // Reset call count
-        container.concertRepository.fetchRecommendedConcertListCallCount = 0
-        
-        // When
-        sut.send(.onAppear)
-        try await Task.sleep(nanoseconds: 100_000_000)
-        
-        // Then
-        #expect(container.concertRepository.fetchRecommendedConcertListCallCount == 0)
-        #expect(sut.state.sections.recommendedConcertList.isEmpty)
-    }
-    
-    @Test("추천 콘서트 로드 실패 시 리스트는 비어야 한다")
-    func testFetchRecommendedConcertFailure() async throws {
-        // Given
-        container.userRepository.userStub = makeMockUser(hasPreferences: true)
-        container.concertRepository.errorStub = ConcertError.serverError
-        
-        let sut = HomeStore()
-        
-        // When
-        sut.send(.onAppear)
-        try await Task.sleep(nanoseconds: 100_000_000)
-        
-        // Then
-        #expect(sut.state.sections.recommendedConcertList.isEmpty)
-        #expect(sut.state.sections.errorMessage.isEmpty)
-    }
-    
-    // MARK: - 연쇄 호출 테스트
-    
-    @Test("관심 공연이 nil로 변경될 때 스케줄, 셋리스트, 곡 목록이 비워져야 한다")
-    func testInterestConcertNilClearsRelatedData() async throws {
-        // Given
-        let concert = makeMockConcert()
-        container.userRepository.userStub = makeMockUser()
-        container.userRepository.interestedConcertStub = concert
-        container.concertRepository.scheduleListStub = [makeMockSchedule()]
-        container.concertRepository.mainSetlistStub = makeMockSetlist()
-        container.setlistRepository.setlistSongsStub = [makeMockSong()]
-        
-        let sut = HomeStore()
-        sut.send(.onAppear)
-        try await Task.sleep(nanoseconds: 150_000_000)
-        
-        // Precondition
-        #expect(!sut.state.interestConcert.scheduleList.isEmpty)
-        
-        // When - 관심 공연을 nil로 받음
-        sut.send(.interestConcert(._fetchUserInterestConcertResult(.success(nil))))
-        
-        // Then
-        #expect(sut.state.interestConcert.concert == nil)
-        #expect(sut.state.interestConcert.scheduleList.isEmpty)
-        #expect(sut.state.interestConcert.setlist == nil)
-        #expect(sut.state.interestConcert.songList.isEmpty)
+        let user = makeMockUser(interestConcertID: 123)
+
+        sut.send(._fetchUserResult(.success(user)))
+
+        #expect(sut.state.route == .interestedConcert)
     }
 }
 
@@ -510,10 +92,14 @@ private extension HomeStoreTests {
         )
     }
     
-    func makeMockUser(nickname: String = "테스트유저", hasPreferences: Bool = false) -> User {
+    func makeMockUser(
+        nickname: String = "테스트유저",
+        hasPreferences: Bool = false,
+        interestConcertID: Int? = nil
+    ) -> User {
         User(
             id: 1,
-            interestConcertID: nil,
+            interestConcertID: interestConcertID,
             provider: "APPLE",
             providerID: "12345",
             email: "test@test.com",

--- a/Projects/HomeFeature/Tests/Mock/MockDIContainer.swift
+++ b/Projects/HomeFeature/Tests/Mock/MockDIContainer.swift
@@ -13,12 +13,14 @@ import Domain
 
 final class MockDIContainer {
     let userRepository = MockUserRepository()
+    let notificationRepository = MockNotificationRepository()
     let concertRepository = MockConcertRepository()
     let setlistRepository = MockSetlistRepository()
     let preferenceRepository = MockPreferenceRepository()
     
     func registerDependencies() {
         DIContainer.shared.register(userRepository, for: UserRepository.self)
+        DIContainer.shared.register(notificationRepository, for: NotificationRepository.self)
         DIContainer.shared.register(concertRepository, for: ConcertRepository.self)
         DIContainer.shared.register(setlistRepository, for: SetlistRepository.self)
         DIContainer.shared.register(preferenceRepository, for: PreferenceRepository.self)

--- a/Projects/HomeFeature/Tests/Mock/MockNotificationRepository.swift
+++ b/Projects/HomeFeature/Tests/Mock/MockNotificationRepository.swift
@@ -1,0 +1,82 @@
+//
+//  MockNotificationRepository.swift
+//  HomeFeatureTests
+//
+//  Created by 김진웅 on 2/13/26.
+//  Copyright © 2026 Livith. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+
+final class MockNotificationRepository: NotificationRepository {
+    var unreadNotificationCountStub: Int = 0
+    var errorStub: NotificationError?
+
+    var fetchUnreadNotificationCountCallCount: Int = 0
+
+    func fetchNotificationList(cursor: Int?, size: Int) async throws(NotificationError) -> [NotificationItem] {
+        if let error = errorStub {
+            throw error
+        }
+        return []
+    }
+
+    func markNotificationAsRead(id: Int) async throws(NotificationError) {
+        if let error = errorStub {
+            throw error
+        }
+    }
+
+    func fetchUnreadNotificationCount() async throws(NotificationError) -> Int {
+        fetchUnreadNotificationCountCallCount += 1
+        if let error = errorStub {
+            throw error
+        }
+        return unreadNotificationCountStub
+    }
+
+    func updateNotificationConsent(
+        field: NotificationConsentField,
+        isAgreed: Bool
+    ) async throws(NotificationError) -> NotificationConsentResult {
+        if let error = errorStub {
+            throw error
+        }
+        return NotificationConsentResult(sender: "mock", agreedAt: "mock", message: "mock")
+    }
+
+    func updateMarketingConsent() async throws(NotificationError) -> NotificationConsentResult {
+        if let error = errorStub {
+            throw error
+        }
+        return NotificationConsentResult(sender: "mock", agreedAt: "mock", message: "mock")
+    }
+
+    func fetchNotificationSettings() async throws(NotificationError) -> NotificationSettings {
+        if let error = errorStub {
+            throw error
+        }
+        return NotificationSettings(
+            benefitAlert: false,
+            nightAlert: false,
+            ticketAlert: false,
+            infoAlert: false,
+            interestAlert: false,
+            recommendAlert: false
+        )
+    }
+
+    func registerFCMToken(_ token: String) async throws(NotificationError) {
+        if let error = errorStub {
+            throw error
+        }
+    }
+
+    func deleteFCMToken(_ token: String) async throws(NotificationError) {
+        if let error = errorStub {
+            throw error
+        }
+    }
+}

--- a/Projects/HomeFeature/Tests/Mock/MockUserRepository.swift
+++ b/Projects/HomeFeature/Tests/Mock/MockUserRepository.swift
@@ -40,6 +40,17 @@ final class MockUserRepository: UserRepository {
         return user
     }
     
+    func refreshUser() async throws(UserError) -> User {
+        fetchUserCallCount += 1
+        if let error = errorStub {
+            throw error
+        }
+        guard let user = userStub else {
+            throw UserError.serverError
+        }
+        return user
+    }
+    
     func fetchInterestedConcert() async throws(UserError) -> Concert? {
         fetchInterestedConcertCallCount += 1
         if let error = errorStub {

--- a/Projects/LoginFeature/Sources/Onboarding/View/PreferredGenreSettingView.swift
+++ b/Projects/LoginFeature/Sources/Onboarding/View/PreferredGenreSettingView.swift
@@ -10,9 +10,12 @@ import SwiftUI
 
 import Domain
 import PreferenceFeature
+import LivithDesignSystem
 
 struct PreferredGenreSettingView: View {
     @Environment(\.loginCoordinator) private var coordinator
+
+    @State private var isDiscardChangesModalPresented: Bool = false
     
     private let builder: SignupBuilder
     
@@ -21,11 +24,29 @@ struct PreferredGenreSettingView: View {
     }
     
     var body: some View {
-        GenreEditView(config: .genreOnboarding()) { _ in
-            coordinator?.pop()
+        GenreEditView(config: .genreOnboarding()) { isModified in
+            if isModified {
+                isDiscardChangesModalPresented = true
+            } else {
+                coordinator?.pop()
+            }
         } onSubmit: { selectedGenreList in
             let updated = builder.withPreferredGenreList(selectedGenreList)
             coordinator?.push(to: .preferredArtist(updated))
+        }
+        .crossDissolve(isPresented: $isDiscardChangesModalPresented, dismissOnTapOutside: false) {
+            LivithDangerModal(
+                message: "선택된 아티스트나 장르가 해제돼요.\n이전 페이지로 돌아가시나요?",
+                confirmTitle: "뒤로 갈게요",
+                cancelTitle: "잘못 눌렀어요",
+                type: .confirm(onConfirm: {
+                    isDiscardChangesModalPresented = false
+                    coordinator?.pop()
+                }),
+                onCancel: {
+                    isDiscardChangesModalPresented = false
+                }
+            )
         }
     }
 }

--- a/Projects/Shared/NicknameEditFeature/Tests/NicknameEditStoreTests.swift
+++ b/Projects/Shared/NicknameEditFeature/Tests/NicknameEditStoreTests.swift
@@ -78,6 +78,20 @@ final class MockUserRepository: UserRepository {
             providerID: "123",
             email: nil,
             nickname: "test",
+            hasPreferences: false,
+            authority: UserAuthority(deviceNotification: true, marketingConsent: false)
+        )
+    }
+    
+    func refreshUser() async throws(UserError) -> User {
+        User(
+            id: 1,
+            interestConcertID: nil,
+            provider: "kakao",
+            providerID: "123",
+            email: nil,
+            nickname: "test",
+            hasPreferences: false,
             authority: UserAuthority(deviceNotification: true, marketingConsent: false)
         )
     }

--- a/Projects/Shared/PreferenceFeature/Sources/Artist/Store/ArtistSelectionStore.swift
+++ b/Projects/Shared/PreferenceFeature/Sources/Artist/Store/ArtistSelectionStore.swift
@@ -138,7 +138,7 @@ private extension ArtistSelectionStore {
     func searchArtistList(keyword: String?) {
         Task {
             do {
-                let result = try await preferenceRepository.searchArtistList(keyword: keyword, size: 12, cursor: nil)
+                let result = try await preferenceRepository.searchArtistList(keyword: keyword, size: 18, cursor: nil)
                 await send(._searchResult(.success(result.artists)))
             } catch {
                 await send(._searchResult(.failure(error)))
@@ -150,7 +150,7 @@ private extension ArtistSelectionStore {
         Task {
             do {
                 let searchKeyword = keyword.isEmpty ? nil : keyword
-                let result = try await preferenceRepository.searchArtistList(keyword: searchKeyword, size: 12, cursor: cursor)
+                let result = try await preferenceRepository.searchArtistList(keyword: searchKeyword, size: 18, cursor: cursor)
                 await send(._searchMoreResult(.success(result.artists)))
             } catch {
                 await send(._searchMoreResult(.failure(error)))

--- a/Projects/Shared/PreferenceFeature/Sources/Artist/View/ArtistEditView.swift
+++ b/Projects/Shared/PreferenceFeature/Sources/Artist/View/ArtistEditView.swift
@@ -140,7 +140,7 @@ private extension ArtistEditView {
         LivithButton(config.submitTitle, isLoading: isSubmitting) {
             onSubmit(store.state.selectedArtistList)
         }
-        .disabled(store.state.selectedArtistList.isEmpty || isSubmitting)
+        .disabled(isSubmitButtonDisabled)
     }
 }
 
@@ -149,6 +149,11 @@ private extension ArtistEditView {
 private extension ArtistEditView {
     var selectedCountText: String {
         "\(store.state.selectedArtistList.count)/\(PreferenceSelectionRule.maxCount)"
+    }
+
+    var isSubmitButtonDisabled: Bool {
+        if isSubmitting { return true }
+        return config.shouldDisableSubmitWhenEmpty && store.state.selectedArtistList.isEmpty
     }
     
     var searchTextBinding: Binding<String> {

--- a/Projects/Shared/PreferenceFeature/Sources/Artist/View/ArtistSelectionView.swift
+++ b/Projects/Shared/PreferenceFeature/Sources/Artist/View/ArtistSelectionView.swift
@@ -117,15 +117,14 @@ private extension ArtistSelectionView {
     }
     
     var selectedArtistChips: some View {
-        HStack(spacing: Constants.chipSpacing) {
+        FlowLayout(spacing: Constants.chipSpacing) {
             ForEach(store.state.selectedArtistList) { artist in
                 RemovableChip(artist.name) {
                     store.send(.toggle(id: artist.id))
                 }
             }
-            
-            Spacer()
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/Projects/Shared/PreferenceFeature/Sources/Genre/View/GenreEditView.swift
+++ b/Projects/Shared/PreferenceFeature/Sources/Genre/View/GenreEditView.swift
@@ -63,7 +63,7 @@ public struct GenreEditView: View {
                 LivithButton(config.submitTitle, isLoading: isSubmitting) {
                     onSubmit(selectionStore.state.selectedGenreList)
                 }
-                .disabled(selectionStore.state.selectedGenreList.isEmpty)
+                .disabled(isSubmitButtonDisabled)
                 .padding(.bottom, Constants.bottomPadding)
             }
             .padding(.horizontal, Constants.horizontalPadding)
@@ -105,6 +105,11 @@ private extension GenreEditView {
 private extension GenreEditView {
     var selectedCountText: String {
         "\(selectionStore.state.selectedGenreList.count)/\(PreferenceSelectionRule.maxCount)"
+    }
+
+    var isSubmitButtonDisabled: Bool {
+        if isSubmitting { return true }
+        return config.shouldDisableSubmitWhenEmpty && selectionStore.state.selectedGenreList.isEmpty
     }
 }
 

--- a/Projects/Shared/PreferenceFeature/Sources/Genre/View/GenreSelectionView.swift
+++ b/Projects/Shared/PreferenceFeature/Sources/Genre/View/GenreSelectionView.swift
@@ -87,15 +87,14 @@ private extension GenreSelectionView {
     }
     
     var selectedGenreChips: some View {
-        HStack(spacing: Constants.chipSpacing) {
+        FlowLayout(spacing: Constants.chipSpacing) {
             ForEach(store.state.selectedGenreList) { genre in
                 RemovableChip(genre.displayName) {
                     store.send(.toggle(id: genre.id))
                 }
             }
-            
-            Spacer()
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/Projects/Shared/PreferenceFeature/Sources/Model/PreferenceEditConfig.swift
+++ b/Projects/Shared/PreferenceFeature/Sources/Model/PreferenceEditConfig.swift
@@ -13,17 +13,20 @@ public struct PreferenceEditConfig {
     public let stepIndicator: (current: Int, total: Int)?
     public let showSubtitle: Bool
     public let submitTitle: String
+    public let shouldDisableSubmitWhenEmpty: Bool
     
     public init(
         navigationTitle: String,
         stepIndicator: (current: Int, total: Int)? = nil,
         showSubtitle: Bool = false,
-        submitTitle: String
+        submitTitle: String,
+        shouldDisableSubmitWhenEmpty: Bool = true
     ) {
         self.navigationTitle = navigationTitle
         self.stepIndicator = stepIndicator
         self.showSubtitle = showSubtitle
         self.submitTitle = submitTitle
+        self.shouldDisableSubmitWhenEmpty = shouldDisableSubmitWhenEmpty
     }
 }
 
@@ -50,10 +53,11 @@ public extension PreferenceEditConfig {
     
     static func artistEdit() -> PreferenceEditConfig {
         PreferenceEditConfig(
-            navigationTitle: "아티스트 변경",
+            navigationTitle: "아티스트 설정",
             stepIndicator: nil,
             showSubtitle: false,
-            submitTitle: "변경하기"
+            submitTitle: "설정하기",
+            shouldDisableSubmitWhenEmpty: false
         )
     }
 }
@@ -81,10 +85,10 @@ public extension PreferenceEditConfig {
     
     static func genreEdit() -> PreferenceEditConfig {
         PreferenceEditConfig(
-            navigationTitle: "장르 변경",
+            navigationTitle: "장르 설정",
             stepIndicator: nil,
             showSubtitle: false,
-            submitTitle: "변경하기"
+            submitTitle: "설정하기"
         )
     }
 }

--- a/Projects/Shared/PreferenceFeature/Tests/ArtistSelectionStoreTests.swift
+++ b/Projects/Shared/PreferenceFeature/Tests/ArtistSelectionStoreTests.swift
@@ -112,7 +112,7 @@ struct ArtistSelectionStoreTests {
         let selectedArtist = PreferredArtist(id: 1, name: "IU", genreID: 1, imageURL: nil)
         
         // When
-        let sut = ArtistSelectionStore(selectedArtists: [selectedArtist])
+        let sut = ArtistSelectionStore(selectedArtistList: [selectedArtist])
         
         // Then
         #expect(sut.state.selectedArtistList.count == 1)
@@ -131,7 +131,7 @@ struct ArtistSelectionStoreTests {
         container.preferenceRepository.artistSearchResultStub = ArtistSearchResult(artists: artists, cursor: nil, totalCount: 4)
         
         let initialSelection = [artists[0], artists[1], artists[2]]
-        let sut = ArtistSelectionStore(selectedArtists: initialSelection)
+        let sut = ArtistSelectionStore(selectedArtistList: initialSelection)
         sut.send(.onAppear)
         try await Task.sleep(nanoseconds: 100_000_000)
         

--- a/Projects/Shared/PreferenceFeature/Tests/GenreSelectionStoreTests.swift
+++ b/Projects/Shared/PreferenceFeature/Tests/GenreSelectionStoreTests.swift
@@ -93,7 +93,7 @@ struct GenreSelectionStoreTests {
         container.preferenceRepository.genreListStub = [genre]
         
         // 초기 선택 상태 주입
-        let sut = GenreSelectionStore(selectedGenres: [genre])
+        let sut = GenreSelectionStore(selectedGenreList: [genre])
         sut.send(.onAppear) // 장르 로드
         try await Task.sleep(nanoseconds: 100_000_000)
         
@@ -120,7 +120,7 @@ struct GenreSelectionStoreTests {
             PreferredGenre(id: 3, name: "Jazz", imageURL: nil)
         ]
         
-        let sut = GenreSelectionStore(selectedGenres: initialSelection)
+        let sut = GenreSelectionStore(selectedGenreList: initialSelection)
         sut.send(.onAppear)
         try await Task.sleep(nanoseconds: 100_000_000)
         
@@ -156,7 +156,7 @@ struct GenreSelectionStoreTests {
         let selectedGenre = PreferredGenre(id: 1, name: "Pop", imageURL: nil)
         
         // When
-        let sut = GenreSelectionStore(selectedGenres: [selectedGenre])
+        let sut = GenreSelectionStore(selectedGenreList: [selectedGenre])
         
         // Then
         #expect(sut.state.selectedGenreList.count == 1)

--- a/Projects/Shared/PreferenceFeature/Tests/Mock/MockPreferenceRepository.swift
+++ b/Projects/Shared/PreferenceFeature/Tests/Mock/MockPreferenceRepository.swift
@@ -15,9 +15,11 @@ final class MockPreferenceRepository: PreferenceRepository {
     var artistSearchResultStub: ArtistSearchResult = ArtistSearchResult(artists: [], cursor: nil, totalCount: 0)
     var errorStub: PreferenceError?
     
+    var fetchGenreListCallCount: Int = 0
     var searchArtistListCallCount: Int = 0
     
     func fetchGenreList() async throws(PreferenceError) -> [PreferredGenre] {
+        fetchGenreListCallCount += 1
         if let error = errorStub {
             throw error
         }

--- a/Projects/UserFeature/Sources/Store/UserArtistUpdateStore.swift
+++ b/Projects/UserFeature/Sources/Store/UserArtistUpdateStore.swift
@@ -52,9 +52,7 @@ final class UserArtistUpdateStore: ObservableObject {
 // MARK: - Helpers
 
 private extension UserArtistUpdateStore {
-    func performUpdateUserArtists(_ artistList: [PreferredArtist]) {
-        guard !artistList.isEmpty else { return }
-        
+    func performUpdateUserArtists(_ artistList: [PreferredArtist]) {        
         Task {
             do {
                 try await preferenceRepository.updateUserPreferredArtistList(artistIDs: artistList.map { $0.id })


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 5차 스프린트 qa 사항을 반영하였습니다.
    - 장르 선택 후 뒤로가기 시, 경고 모달이 보이지 않는 문제
    - 유저 탭에서 아티스트 설정 시, '변경' 대신 '설정' 키워드 사용
    - 취향 아티스트 진입 시, 검색 바 활성 후 해지 시 무한 스크롤이 막혀 다시 올려야 하는 문제
    - 홈 화면 최초 진입 시, 올바르지 않은 형태로 보여지는 문제
    - 홈 화면 진입 시 배너 크기가 초기화 되지 않는 문제
    - 홈 탭 콘서트 섹션에서 추천 콘서트 섹션 더보기 버튼 관련 문제
    - 선호 설정 시 선택된 내용의 이름이 길 경우, 줄바꿈이 안되는 문제

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- HomeStore를 위한 테스트 케이스를 재 작성했습니다.

## 🔗 연결된 이슈
- Resolved: #219
