### PR TITLE
[Fix] 홈 탭 콘서트 섹션 애니메이션 중복 및 속도 증가 문제 해결

### DIFF
--- a/Projects/HomeFeature/Sources/Home/View/Subview/InterestedConcertSettingButton.swift
+++ b/Projects/HomeFeature/Sources/Home/View/Subview/InterestedConcertSettingButton.swift
@@ -12,6 +12,7 @@ import LivithDesignSystem
 
 struct InterestedConcertSettingButton: View {
     @State private var isRotating = false
+    @State private var rotationTask: Task<Void, Never>?
     
     let action: () -> ()
     
@@ -35,7 +36,7 @@ struct InterestedConcertSettingButton: View {
     }
 }
 
-// MARK: - UIComponents
+// MARK: - Subviews
 
 private extension InterestedConcertSettingButton {
     var iconContainer: some View {
@@ -46,7 +47,10 @@ private extension InterestedConcertSettingButton {
                 .padding(4)
                 .rotationEffect(.degrees(isRotating ? 180 : 0))
                 .onAppear {
-                    startRotationTimer()
+                    startRotationTask()
+                }
+                .onDisappear {
+                    stopRotationTask()
                 }
         }
         .background(
@@ -54,17 +58,38 @@ private extension InterestedConcertSettingButton {
                 .fill(Color.livithColor(.black90))
         )
     }
-    
-    func startRotationTimer() {
-        Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { _ in
-            withAnimation(.linear(duration: 0.5)) {
-                isRotating = true
-            }
-            
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                isRotating = false
+}
+
+// MARK: - Helpers
+
+private extension InterestedConcertSettingButton {
+    func startRotationTask() {
+        rotationTask?.cancel()
+        rotationTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(2.0))
+                guard !Task.isCancelled else { break }
+                
+                await MainActor.run {
+                    withAnimation(.linear(duration: 0.5)) {
+                        isRotating = true
+                    }
+                }
+                
+                try? await Task.sleep(for: .seconds(0.5))
+                guard !Task.isCancelled else { break }
+                
+                await MainActor.run {
+                    isRotating = false
+                }
             }
         }
+    }
+    
+    func stopRotationTask() {
+        rotationTask?.cancel()
+        rotationTask = nil
+        isRotating = false
     }
 }
 

--- a/Projects/SearchFeature/Sources/Explore/View/ExploreView.swift
+++ b/Projects/SearchFeature/Sources/Explore/View/ExploreView.swift
@@ -22,18 +22,15 @@ struct ExploreView: View {
             LivithNavigationView(type: .logo())
             
             ZStack(alignment: .top) {
-                ExploreSearchButton(onTap: {
-                    AmplitudeService.shared.trackEvent(tag: .click(.searchBar))
-                    coordinator?.push(to: .search)
-                })
-                .zIndex(2)
-                .background(
-                    scrollOffset > Constants.bannerHeight - 60
-                    ? Color.livithColor(.black100)
-                    : Color.clear
-                )
+                ExploreSearchButton(onTap: handleSearchTap)
+                    .zIndex(2)
+                    .background(
+                        scrollOffset > Constants.bannerHeight - 60
+                        ? Color.livithColor(.black100)
+                        : Color.clear
+                    )
                 
-                scrollContent
+                scrollView
             }
         }
         .background(Color.livithColor(.black100))
