### PR TITLE
[Feat] 관심 콘서트 미설정한 유저의 홈 화면 기능 추가

### DIFF
--- a/Projects/DesignSystem/Sources/Components/View/LivithCalloutView.swift
+++ b/Projects/DesignSystem/Sources/Components/View/LivithCalloutView.swift
@@ -73,7 +73,7 @@ public extension LivithCalloutStyle {
         highlightColor: .livithColor(.black100),
         cornerRadius: 24,
         contentInsets: EdgeInsets(top: 7.5, leading: 15, bottom: 7.5, trailing: 15),
-        tailSize: CGSize(width: 8, height: 4),
+        tailSize: CGSize(width: 12, height: 8),
         minBubbleHeight: 32
     )
 }

--- a/Projects/DesignSystem/Sources/Components/View/LivithCalloutView.swift
+++ b/Projects/DesignSystem/Sources/Components/View/LivithCalloutView.swift
@@ -23,6 +23,13 @@ public enum LivithCalloutPlacement {
     case bottom(LivithCalloutAlignment)
 }
 
+// MARK: - LivithCalloutWidthMode
+
+public enum LivithCalloutWidthMode {
+    case intrinsic
+    case fill
+}
+
 // MARK: - LivithCalloutStyle
 
 public struct LivithCalloutStyle {
@@ -89,6 +96,7 @@ public struct LivithCalloutView: View {
     private let style: LivithCalloutStyle
     private let placement: LivithCalloutPlacement
     private let tailInset: CGFloat
+    private let widthMode: LivithCalloutWidthMode
 
     // MARK: - Initializer
 
@@ -97,13 +105,15 @@ public struct LivithCalloutView: View {
         highlight highlightText: String? = nil,
         style: LivithCalloutStyle = .gray,
         placement: LivithCalloutPlacement = .bottom(.center),
-        tailInset: CGFloat = 24
+        tailInset: CGFloat = 24,
+        widthMode: LivithCalloutWidthMode = .intrinsic
     ) {
         self.text = text
         self.highlightText = highlightText
         self.style = style
         self.placement = placement
         self.tailInset = tailInset
+        self.widthMode = widthMode
     }
 
     // MARK: - Body
@@ -120,16 +130,29 @@ public struct LivithCalloutView: View {
 // MARK: - Subviews
 
 private extension LivithCalloutView {
+    @ViewBuilder
     var bubbleView: some View {
-        Text(attributedString)
+        let text = Text(attributedString)
             .notosans(.caption1Bold)
             .multilineTextAlignment(style.textAlignment)
             .padding(style.contentInsets)
             .frame(minHeight: style.minBubbleHeight)
-            .background(
-                RoundedRectangle(cornerRadius: style.cornerRadius)
-                    .fill(style.backgroundColor)
-            )
+
+        switch widthMode {
+        case .intrinsic:
+            text
+                .background(
+                    RoundedRectangle(cornerRadius: style.cornerRadius)
+                        .fill(style.backgroundColor)
+                )
+        case .fill:
+            text
+                .frame(maxWidth: .infinity)
+                .background(
+                    RoundedRectangle(cornerRadius: style.cornerRadius)
+                        .fill(style.backgroundColor)
+                )
+        }
     }
 
     @ViewBuilder
@@ -261,8 +284,10 @@ private extension LivithCalloutPlacement {
         VStack(spacing: 20) {
             LivithCalloutView(
                 "회원가입하고 모든 서비스 이용해보세요!",
-                highlight: "모든 서비스 이용"
+                highlight: "모든 서비스 이용",
+                widthMode: .fill
             )
+            .frame(width: 272)
 
             LivithCalloutView(
                 "카카오로 최근에 로그인 했어요",

--- a/Projects/DesignSystem/Sources/Components/View/LivithCalloutView.swift
+++ b/Projects/DesignSystem/Sources/Components/View/LivithCalloutView.swift
@@ -8,6 +8,76 @@
 
 import SwiftUI
 
+// MARK: - LivithCalloutAlignment
+
+public enum LivithCalloutAlignment {
+    case leading
+    case center
+    case trailing
+}
+
+// MARK: - LivithCalloutPlacement
+
+public enum LivithCalloutPlacement {
+    case top(LivithCalloutAlignment)
+    case bottom(LivithCalloutAlignment)
+}
+
+// MARK: - LivithCalloutStyle
+
+public struct LivithCalloutStyle {
+    public let backgroundColor: Color
+    public let foregroundColor: Color
+    public let highlightColor: Color
+    public let cornerRadius: CGFloat
+    public let contentInsets: EdgeInsets
+    public let tailSize: CGSize
+    public let minBubbleHeight: CGFloat
+    public let textAlignment: TextAlignment
+
+    public init(
+        backgroundColor: Color,
+        foregroundColor: Color,
+        highlightColor: Color,
+        cornerRadius: CGFloat,
+        contentInsets: EdgeInsets,
+        tailSize: CGSize,
+        minBubbleHeight: CGFloat,
+        textAlignment: TextAlignment = .center
+    ) {
+        self.backgroundColor = backgroundColor
+        self.foregroundColor = foregroundColor
+        self.highlightColor = highlightColor
+        self.cornerRadius = cornerRadius
+        self.contentInsets = contentInsets
+        self.tailSize = tailSize
+        self.minBubbleHeight = minBubbleHeight
+        self.textAlignment = textAlignment
+    }
+}
+
+public extension LivithCalloutStyle {
+    static let gray = Self(
+        backgroundColor: .livithColor(.black80),
+        foregroundColor: .livithColor(.black50),
+        highlightColor: .livithColor(.black5),
+        cornerRadius: 24,
+        contentInsets: EdgeInsets(top: 7, leading: 12, bottom: 7, trailing: 12),
+        tailSize: CGSize(width: 12, height: 8),
+        minBubbleHeight: 32
+    )
+
+    static let yellow = Self(
+        backgroundColor: .livithColor(.yellow30),
+        foregroundColor: .livithColor(.black100),
+        highlightColor: .livithColor(.black100),
+        cornerRadius: 24,
+        contentInsets: EdgeInsets(top: 7.5, leading: 15, bottom: 7.5, trailing: 15),
+        tailSize: CGSize(width: 8, height: 4),
+        minBubbleHeight: 32
+    )
+}
+
 // MARK: - LivithCalloutView
 
 public struct LivithCalloutView: View {
@@ -16,70 +86,174 @@ public struct LivithCalloutView: View {
 
     private let text: String
     private let highlightText: String?
+    private let style: LivithCalloutStyle
+    private let placement: LivithCalloutPlacement
+    private let tailInset: CGFloat
 
     // MARK: - Initializer
 
     public init(
         _ text: String,
-        highlight highlightText: String? = nil
+        highlight highlightText: String? = nil,
+        style: LivithCalloutStyle = .gray,
+        placement: LivithCalloutPlacement = .bottom(.center),
+        tailInset: CGFloat = 24
     ) {
         self.text = text
         self.highlightText = highlightText
+        self.style = style
+        self.placement = placement
+        self.tailInset = tailInset
     }
 
     // MARK: - Body
 
     public var body: some View {
-        ZStack(alignment: .bottom) {
-            RoundedRectangle(cornerRadius: 24)
-                .fill(Color.livithColor(.black80))
-                .frame(height: 32)
-                .overlay {
-                    Text(attributedString)
-                        .notosans(.caption1Bold)
-                }
-
-            TriangleTail()
-                .fill(Color.livithColor(.black80))
-                .frame(width: 12, height: 8)
-                .offset(y: 8)
-        }
-        .frame(height: 40)
+        bubbleView
+            .padding(placement.containerPaddingEdge, style.tailSize.height)
+            .overlay(alignment: placement.overlayAlignment) {
+                tailView
+            }
     }
 }
 
-// MARK: - Helper
+// MARK: - Subviews
+
+private extension LivithCalloutView {
+    var bubbleView: some View {
+        Text(attributedString)
+            .notosans(.caption1Bold)
+            .multilineTextAlignment(style.textAlignment)
+            .padding(style.contentInsets)
+            .frame(minHeight: style.minBubbleHeight)
+            .background(
+                RoundedRectangle(cornerRadius: style.cornerRadius)
+                    .fill(style.backgroundColor)
+            )
+    }
+
+    @ViewBuilder
+    var tailView: some View {
+        let tail = TriangleTail(edge: placement.edge)
+            .fill(style.backgroundColor)
+            .frame(width: style.tailSize.width, height: style.tailSize.height)
+            .frame(maxWidth: .infinity, alignment: placement.frameAlignment)
+
+        switch placement.alignment {
+        case .leading:
+            tail.padding(.leading, resolvedTailInset)
+        case .center:
+            tail
+        case .trailing:
+            tail.padding(.trailing, resolvedTailInset)
+        }
+    }
+}
+
+// MARK: - Helpers
 
 private extension LivithCalloutView {
     var attributedString: AttributedString {
         var attributedString = AttributedString(text)
-        attributedString.foregroundColor = .livithColor(.black50)
+        attributedString.foregroundColor = style.foregroundColor
 
         if let highlightText = highlightText,
            let range = attributedString.range(of: highlightText) {
-            attributedString[range].foregroundColor = .livithColor(.black5)
+            attributedString[range].foregroundColor = style.highlightColor
         }
 
         return attributedString
+    }
+
+    var resolvedTailInset: CGFloat {
+        switch placement.alignment {
+        case .center:
+            return .zero
+        case .leading, .trailing:
+            return max(tailInset, style.cornerRadius)
+        }
     }
 }
 
 // MARK: - Triangle Tail
 
 private struct TriangleTail: Shape {
+    let edge: LivithCalloutEdge
+
     func path(in rect: CGRect) -> Path {
         var path = Path()
-        path.move(to: CGPoint(x: rect.midX, y: rect.maxY))
-        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
-        path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+
+        switch edge {
+        case .top:
+            path.move(to: CGPoint(x: rect.midX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        case .bottom:
+            path.move(to: CGPoint(x: rect.midX, y: rect.maxY))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+        }
+
         path.closeSubpath()
         return path
     }
 }
 
+private enum LivithCalloutEdge {
+    case top
+    case bottom
+}
+
+private extension LivithCalloutPlacement {
+    var edge: LivithCalloutEdge {
+        switch self {
+        case .top:
+            return .top
+        case .bottom:
+            return .bottom
+        }
+    }
+
+    var alignment: LivithCalloutAlignment {
+        switch self {
+        case .top(let alignment), .bottom(let alignment):
+            return alignment
+        }
+    }
+
+    var frameAlignment: Alignment {
+        switch alignment {
+        case .leading:
+            return .leading
+        case .center:
+            return .center
+        case .trailing:
+            return .trailing
+        }
+    }
+
+    var overlayAlignment: Alignment {
+        switch edge {
+        case .top:
+            return .top
+        case .bottom:
+            return .bottom
+        }
+    }
+
+    var containerPaddingEdge: Edge.Set {
+        switch edge {
+        case .top:
+            return .top
+        case .bottom:
+            return .bottom
+        }
+    }
+}
+
 // MARK: - Preview
 
-#Preview {
+#Preview("Gray") {
     ZStack {
         Color.livithColor(.black100)
             .ignoresSafeArea()
@@ -92,13 +266,41 @@ private struct TriangleTail: Shape {
 
             LivithCalloutView(
                 "카카오로 최근에 로그인 했어요",
-                highlight: "카카오"
+                highlight: "카카오",
+                placement: .top(.leading)
             )
 
             LivithCalloutView(
                 "Apple로 최근에 로그인 했어요",
-                highlight: "Apple"
+                highlight: "Apple",
+                placement: .bottom(.trailing),
+                tailInset: 24
             )
+        }
+        .padding()
+    }
+}
+
+#Preview("Yellow") {
+    ZStack {
+        Color.livithColor(.black100)
+            .ignoresSafeArea()
+
+        VStack(spacing: 24) {
+            LivithCalloutView(
+                "관심 콘서트 설정하고 공연 일정·셋리스트 정보 빠르게",
+                style: .yellow,
+                placement: .top(.trailing),
+                tailInset: 24
+            )
+            .frame(maxWidth: 340)
+
+            LivithCalloutView(
+                "관심 콘서트 알림과 소식을 한 곳에서 받아보세요",
+                style: .yellow,
+                placement: .bottom(.center)
+            )
+            .frame(maxWidth: 320)
         }
         .padding()
     }

--- a/Projects/HomeFeature/Sources/Home/View/ConcertSection/HomeConcertSectionView.swift
+++ b/Projects/HomeFeature/Sources/Home/View/ConcertSection/HomeConcertSectionView.swift
@@ -89,6 +89,7 @@ private extension HomeConcertSectionView {
             )
         }
         .background(Color.livithColor(.black90))
+        .zIndex(1)
     }
     
     var contentView: some View {

--- a/Projects/HomeFeature/Sources/Home/View/ConcertSection/HomeConcertSectionView.swift
+++ b/Projects/HomeFeature/Sources/Home/View/ConcertSection/HomeConcertSectionView.swift
@@ -149,7 +149,7 @@ private extension HomeConcertSectionView {
 private extension HomeConcertSectionView {
     enum Constants {
         static let emptySpaceHeight: CGFloat = 210
-        static let sectionTopPadding: CGFloat = 28
+        static let sectionTopPadding: CGFloat = 32
         static let sectionLeadingPadding: CGFloat = 16
         static let loadingMinHeight: CGFloat = 240
     }

--- a/Projects/HomeFeature/Sources/Home/View/ConcertSection/Subview/HomeHeaderView.swift
+++ b/Projects/HomeFeature/Sources/Home/View/ConcertSection/Subview/HomeHeaderView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 import LivithDesignSystem
 
 struct HomeHeaderView: View {
+    @State private var buttonHeight: CGFloat = .zero
+
     let nickname: String
     let action: () -> Void
     
@@ -29,11 +31,64 @@ struct HomeHeaderView: View {
             Spacer()
             
             InterestConcertSettingButton(action: action)
+                .background(buttonHeightReader)
+                .onPreferenceChange(InterestConcertButtonHeightPreferenceKey.self) { buttonHeight = $0 }
+                .overlay(alignment: .topTrailing) {
+                    if buttonHeight > .zero {
+                        interestConcertCallout
+                            .offset(y: buttonHeight + Constants.calloutTopSpacing)
+                            .allowsHitTesting(false)
+                    }
+                }
                 .padding(.trailing, 16)
                 .padding(.top, 24)
                 .padding(.bottom, 28)
         }
         .background(Color.livithColor(.black90))
+    }
+}
+
+// MARK: - Subviews
+
+private extension HomeHeaderView {
+    var buttonHeightReader: some View {
+        GeometryReader { proxy in
+            Color.clear
+                .preference(
+                    key: InterestConcertButtonHeightPreferenceKey.self,
+                    value: proxy.size.height
+                )
+        }
+    }
+
+    var interestConcertCallout: some View {
+        LivithCalloutView(
+            "관심 콘서트 설정하고 공연 일정•셋리스트 정보 빠르게",
+            style: .yellow,
+            placement: .top(.trailing),
+            tailInset: Constants.calloutTailInset
+        )
+        .lineLimit(1)
+        .fixedSize(horizontal: true, vertical: false)
+    }
+}
+
+// MARK: - Constants
+
+private extension HomeHeaderView {
+    enum Constants {
+        static let calloutTopSpacing: CGFloat = 12
+        static let calloutTailInset: CGFloat = 24
+    }
+}
+
+// MARK: - Preference Key
+
+private struct InterestConcertButtonHeightPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = .zero
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
     }
 }
 

--- a/Projects/HomeFeature/Sources/Home/View/ConcertSection/Subview/InterestConcertSettingButton.swift
+++ b/Projects/HomeFeature/Sources/Home/View/ConcertSection/Subview/InterestConcertSettingButton.swift
@@ -20,14 +20,14 @@ struct InterestConcertSettingButton: View {
         Button(action: action) {
             VStack(spacing: 8) {
                 iconContainer
-                    .padding(.top, 32)
+                    .padding(.top, 24)
                 
                 Text("관심 콘서트\n알림 · 소식 설정")
                     .notosans(.body4Semibold)
                     .multilineTextAlignment(.center)
                     .foregroundStyle(Color.livithColor(.white100))
                     .padding(.horizontal, 28)
-                    .padding(.bottom, 36)
+                    .padding(.bottom, 24)
             }
             .background(
                 RoundedRectangle(cornerRadius: 12)

--- a/Projects/HomeFeature/Sources/Home/View/ConcertSection/Subview/InterestConcertSettingButton.swift
+++ b/Projects/HomeFeature/Sources/Home/View/ConcertSection/Subview/InterestConcertSettingButton.swift
@@ -22,8 +22,9 @@ struct InterestConcertSettingButton: View {
                 iconContainer
                     .padding(.top, 32)
                 
-                Text("관심 콘서트 설정")
+                Text("관심 콘서트\n알림 · 소식 설정")
                     .notosans(.body4Semibold)
+                    .multilineTextAlignment(.center)
                     .foregroundStyle(Color.livithColor(.white100))
                     .padding(.horizontal, 28)
                     .padding(.bottom, 36)

--- a/Projects/LoginFeature/Sources/Login/View/LoginView.swift
+++ b/Projects/LoginFeature/Sources/Login/View/LoginView.swift
@@ -77,8 +77,12 @@ private extension LoginView {
     
     var loginButtons: some View {
         VStack(spacing: 20) {
-            LivithCalloutView(store.state.calloutMessage.text, highlight: store.state.calloutMessage.targetText)
-                .frame(width: Constants.calloutWidth)
+            LivithCalloutView(
+                store.state.calloutMessage.text,
+                highlight: store.state.calloutMessage.targetText,
+                widthMode: .fill
+            )
+            .frame(width: Constants.calloutWidth)
             
             VStack(spacing: 12) {
                 LivithLoginButton(provider: .kakao) {

--- a/Projects/LoginFeature/Sources/Login/View/LoginView.swift
+++ b/Projects/LoginFeature/Sources/Login/View/LoginView.swift
@@ -78,7 +78,7 @@ private extension LoginView {
     var loginButtons: some View {
         VStack(spacing: 20) {
             LivithCalloutView(store.state.calloutMessage.text, highlight: store.state.calloutMessage.targetText)
-                .frame(width: Constants.calloutWidth, height: 40)
+                .frame(width: Constants.calloutWidth)
             
             VStack(spacing: 12) {
                 LivithLoginButton(provider: .kakao) {


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 홈 관심 콘서트 미설정 상태에서 CTA 버튼 문구를 변경하고, 버튼 하단에 노란 콜아웃을 오버레이로 추가했습니다.
- `LivithCalloutView`를 스타일, 꼬리 배치, 너비 모드까지 확장해 홈/로그인 화면에서 공통으로 사용할 수 있도록 정리했습니다.

|    구현 내용    |   iPhone 17 pro   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/423f0a1b-0a1f-40ee-afe1-604a1037d46c" width=250> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### `LivithCalloutView` 확장
- `LivithCalloutStyle.gray`, `LivithCalloutStyle.yellow` 프리셋을 추가했습니다.
- `LivithCalloutPlacement`로 꼬리의 상하 위치와 정렬을 제어할 수 있도록 확장했습니다.
- `LivithCalloutWidthMode`를 추가해 홈에서는 내용 기반 폭, 로그인에서는 고정 폭 채우기 동작을 분리했습니다.
### 홈 관심 콘서트 콜아웃 오버레이
- `HomeHeaderView`에서 관심 콘서트 설정 버튼 높이를 기준으로 버튼 아래 16px 위치에 콜아웃을 오버레이로 배치했습니다.
- `zIndex`와 `overlay`를 사용해 하위 콘텐츠 레이아웃에는 영향을 주지 않도록 처리했습니다.

## 🔗 연결된 이슈
- Resolved: LIVD-341
