### PR TITLE
[Fix] 최초 홈 화면 진입 시, 데이터가 제대로 보이지 않는 문제 해결

### DIFF
--- a/Projects/HomeFeature/Sources/Home/Store/HomeStore.swift
+++ b/Projects/HomeFeature/Sources/Home/Store/HomeStore.swift
@@ -25,7 +25,6 @@ enum HomeIntent {
     enum InterestConcertIntent {
         case onDelete
         case onRefresh
-        case onAppear
         case _fetchUserInterestConcertResult(Result<Concert?, Error>)
         case _fetchScheduleListResult(Result<[ConcertSchedule], Error>)
         case _fetchMainSetlistResult(Result<Setlist, Error>)
@@ -34,7 +33,6 @@ enum HomeIntent {
     }
     
     enum ConcertSectionIntent {
-        case onAppear
         case onRefresh
         case _concertSectionDataResult(Result<HomeState.ConcertSectionState.Data, Error>)
     }
@@ -55,6 +53,7 @@ struct HomeState {
     var sections: ConcertSectionState = .init()
     
     struct InterestConcertState {
+        var isInitialLoad: Bool = true
         var concert: Concert? = nil
         var scheduleList: [ConcertSchedule] = []
         var setlist: Setlist? = nil
@@ -117,6 +116,8 @@ final class HomeStore: ObservableObject {
             case .success(let user):
                 state.user = user
                 state.route = user.interestConcertID == nil ? .concertSection : .interestedConcert
+                prepareInitialLoad(for: state.route)
+                executeInitialLoad(for: state.route)
             case .failure(let error):
                 state.errorMessage = getErrorMessage(from: error)
             }
@@ -147,8 +148,6 @@ private extension HomeStore {
             performDeleteInterestConcert()
         case .onRefresh:
             executeRefreshInterestConcert()
-        case .onAppear:
-            performFetchUserInterestedConcert()
         case ._fetchUserInterestConcertResult(let result):
             handleFetchUserInterestConcertResult(result)
         case ._fetchScheduleListResult(let result):
@@ -169,6 +168,13 @@ private extension HomeStore {
         } else {
             performFetchUserInterestedConcert()
         }
+    }
+
+    func executeInitialInterestConcertLoadIfNeeded() {
+        guard state.user != nil else { return }
+        guard state.interestConcert.isInitialLoad else { return }
+        state.interestConcert.isInitialLoad = false
+        performFetchUserInterestedConcert()
     }
     
     func handleFetchUserInterestConcertResult(_ result: Result<Concert?, Error>) {
@@ -240,17 +246,20 @@ private extension HomeStore {
 private extension HomeStore {
     func handleConcertSectionIntent(_ intent: HomeIntent.ConcertSectionIntent) {
         switch intent {
-        case .onAppear:
-            if state.sections.isInitialLoad {
-                state.sections.isLoading = true
-                state.sections.isInitialLoad = false
-            }
-            performFetchConcertSectionData()
         case .onRefresh:
             performFetchConcertSectionData()
         case ._concertSectionDataResult(let result):
             handleConcertSectionDataResult(result)
         }
+    }
+
+    func executeInitialConcertSectionLoadIfNeeded() {
+        guard state.user != nil else { return }
+        guard state.sections.isInitialLoad else { return }
+
+        state.sections.isLoading = true
+        state.sections.isInitialLoad = false
+        performFetchConcertSectionData()
     }
     
     func handleConcertSectionDataResult(
@@ -390,6 +399,26 @@ private extension HomeStore {
 // MARK: - Utilities
 
 private extension HomeStore {
+    func executeInitialLoad(for route: HomeState.Route) {
+        switch route {
+        case .concertSection:
+            executeInitialConcertSectionLoadIfNeeded()
+        case .interestedConcert:
+            executeInitialInterestConcertLoadIfNeeded()
+        }
+    }
+
+    func prepareInitialLoad(for route: HomeState.Route) {
+        switch route {
+        case .concertSection:
+            state.sections.isInitialLoad = true
+            state.interestConcert.isInitialLoad = false
+        case .interestedConcert:
+            state.interestConcert.isInitialLoad = true
+            state.sections.isInitialLoad = false
+        }
+    }
+
     func fetchRecommendationsIfNeeded() async -> [Concert]? {
         guard let hasPreferences = state.user?.hasPreferences else { return nil }
         if hasPreferences {

--- a/Projects/HomeFeature/Sources/Home/Store/HomeStore.swift
+++ b/Projects/HomeFeature/Sources/Home/Store/HomeStore.swift
@@ -81,7 +81,6 @@ final class HomeStore: ObservableObject {
         case fetchInterestedConcert
         case fetchScheduleList
         case fetchMainSetlist
-        case fetchSetlistSongList
         case fetchUser
         case refreshSections
         case fetchUnreadNotificationCount
@@ -116,7 +115,6 @@ final class HomeStore: ObservableObject {
             case .success(let user):
                 state.user = user
                 state.route = user.interestConcertID == nil ? .concertSection : .interestedConcert
-                prepareInitialLoad(for: state.route)
                 executeInitialLoad(for: state.route)
             case .failure(let error):
                 state.errorMessage = getErrorMessage(from: error)
@@ -139,148 +137,128 @@ final class HomeStore: ObservableObject {
     }
 }
 
-// MARK: - Interest Concert Intent Handlers
+// MARK: - Intent Reducers
 
 private extension HomeStore {
     func handleInterestConcertIntent(_ intent: HomeIntent.InterestConcertIntent) {
         switch intent {
         case .onDelete:
             performDeleteInterestConcert()
-        case .onRefresh:
-            executeRefreshInterestConcert()
-        case ._fetchUserInterestConcertResult(let result):
-            handleFetchUserInterestConcertResult(result)
-        case ._fetchScheduleListResult(let result):
-            handleFetchScheduleListResult(result)
-        case ._fetchMainSetlistResult(let result):
-            handleFetchMainSetlistResult(result)
-        case ._fetchSetlistSongListResult(let result):
-            handleFetchSetlistSongListResult(result)
-        case ._deleteInterestConcertResult(let result):
-            handleDeleteInterestConcertResult(result)
-        }
-    }
-    
-    func executeRefreshInterestConcert() {
-        if let concert = state.interestConcert.concert {
-            performFetchScheduleList(concertID: concert.id)
-            performFetchMainSetlist(concertID: concert.id)
-        } else {
-            performFetchUserInterestedConcert()
-        }
-    }
 
-    func executeInitialInterestConcertLoadIfNeeded() {
-        guard state.user != nil else { return }
-        guard state.interestConcert.isInitialLoad else { return }
-        state.interestConcert.isInitialLoad = false
-        performFetchUserInterestedConcert()
-    }
-    
-    func handleFetchUserInterestConcertResult(_ result: Result<Concert?, Error>) {
-        switch result {
-        case .success(let concert):
-            state.interestConcert.concert = concert
-            
-            if let concert {
+        case .onRefresh:
+            if let concert = state.interestConcert.concert {
                 performFetchScheduleList(concertID: concert.id)
                 performFetchMainSetlist(concertID: concert.id)
             } else {
+                performFetchUserInterestedConcert()
+            }
+
+        case ._fetchUserInterestConcertResult(let result):
+            switch result {
+            case .success(let concert):
+                state.interestConcert.concert = concert
+                if let concert {
+                    performFetchScheduleList(concertID: concert.id)
+                    performFetchMainSetlist(concertID: concert.id)
+                } else {
+                    state.interestConcert.scheduleList = []
+                    state.interestConcert.setlist = nil
+                    state.interestConcert.songList = []
+                }
+            case .failure(let error):
+                state.interestConcert.concert = nil
+                state.errorMessage = getErrorMessage(from: error)
+            }
+
+        case ._fetchScheduleListResult(let result):
+            switch result {
+            case .success(let schedules):
+                state.interestConcert.scheduleList = schedules
+            case .failure(let error):
+                state.interestConcert.scheduleList = []
+                state.errorMessage = getErrorMessage(from: error)
+            }
+
+        case ._fetchMainSetlistResult(let result):
+            switch result {
+            case .success(let setlist):
+                state.interestConcert.setlist = setlist
+            case .failure(let error):
+                state.interestConcert.setlist = nil
+                state.interestConcert.songList = []
+                state.errorMessage = getErrorMessage(from: error)
+            }
+
+        case ._fetchSetlistSongListResult(let result):
+            switch result {
+            case .success(let songs):
+                state.interestConcert.songList = songs
+            case .failure(let error):
+                state.interestConcert.songList = []
+                state.errorMessage = getErrorMessage(from: error)
+            }
+
+        case ._deleteInterestConcertResult(let result):
+            switch result {
+            case .success:
+                state.interestConcert.concert = nil
                 state.interestConcert.scheduleList = []
                 state.interestConcert.setlist = nil
                 state.interestConcert.songList = []
+                state.toastMessage = "관심 공연을 삭제했어요"
+            case .failure(let error):
+                state.errorMessage = error.localizedDescription
             }
-        case .failure(let error):
-            state.interestConcert.concert = nil
-            state.errorMessage = getErrorMessage(from: error)
-        }
-    }
-    
-    func handleFetchScheduleListResult(_ result: Result<[ConcertSchedule], Error>) {
-        switch result {
-        case .success(let schedules):
-            state.interestConcert.scheduleList = schedules
-        case .failure(let error):
-            state.interestConcert.scheduleList = []
-            state.errorMessage = getErrorMessage(from: error)
-        }
-    }
-    
-    func handleFetchMainSetlistResult(_ result: Result<Setlist, Error>) {
-        switch result {
-        case .success(let setlist):
-            state.interestConcert.setlist = setlist
-        case .failure(let error):
-            state.interestConcert.setlist = nil
-            state.interestConcert.songList = []
-            state.errorMessage = getErrorMessage(from: error)
-        }
-    }
-    
-    func handleFetchSetlistSongListResult(_ result: Result<[SetlistSong], Error>) {
-        switch result {
-        case .success(let songs):
-            state.interestConcert.songList = songs
-        case .failure(let error):
-            state.interestConcert.songList = []
-            state.errorMessage = getErrorMessage(from: error)
-        }
-    }
-    
-    func handleDeleteInterestConcertResult(_ result: Result<Void, Error>) {
-        switch result {
-        case .success:
-            state.interestConcert.concert = nil
-            state.interestConcert.scheduleList = []
-            state.interestConcert.setlist = nil
-            state.interestConcert.songList = []
-            state.toastMessage = "관심 공연을 삭제했어요"
-        case .failure(let error):
-            state.errorMessage = error.localizedDescription
         }
     }
 }
-
-// MARK: - Concert Section Intent Handlers
 
 private extension HomeStore {
     func handleConcertSectionIntent(_ intent: HomeIntent.ConcertSectionIntent) {
         switch intent {
         case .onRefresh:
             performFetchConcertSectionData()
+
         case ._concertSectionDataResult(let result):
-            handleConcertSectionDataResult(result)
-        }
-    }
+            state.sections.isLoading = false
 
-    func executeInitialConcertSectionLoadIfNeeded() {
-        guard state.user != nil else { return }
-        guard state.sections.isInitialLoad else { return }
-
-        state.sections.isLoading = true
-        state.sections.isInitialLoad = false
-        performFetchConcertSectionData()
-    }
-    
-    func handleConcertSectionDataResult(
-        _ result: Result<HomeState.ConcertSectionState.Data, Error>
-    ) {
-        state.sections.isLoading = false
-        
-        switch result {
-        case .success(let data):
-            state.sections.sectionList = data.sections
-            state.sections.shouldShowPreferenceBanner = !(state.user?.hasPreferences ?? false)
-            state.sections.recommendedConcertList = data.recommended ?? []
-            state.sections.errorMessage = ""
-            
-        case .failure(let error):
-            state.sections.errorMessage = getErrorMessage(from: error)
+            switch result {
+            case .success(let data):
+                state.sections.sectionList = data.sections
+                state.sections.shouldShowPreferenceBanner = !(state.user?.hasPreferences ?? false)
+                state.sections.recommendedConcertList = data.recommended ?? []
+                state.sections.errorMessage = ""
+            case .failure(let error):
+                state.sections.errorMessage = getErrorMessage(from: error)
+            }
         }
     }
 }
 
-// MARK: - Network Operations
+// MARK: - Initial Load Control
+
+private extension HomeStore {
+    func executeInitialConcertSectionLoadIfNeeded() {
+        guard state.user != nil else { return }
+        
+        if state.sections.isInitialLoad {
+            state.sections.isLoading = true
+            state.sections.isInitialLoad = false
+        }
+        
+        performFetchConcertSectionData()
+    }
+
+    func executeInitialInterestConcertLoadIfNeeded() {
+        guard state.user != nil else { return }
+        if state.interestConcert.isInitialLoad {
+            state.interestConcert.isInitialLoad = false
+        }
+        performFetchUserInterestedConcert()
+    }
+}
+
+// MARK: - Effects
 
 private extension HomeStore {
     func performFetchUserInterestedConcert() {
@@ -349,18 +327,6 @@ private extension HomeStore {
             }
         }
     }
-
-    func performFetchSetlistSongList(setlistID: Int) {
-        cancellables[.fetchSetlistSongList]?.cancel()
-        cancellables[.fetchSetlistSongList] = Task {
-            do {
-                let songList = try await setlistRepository.fetchSetlistSongs(setlistID: setlistID)
-                send(.interestConcert(._fetchSetlistSongListResult(.success(songList))))
-            } catch {
-                send(.interestConcert(._fetchSetlistSongListResult(.failure(error))))
-            }
-        }
-    }
     
     func performDeleteInterestConcert() {
         Task {
@@ -396,7 +362,7 @@ private extension HomeStore {
     }
 }
 
-// MARK: - Utilities
+// MARK: - Route Load Strategy
 
 private extension HomeStore {
     func executeInitialLoad(for route: HomeState.Route) {
@@ -407,18 +373,11 @@ private extension HomeStore {
             executeInitialInterestConcertLoadIfNeeded()
         }
     }
+}
 
-    func prepareInitialLoad(for route: HomeState.Route) {
-        switch route {
-        case .concertSection:
-            state.sections.isInitialLoad = true
-            state.interestConcert.isInitialLoad = false
-        case .interestedConcert:
-            state.interestConcert.isInitialLoad = true
-            state.sections.isInitialLoad = false
-        }
-    }
+// MARK: - Utilities
 
+private extension HomeStore {
     func fetchRecommendationsIfNeeded() async -> [Concert]? {
         guard let hasPreferences = state.user?.hasPreferences else { return nil }
         if hasPreferences {

--- a/Projects/HomeFeature/Sources/Home/View/HomeConcertSectionView.swift
+++ b/Projects/HomeFeature/Sources/Home/View/HomeConcertSectionView.swift
@@ -45,10 +45,6 @@ struct HomeConcertSectionView: View {
             .ignoresSafeArea(edges: .bottom)
         }
         .background(.livithColor(.black90))
-        .onAppear {
-            isPreferenceBannerExpanded = true
-            store.send(.concertSection(.onAppear))
-        }
     }
 }
 

--- a/Projects/HomeFeature/Sources/Home/View/HomeConcertSectionView.swift
+++ b/Projects/HomeFeature/Sources/Home/View/HomeConcertSectionView.swift
@@ -45,6 +45,9 @@ struct HomeConcertSectionView: View {
             .ignoresSafeArea(edges: .bottom)
         }
         .background(.livithColor(.black90))
+        .onAppear {
+            isPreferenceBannerExpanded = true
+        }
     }
 }
 

--- a/Projects/HomeFeature/Sources/Home/View/HomeInterestConcertView.swift
+++ b/Projects/HomeFeature/Sources/Home/View/HomeInterestConcertView.swift
@@ -52,9 +52,6 @@ struct HomeInterestConcertView: View {
                     onDeleteConcert: handleDeleteConcert
                 )
             }
-            .onAppear {
-                store.send(.interestConcert(.onAppear))
-            }
     }
 }
 

--- a/Projects/HomeFeature/Tests/HomeStoreTests.swift
+++ b/Projects/HomeFeature/Tests/HomeStoreTests.swift
@@ -79,6 +79,23 @@ struct HomeStoreTests {
         #expect(sut.state.sections.recommendedConcertList.first?.id == recommended.first?.id)
     }
 
+    @Test("같은 route의 유저 조회 결과가 다시 들어와도 초기 로딩은 한 번만 수행되어야 한다")
+    func testUserResultDoesNotResetInitialLoadForSameRoute() async throws {
+        let sut = HomeStore()
+        let user = makeMockUser(hasPreferences: true, interestConcertID: nil)
+
+        container.concertRepository.homeSectionListStub = [makeMockSection(id: 10)]
+        container.concertRepository.recommendedConcertListStub = [makeMockConcert(id: 100)]
+
+        sut.send(._fetchUserResult(.success(user)))
+        try await Task.sleep(nanoseconds: 100_000_000)
+        sut.send(._fetchUserResult(.success(user)))
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(container.concertRepository.fetchHomeConcertSectionListCallCount == 1)
+        #expect(container.concertRepository.fetchRecommendedConcertListCallCount == 1)
+    }
+
     @Test("유저 조회 결과에서 interestedConcertID가 있으면 interestedConcert route를 설정하고 데이터를 로드해야 한다")
     func testUserResultWithInterestConcertIDSetsInterestedConcertRoute() async throws {
         let sut = HomeStore()

--- a/Projects/HomeFeature/Tests/HomeStoreTests.swift
+++ b/Projects/HomeFeature/Tests/HomeStoreTests.swift
@@ -33,91 +33,90 @@ struct HomeStoreTests {
 
     // MARK: - onAppear 테스트
 
-    @Test("onAppear 시 유저 정보와 읽지 않은 알림 수를 조회해야 한다")
+    @Test("onAppear 시 유저/알림 조회 후 route에 필요한 데이터를 이어서 로드해야 한다")
     func testOnAppearFetchesUserAndUnreadNotificationCount() async throws {
         // Given
         container.userRepository.userStub = makeMockUser(nickname: "홍길동")
         container.notificationRepository.unreadNotificationCountStub = 3
+        container.concertRepository.homeSectionListStub = [makeMockSection(id: 1)]
         
         let sut = HomeStore()
         
         // When
         sut.send(.onAppear)
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await Task.sleep(nanoseconds: 150_000_000)
         
         // Then
         #expect(container.userRepository.fetchUserCallCount == 1)
         #expect(container.notificationRepository.fetchUnreadNotificationCountCallCount == 1)
+        #expect(container.concertRepository.fetchHomeConcertSectionListCallCount == 1)
+        #expect(container.concertRepository.fetchRecommendedConcertListCallCount == 0)
         #expect(sut.state.user?.nickname == "홍길동")
         #expect(sut.state.hasNewNotice)
+        #expect(sut.state.route == .concertSection)
+        #expect(sut.state.sections.sectionList.count == 1)
     }
 
     // MARK: - Route 결정 테스트
 
-    @Test("유저 조회 결과에서 interestedConcertID가 nil이면 route는 concertSection이어야 한다")
-    func testUserResultWithNilInterestConcertIDSetsConcertSectionRoute() {
+    @Test("유저 조회 결과에서 interestedConcertID가 nil이면 concertSection route를 설정하고 데이터를 로드해야 한다")
+    func testUserResultWithNilInterestConcertIDSetsConcertSectionRoute() async throws {
         let sut = HomeStore()
-        let user = makeMockUser(interestConcertID: nil)
+        let user = makeMockUser(hasPreferences: true, interestConcertID: nil)
+        let section = makeMockSection(id: 5)
+        let recommended = [makeMockConcert(id: 21)]
+
+        container.concertRepository.homeSectionListStub = [section]
+        container.concertRepository.recommendedConcertListStub = recommended
 
         sut.send(._fetchUserResult(.success(user)))
+        try await Task.sleep(nanoseconds: 100_000_000)
 
         #expect(sut.state.route == .concertSection)
+        #expect(container.concertRepository.fetchHomeConcertSectionListCallCount == 1)
+        #expect(container.concertRepository.fetchRecommendedConcertListCallCount == 1)
+        #expect(sut.state.sections.sectionList.first?.id == section.id)
+        #expect(sut.state.sections.recommendedConcertList.first?.id == recommended.first?.id)
     }
 
-    @Test("유저 조회 결과에서 interestedConcertID가 있으면 route는 interestedConcert여야 한다")
-    func testUserResultWithInterestConcertIDSetsInterestedConcertRoute() {
+    @Test("유저 조회 결과에서 interestedConcertID가 있으면 interestedConcert route를 설정하고 데이터를 로드해야 한다")
+    func testUserResultWithInterestConcertIDSetsInterestedConcertRoute() async throws {
         let sut = HomeStore()
         let user = makeMockUser(interestConcertID: 123)
+        let concert = makeMockConcert(id: 100)
+        let schedule = makeMockSchedule(id: 200)
+        let setlist = makeMockSetlist(id: 300)
+        let songs = [makeMockSong(id: 400, orderIndex: 1), makeMockSong(id: 401, orderIndex: 2)]
+
+        container.userRepository.interestedConcertStub = concert
+        container.concertRepository.scheduleListStub = [schedule]
+        container.concertRepository.mainSetlistStub = setlist
+        container.setlistRepository.setlistSongsStub = songs
 
         sut.send(._fetchUserResult(.success(user)))
+        try await Task.sleep(nanoseconds: 150_000_000)
 
         #expect(sut.state.route == .interestedConcert)
+        #expect(container.userRepository.fetchInterestedConcertCallCount == 1)
+        #expect(container.concertRepository.fetchConcertScheduleListCallCount == 1)
+        #expect(container.concertRepository.fetchMainSetlistCallCount == 1)
+        #expect(container.setlistRepository.fetchSetlistSongsCallCount == 1)
+        #expect(sut.state.interestConcert.concert?.id == concert.id)
     }
 
     // MARK: - ConcertSection 상태 테스트
 
-    @Test("concertSection onAppear 시 섹션/추천 데이터가 로드되어야 한다")
-    func testConcertSectionOnAppearLoadsSectionsAndRecommendations() async throws {
-        // Given
-        let sut = HomeStore()
-        let section = makeMockSection(id: 1)
-        let recommended = [makeMockConcert(id: 10), makeMockConcert(id: 11)]
-        let user = makeMockUser(hasPreferences: true)
-
-        container.concertRepository.homeSectionListStub = [section]
-        container.concertRepository.recommendedConcertListStub = recommended
-        sut.send(._fetchUserResult(.success(user)))
-
-        // When
-        sut.send(.concertSection(.onAppear))
-
-        // Then (immediate)
-        #expect(sut.state.sections.isLoading)
-        #expect(!sut.state.sections.isInitialLoad)
-
-        // Then (after async)
-        try await Task.sleep(nanoseconds: 100_000_000)
-        #expect(container.concertRepository.fetchHomeConcertSectionListCallCount == 1)
-        #expect(container.concertRepository.fetchRecommendedConcertListCallCount == 1)
-        #expect(sut.state.sections.sectionList.count == 1)
-        #expect(sut.state.sections.sectionList.first?.id == section.id)
-        #expect(sut.state.sections.recommendedConcertList.count == 2)
-        #expect(!sut.state.sections.shouldShowPreferenceBanner)
-        #expect(!sut.state.sections.isLoading)
-    }
-
-    @Test("concertSection onAppear 시 hasPreferences가 false면 추천을 조회하지 않고 배너를 표시해야 한다")
-    func testConcertSectionOnAppearShowsPreferenceBannerWhenUserHasNoPreferences() async throws {
+    @Test("concertSection route가 결정되고 hasPreferences가 false면 추천 없이 배너를 표시해야 한다")
+    func testConcertSectionRouteShowsPreferenceBannerWhenUserHasNoPreferences() async throws {
         // Given
         let sut = HomeStore()
         let section = makeMockSection(id: 2)
         let user = makeMockUser(hasPreferences: false)
 
         container.concertRepository.homeSectionListStub = [section]
-        sut.send(._fetchUserResult(.success(user)))
 
         // When
-        sut.send(.concertSection(.onAppear))
+        sut.send(._fetchUserResult(.success(user)))
         try await Task.sleep(nanoseconds: 100_000_000)
 
         // Then
@@ -129,36 +128,6 @@ struct HomeStoreTests {
     }
 
     // MARK: - InterestConcert 상태 테스트
-
-    @Test("interestConcert onAppear 시 관심 공연과 상세 데이터를 로드해야 한다")
-    func testInterestConcertOnAppearLoadsConcertAndDetailState() async throws {
-        // Given
-        let sut = HomeStore()
-        let concert = makeMockConcert(id: 100)
-        let schedule = makeMockSchedule(id: 200)
-        let setlist = makeMockSetlist(id: 300)
-        let songs = [makeMockSong(id: 400, orderIndex: 1), makeMockSong(id: 401, orderIndex: 2)]
-
-        container.userRepository.interestedConcertStub = concert
-        container.concertRepository.scheduleListStub = [schedule]
-        container.concertRepository.mainSetlistStub = setlist
-        container.setlistRepository.setlistSongsStub = songs
-
-        // When
-        sut.send(.interestConcert(.onAppear))
-        try await Task.sleep(nanoseconds: 150_000_000)
-
-        // Then
-        #expect(container.userRepository.fetchInterestedConcertCallCount == 1)
-        #expect(container.concertRepository.fetchConcertScheduleListCallCount == 1)
-        #expect(container.concertRepository.fetchMainSetlistCallCount == 1)
-        #expect(container.setlistRepository.fetchSetlistSongsCallCount == 1)
-        #expect(sut.state.interestConcert.concert?.id == concert.id)
-        #expect(sut.state.interestConcert.scheduleList.count == 1)
-        #expect(sut.state.interestConcert.scheduleList.first?.id == schedule.id)
-        #expect(sut.state.interestConcert.setlist?.id == setlist.id)
-        #expect(sut.state.interestConcert.songList.count == 2)
-    }
 
     @Test("interestConcert onRefresh 시 현재 concert가 없으면 관심 공연을 다시 조회해야 한다")
     func testInterestConcertOnRefreshWithoutConcertFetchesInterestedConcert() async throws {

--- a/Projects/Shared/PreferenceFeature/Sources/Artist/View/ArtistSelectionView.swift
+++ b/Projects/Shared/PreferenceFeature/Sources/Artist/View/ArtistSelectionView.swift
@@ -64,20 +64,41 @@ private extension ArtistSelectionView {
         if store.state.isLoading {
             loadingIndicator
         } else {
-            ZStack(alignment: .bottom) {
-                ScrollView {
-                    artistGrid
-                        .padding(2)
-                }
-                .scrollIndicators(.hidden)
-                .scrollDismissesKeyboard(.immediately)
-                
-                if !store.state.selectedArtistList.isEmpty {
-                    selectedArtistChips
-                        .padding(.vertical, Constants.chipVerticalPadding)
-                        .background(BackgroundGradientView())
-                }
-            }
+            loadedContent
+        }
+    }
+
+    var loadedContent: some View {
+        ZStack(alignment: .bottom) {
+            artistContent
+            selectedArtistChipOverlay
+        }
+    }
+
+    @ViewBuilder
+    var artistContent: some View {
+        if store.state.artistList.isEmpty {
+            artistGridEmptyView
+        } else {
+            artistGridScrollView
+        }
+    }
+
+    var artistGridScrollView: some View {
+        ScrollView {
+            artistGrid
+                .padding(2)
+        }
+        .scrollIndicators(.hidden)
+        .scrollDismissesKeyboard(.immediately)
+    }
+
+    @ViewBuilder
+    var selectedArtistChipOverlay: some View {
+        if !store.state.selectedArtistList.isEmpty {
+            selectedArtistChips
+                .padding(.vertical, Constants.chipVerticalPadding)
+                .background(BackgroundGradientView())
         }
     }
     
@@ -92,27 +113,37 @@ private extension ArtistSelectionView {
         }
     }
     
+    var artistGridEmptyView: some View {
+        VStack {
+            Spacer()
+            
+            LivithEmptyView(text: "검색 결과가 없어요")
+            
+            Spacer()
+        }
+    }
+    
     var artistGrid: some View {
         LazyVGrid(
-            columns: Array(repeating: GridItem(.flexible(), spacing: Constants.gridSpacing), count: Constants.gridColumns),
+            columns: gridItems,
             spacing: Constants.gridSpacing
         ) {
-
             ForEach(store.state.artistList) { artist in
-                PreferenceCard(
-                    title: artist.name,
-                    imageURL: artist.imageURL,
-                    isSelected: store.state.selectedArtistList.contains(where: { $0.id == artist.id }),
-                    action: {
-                        store.send(.toggle(id: artist.id))
-                    }
-                )
-                .onAppear {
-                    if artist == store.state.artistList.last {
-                        store.send(.loadMore)
-                    }
-                }
+                artistCard(for: artist)
             }
+        }
+    }
+
+    func artistCard(for artist: PreferredArtist) -> some View {
+        PreferenceCard(
+            title: artist.name,
+            imageURL: artist.imageURL,
+            isSelected: isArtistSelected(artist),
+            action: { store.send(.toggle(id: artist.id)) }
+        )
+        .onAppear {
+            guard shouldLoadMore(for: artist) else { return }
+            store.send(.loadMore)
         }
     }
     
@@ -131,6 +162,21 @@ private extension ArtistSelectionView {
 // MARK: - Helpers
 
 private extension ArtistSelectionView {
+    var gridItems: [GridItem] {
+        Array(
+            repeating: GridItem(.flexible(), spacing: Constants.gridSpacing),
+            count: Constants.gridColumns
+        )
+    }
+
+    func isArtistSelected(_ artist: PreferredArtist) -> Bool {
+        store.state.selectedArtistList.contains(where: { $0.id == artist.id })
+    }
+
+    func shouldLoadMore(for artist: PreferredArtist) -> Bool {
+        artist == store.state.artistList.last
+    }
+
     var searchTextBinding: Binding<String> {
         Binding(
             get: { store.state.searchKeyword },


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- HomeStore의 로직을 재정렬하였습니다.
- 각 세부화면의 필요한 정보를 각 화면의 onAppear에 의해서가 아닌 Store 내부에서 결정하도록 하였습니다. 
- 선호 아티스트 선택 화면에서 검색 시 엠티뷰를 도입하였습니다.

## 🔗 연결된 이슈
- Resolved: #226
