### PR TITLE
[Fix] 변경된 콘서트 목록 조회 API 반영 및 UI 개선

### DIFF
--- a/Projects/Core/LivithNetwork/Sources/DTO/SearchFeature/FetchConcertList.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/SearchFeature/FetchConcertList.swift
@@ -13,7 +13,8 @@ import Foundation
 public extension DTO.Response {
     struct FetchConcertList: Decodable {
         public let data: [FilteredConcert]
-        public let cursor: Cursor
+        public let cursor: String
+        public let id: Int
 
         public struct FilteredConcert: Decodable {
             public let id: Int
@@ -47,11 +48,6 @@ public extension DTO.Response {
                 case introduction
                 case label
             }
-        }
-
-        public struct Cursor: Decodable {
-            public let startDate: String
-            public let id: Int
         }
     }
 }

--- a/Projects/Data/ConcertData/Sources/Repository/ConcertRepositoryImpl.swift
+++ b/Projects/Data/ConcertData/Sources/Repository/ConcertRepositoryImpl.swift
@@ -33,7 +33,7 @@ struct ConcertRepositoryImpl: ConcertRepository {
     }
     
     func fetchAllConcertList(startDate: Date?, concertID: Int?) async throws(ConcertError) -> [Concert] {
-        let cursor: String? = configureCursor(startDate: startDate, concertID: concertID)
+        let cursor: String? = configureCursor(startDate: startDate)
 
         do {
             let response: DTO.Response.FetchConcertList = try await searchService.request(
@@ -173,9 +173,8 @@ struct ConcertRepositoryImpl: ConcertRepository {
 // MARK: - Helpers
 
 private extension ConcertRepositoryImpl {
-    func configureCursor(startDate: Date?, concertID: Int?) -> String? {
-        guard let startDate, let concertID else { return nil }
-        let startDateString: String = DateFormatterService.string(from: startDate, type: .dotDate)
-        return "{\"value\":\"\(startDateString)\",\"id\":\(concertID)}"
+    func configureCursor(startDate: Date?) -> String? {
+        guard let startDate else { return nil }
+        return DateFormatterService.string(from: startDate, type: .dotDate)
     }
 }

--- a/Projects/HomeFeature/Sources/Interest/View/Subview/ConcertGridView.swift
+++ b/Projects/HomeFeature/Sources/Interest/View/Subview/ConcertGridView.swift
@@ -20,7 +20,13 @@ struct ConcertGridView: View {
     let onLoadMore: () -> Void
     
     var body: some View {
-        concerts.isEmpty ? AnyView(emptyView) : AnyView(gridView)
+        ScrollView(showsIndicators: false) {
+            if concerts.isEmpty {
+                emptyView
+            } else {
+                gridView
+            }
+        }
     }
 }
 
@@ -28,25 +34,18 @@ struct ConcertGridView: View {
 
 private extension ConcertGridView {
     var emptyView: some View {
-        VStack {
-            Spacer()
-            
-            LivithEmptyView(text: "콘서트 일정이 없어요")
-                .frame(maxWidth: .infinity)
-            
-            Spacer()
-        }
+        LivithEmptyView(text: "콘서트 일정이 없어요")
+            .frame(maxWidth: .infinity)
+            .containerRelativeFrame(.vertical)
     }
     
     var gridView: some View {
-        ScrollView(showsIndicators: false) {
-            LazyVGrid(
-                columns: Array(repeating: GridItem(.flexible(), alignment: .top), count: 3),
-                spacing: 32
-            ) {
-                ForEach(concerts, id: \.id) { concert in
-                    concertCard(for: concert)
-                }
+        LazyVGrid(
+            columns: Array(repeating: GridItem(.flexible(), alignment: .top), count: 3),
+            spacing: 32
+        ) {
+            ForEach(concerts, id: \.id) { concert in
+                concertCard(for: concert)
             }
         }
     }

--- a/Projects/HomeFeature/Sources/Interest/View/Subview/SearchResultGridView.swift
+++ b/Projects/HomeFeature/Sources/Interest/View/Subview/SearchResultGridView.swift
@@ -22,8 +22,15 @@ struct SearchResultGridView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             resultHeaderText
-            
-            searchResults.isEmpty ? AnyView(emptyView) : AnyView(gridView)
+
+            ScrollView(showsIndicators: false) {
+                if searchResults.isEmpty {
+                    emptyView
+                } else {
+                    gridView
+                }
+            }
+            .padding(.top, 20)
         }
     }
 }
@@ -42,28 +49,20 @@ private extension SearchResultGridView {
     }
     
     var emptyView: some View {
-        VStack {
-            Spacer()
-            
-            LivithEmptyView(text: "검색 결과가 없어요")
-                .frame(maxWidth: .infinity)
-            
-            Spacer()
-        }
+        LivithEmptyView(text: "검색 결과가 없어요")
+            .frame(maxWidth: .infinity)
+            .containerRelativeFrame(.vertical)
     }
     
     var gridView: some View {
-        ScrollView(showsIndicators: false) {
-            LazyVGrid(
-                columns: Array(repeating: GridItem(.flexible(), alignment: .top), count: 3),
-                spacing: 32
-            ) {
-                ForEach(searchResults, id: \.id) { concert in
-                    concertCard(for: concert)
-                }
+        LazyVGrid(
+            columns: Array(repeating: GridItem(.flexible(), alignment: .top), count: 3),
+            spacing: 32
+        ) {
+            ForEach(searchResults, id: \.id) { concert in
+                concertCard(for: concert)
             }
         }
-        .padding(.top, 20)
     }
     
     func concertCard(for concert: Concert) -> some View {


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 관심 콘서트 설정 시, 콘서트 전체 목록을 조회하는 API가 변경되어 반영하였습니다.
- 관심 콘서트 설정 시, `containerRelativeFrame`을 이용하여 스크롤뷰 컨텐츠가 없을 때에도 엠티뷰가 반응형으로 대응되도록 하였습니다.

## 🔗 연결된 이슈
- Resolved: #239 