@@ -43,7 +40,7 @@ struct ExploreView: View {
 // MARK: - Subviews
 
 private extension ExploreView {
-    var scrollContent: some View {
+    var scrollView: some View {
         ScrollView(showsIndicators: false) {
             if shouldShowEmptyState {
                 LivithEmptyView(text: emptyStateMessage)
@@ -52,11 +49,7 @@ private extension ExploreView {
                 VStack(spacing: 0) {
                     bannerView
                     
-                    ForEach(store.state.concertSections, id: \.id) { section in
-                        concertSectionRow(for: section)
-                            .padding(.top, 36)
-                            .padding(.leading, 16)
-                    }
+                    concertSectionView
                     
                     Spacer(minLength: Constants.emptySpaceHeight)
                 }
@@ -86,13 +79,14 @@ private extension ExploreView {
         )
     }
     
-    func concertSectionRow(for section: ConcertSection) -> some View {
-        ConcertSectionView(
-            concertSection: section,
-            onConcertTap: { concert in
+    var concertSectionView: some View {
+        ForEach(store.state.concertSections, id: \.id) { section in
+            ConcertSectionView(concertSection: section) { concert in
                 coordinator?.showConcertDetail(concertID: concert.id)
             }
-        )
+            .padding(.top, 36)
+            .padding(.leading, 16)
+        }
     }
 }
 
@@ -105,6 +99,11 @@ private extension ExploreView {
     
     var emptyStateMessage: String {
         store.state.errorMessage.isEmpty ? "탐색할 콘텐츠가 없습니다." : store.state.errorMessage
+    }
+    
+    func handleSearchTap() {
+        AmplitudeService.shared.trackEvent(tag: .click(.searchBar))
+        coordinator?.push(to: .search)
     }
 }
 

--- a/Projects/SearchFeature/Sources/Explore/View/ExploreView.swift
+++ b/Projects/SearchFeature/Sources/Explore/View/ExploreView.swift
@@ -26,12 +26,12 @@ struct ExploreView: View {
                     AmplitudeService.shared.trackEvent(tag: .click(.searchBar))
                     coordinator?.push(to: .search)
                 })
-                    .zIndex(2)
-                    .background(
-                        scrollOffset > Constants.bannerHeight - 60
-                        ? Color.livithColor(.black100)
-                        : Color.clear
-                    )
+                .zIndex(2)
+                .background(
+                    scrollOffset > Constants.bannerHeight - 60
+                    ? Color.livithColor(.black100)
+                    : Color.clear
+                )
                 
                 scrollContent
             }
@@ -40,32 +40,31 @@ struct ExploreView: View {
     }
 }
 
-// MARK: - UI Components
+// MARK: - Subviews
 
 private extension ExploreView {
     var scrollContent: some View {
         ScrollView(showsIndicators: false) {
-            VStack(spacing: 0) {                
-                bannerView
-                
-                ForEach(store.state.concertSections, id: \.id) { section in
-                    concertSectionRow(for: section)
-                        .padding(.top, 36)
-                        .padding(.leading, 16)
+            if shouldShowEmptyState {
+                LivithEmptyView(text: emptyStateMessage)
+                    .containerRelativeFrame(.vertical)
+            } else {
+                VStack(spacing: 0) {
+                    bannerView
+                    
+                    ForEach(store.state.concertSections, id: \.id) { section in
+                        concertSectionRow(for: section)
+                            .padding(.top, 36)
+                            .padding(.leading, 16)
+                    }
+                    
+                    Spacer(minLength: Constants.emptySpaceHeight)
                 }
-                
-                Spacer(minLength: Constants.emptySpaceHeight)
             }
         }
         .coordinateSpace(name: Literals.scrollCoordinateName)
         .refreshable {
             store.send(.onRefresh)
-        }
-        .overlay {
-            if store.state.banners.isEmpty && store.state.concertSections.isEmpty && !store.state.isLoading {
-                let message = store.state.errorMessage.isEmpty ? "탐색할 콘텐츠가 없습니다." : store.state.errorMessage
-                LivithEmptyView(text: message)
-            }
         }
     }
     
@@ -94,6 +93,18 @@ private extension ExploreView {
                 coordinator?.showConcertDetail(concertID: concert.id)
             }
         )
+    }
+}
+
+// MARK: - Helpers
+
+private extension ExploreView {
+    var shouldShowEmptyState: Bool {
+        store.state.banners.isEmpty && store.state.concertSections.isEmpty && !store.state.isLoading
+    }
+    
+    var emptyStateMessage: String {
+        store.state.errorMessage.isEmpty ? "탐색할 콘텐츠가 없습니다." : store.state.errorMessage
     }
 }
 


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 홈 탭 콘서트 섹션 화면에서 애니메이션이 빨라지는 원인을 찾고 해결하였습니다.
- 원인은 onAppear 시 타이머 작업이 추가되어, 탭 전환 등의 이벤트가 발생한다면 이러한 작업이 누적되어 빨라지는 것이 원인이었습니다.
- Task 기반으로 수정하고, 단일 작업만이 존재할 수 있도록 하였습니다.
- 탐색 탭 루트 화면에서 엠티뷰가 오므라드는 문제를 해결하였습니다.

## 🔗 연결된 이슈
- Resolved: #234
