### PR TITLE
[Chore] AGENTS 규칙 문서 링크 정리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,16 @@
 - Read the relevant rule documents before making changes.
 
 ## Rule Documents
+- Planning multi-step work and troubleshooting records: `docs/rules/plan.md`
 - Tests and behavior changes: `docs/rules/tdd.md`
 - Security-sensitive work, secrets, config, external input, and logging: `docs/rules/security.md`
+- Architecture, module boundaries, dependency direction, MVI, repositories, coordinators, and DI: `docs/rules/architecture.md`
 - Swift file edits, file structure, `MARK` sections, access control, `typed throws`, and control flow: `docs/rules/code-convention.md`
+- Git branches, commits, PRs, merges, and release flow: `docs/rules/git.md`
 
 ## Workflow Reminder
 - Choose the relevant rule document before editing code, tests, or documents.
 - If multiple rule documents apply, follow all of them.
+- If a selected rule document references `docs/templates/*.md`, follow the referenced template as well.
+- For read-only exploration or analysis involving sensitive files or values, follow `docs/rules/security.md`.
 - Keep detailed standards in `docs/rules/*.md`; this file is only the entry point.


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- `AGENTS.md`에서 누락되어 있던 rule 문서 링크를 추가했습니다.
- rule 문서가 참조하는 template 문서를 함께 따르도록 워크플로우 안내를 보강했습니다.
- 읽기 전용 탐색/분석에서도 민감 파일 또는 민감 값 가능성이 있으면 security rule을 따르도록 명시했습니다.

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### AGENTS.md 규칙 문서 포인팅 정리
- `docs/rules/plan.md`, `docs/rules/architecture.md`, `docs/rules/git.md`를 `Rule Documents`에 추가했습니다.
- 템플릿 문서는 직접 링크하지 않고, 관련 rule 문서에서 참조될 때 따라가도록 안내했습니다.
- 보안 규칙은 코드 변경뿐 아니라 읽기 전용 탐색/분석에도 적용될 수 있도록 명시했습니다.

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 복잡도나 영향이 큰 범위의 작업은 계획 문서를 바탕으로 구현한 내용을 서브에이전트에게 리뷰 및 평가를 받고 '통과'가 될 때까지 수정을 거친 후, 사용자에게 알리는 것을 규칙으로 추가하는 것은 어떤지 의견을 듣고 싶습니다.

## 🔗 연결된 이슈
- Resolved: LIVD-361
