### PR TITLE
[Fix] QA 사항 반영

### DIFF
--- a/Projects/HomeFeature/Sources/Interest/View/InterestConcertListView.swift
+++ b/Projects/HomeFeature/Sources/Interest/View/InterestConcertListView.swift
@@ -77,12 +77,12 @@ private extension InterestConcertListView {
         } label: {
             Text("변경하기")
                 .notosans(.body4Medium)
-                .foregroundStyle(Color.livithColor(.black80))
+                .foregroundStyle(Color.livithColor(.black50))
                 .padding(.horizontal, 12)
                 .padding(.vertical, 4)
                 .background {
                     Capsule()
-                        .strokeBorder(Color.livithColor(.black80), lineWidth: 1)
+                        .strokeBorder(Color.livithColor(.black50), lineWidth: 1)
                 }
         }
     }

--- a/Projects/HomeFeature/Sources/Interest/View/Subview/InterestConcertSelectionBottomSectionView.swift
+++ b/Projects/HomeFeature/Sources/Interest/View/Subview/InterestConcertSelectionBottomSectionView.swift
@@ -50,7 +50,7 @@ struct InterestConcertSelectionBottomSectionView: View {
 private extension InterestConcertSelectionBottomSectionView {
     var selectedConcertChipScrollView: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 8) {
+            LazyHStack(spacing: 8) {
                 ForEach(selectedConcertList) { concert in
                     RemovableChip(truncatedTitle(for: ConcertDisplayText.title(for: concert))) {
                         onRemoveSelectedConcert(concert.id)
@@ -58,6 +58,7 @@ private extension InterestConcertSelectionBottomSectionView {
                 }
             }
             .padding(.horizontal, Constants.horizontalPadding)
+            .fixedSize(horizontal: false, vertical: true)
         }
     }
 }

--- a/Projects/Shared/DisplaySupport/Sources/InterestConcertDisplayText.swift
+++ b/Projects/Shared/DisplaySupport/Sources/InterestConcertDisplayText.swift
@@ -77,15 +77,15 @@ public enum InterestConcertDisplayText {
         }
 
         let schedule = interestConcert.ticketingSchedule
-        if let preSaleDate = schedule.preSaleDate {
-            return "선예매 오픈 · \(ticketingDate(preSaleDate))"
+        if let generalSaleDate = schedule.generalSaleDate {
+            return "일반 예매 오픈 · \(ticketingDate(generalSaleDate))"
         }
 
-        guard let generalSaleDate = schedule.generalSaleDate else {
+        guard let preSaleDate = schedule.preSaleDate else {
             return unknownTicketingDate
         }
 
-        return "일반 예매 오픈 · \(ticketingDate(generalSaleDate))"
+        return "선예매 오픈 · \(ticketingDate(preSaleDate))"
     }
 }
 

--- a/Projects/Shared/DisplaySupport/Tests/InterestConcertDisplayTextTests.swift
+++ b/Projects/Shared/DisplaySupport/Tests/InterestConcertDisplayTextTests.swift
@@ -159,10 +159,22 @@ struct InterestConcertDisplayTextTests {
         #expect(bottom != "콘서트 진행중")
     }
 
-    @Test("선예매 일정이 있으면 하단 문구는 선예매 오픈 문구를 우선 표시해야 한다")
-    func 선예매_일정이_있으면_하단_문구는_선예매_오픈_문구를_우선_표시해야_한다() {
+    @Test("선예매와 일반 예매 일정이 모두 있으면 하단 문구는 일반 예매 오픈 문구를 우선 표시해야 한다")
+    func 선예매와_일반_예매_일정이_모두_있으면_하단_문구는_일반_예매_오픈_문구를_우선_표시해야_한다() {
         // Given
         let interestConcert = makeInterestConcert(preSaleDate: ticketingDate, generalSaleDate: laterTicketingDate)
+
+        // When
+        let bottom = InterestConcertDisplayText.bottom(for: interestConcert)
+
+        // Then
+        #expect(bottom == "일반 예매 오픈 · 8/11(월) 2:20AM")
+    }
+
+    @Test("선예매 일정만 있으면 하단 문구는 선예매 오픈 문구를 표시해야 한다")
+    func 선예매_일정만_있으면_하단_문구는_선예매_오픈_문구를_표시해야_한다() {
+        // Given
+        let interestConcert = makeInterestConcert(preSaleDate: ticketingDate, generalSaleDate: nil)
 
         // When
         let bottom = InterestConcertDisplayText.bottom(for: interestConcert)


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 관심 콘서트 카드의 하단 문구 정책을 반영하였습니다.
    - 선예매와 일반 예매 모두 있을 시, 일반 예매를 보여준다.
- 관심 콘서트 목록 화면의 '변경하기' 디자인 반영
- 하단 칩 LazyHStack 적용 및 레이아웃 이슈 해결

|    구현 내용    |   iPhone 16   |
| :-------------: | :----------: |
| 관심콘서트 설정 화면 하단 칩 레이아웃 | <img src = "https://github.com/user-attachments/assets/8d3c8288-625f-4828-a539-146ebfb0bb6c" width=250> |
| '변경하기' 버튼 디자인 수정 | <img src = "https://github.com/user-attachments/assets/9d30af3a-0801-4e7f-a0d0-28889954e0e8" width=250> |

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 토스트는 서버 개발자와 상의 후 추후 반영 예정입니다.

## 🔗 연결된 이슈
- Resolved: LIVD-394
