### PR TITLE
[Fix] 관심 콘서트 정리 토스트 API 반영

### DIFF
--- a/Projects/Core/LivithNetwork/Sources/DTO/HomeFeature/InterestConcertToast.swift
+++ b/Projects/Core/LivithNetwork/Sources/DTO/HomeFeature/InterestConcertToast.swift
@@ -13,6 +13,13 @@ import Foundation
 public extension DTO.Response {
     struct FetchInterestConcertToast: Decodable {
         public let needsToShow: Bool
+        public let type: ToastType?
+
+        public enum ToastType: String, Decodable {
+            case canceled = "CANCELED"
+            case completed = "COMPLETED"
+            case both = "BOTH"
+        }
     }
 
     struct UpdateInterestConcertToast: Decodable {

--- a/Projects/Core/LivithNetwork/Tests/HomeFeatureDTOTests.swift
+++ b/Projects/Core/LivithNetwork/Tests/HomeFeatureDTOTests.swift
@@ -185,7 +185,8 @@ struct HomeFeatureDTOTests {
           "statusCode": 200,
           "message": "요청에 성공하였습니다.",
           "data": {
-            "needsToShow": true
+            "needsToShow": true,
+            "type": "COMPLETED"
           }
         }
         """.data(using: .utf8)!
@@ -196,6 +197,42 @@ struct HomeFeatureDTOTests {
         // Then
         #expect(result.statusCode == 200)
         #expect(result.data?.needsToShow == true)
+        #expect(result.data?.type == .completed)
+    }
+
+    @Test("FetchInterestConcertToast type은 취소, 완료, 혼합 값을 디코딩해야 한다")
+    func fetchInterestConcertToast_type은_취소_완료_혼합_값을_디코딩해야_한다() throws {
+        // Given
+        let json = """
+        [
+          { "needsToShow": true, "type": "CANCELED" },
+          { "needsToShow": true, "type": "COMPLETED" },
+          { "needsToShow": true, "type": "BOTH" }
+        ]
+        """.data(using: .utf8)!
+
+        // When
+        let result = try JSONDecoder().decode([DTO.Response.FetchInterestConcertToast].self, from: json)
+
+        // Then
+        #expect(result.map(\.type) == [.canceled, .completed, .both])
+    }
+
+    @Test("FetchInterestConcertToast는 type이 없어도 디코딩되어야 한다")
+    func fetchInterestConcertToast는_type이_없어도_디코딩되어야_한다() throws {
+        // Given
+        let json = """
+        {
+          "needsToShow": false
+        }
+        """.data(using: .utf8)!
+
+        // When
+        let result = try JSONDecoder().decode(DTO.Response.FetchInterestConcertToast.self, from: json)
+
+        // Then
+        #expect(!result.needsToShow)
+        #expect(result.type == nil)
     }
 
     @Test("UpdateInterestConcertToast BaseResponse 디코딩이 정상적으로 되어야 한다")

--- a/Projects/Data/UserData/Sources/Mapper/UserMapper.swift
+++ b/Projects/Data/UserData/Sources/Mapper/UserMapper.swift
@@ -75,6 +75,20 @@ struct UserMapper {
     func toDomain(from dto: DTO.Response.UpdateUserInterestConcertList) -> [Concert] {
         dto.compactMap(toConcert)
     }
+
+    func toDomain(from dto: DTO.Response.FetchInterestConcertToast) -> InterestConcertCleanupPolicy? {
+        guard dto.needsToShow else { return InterestConcertCleanupPolicy.none }
+        guard let type = dto.type else { return nil }
+
+        switch type {
+        case .canceled:
+            return .canceled
+        case .completed:
+            return .completed
+        case .both:
+            return .both
+        }
+    }
 }
 
 private extension UserMapper {

--- a/Projects/Data/UserData/Sources/Mock/MockUserRepository.swift
+++ b/Projects/Data/UserData/Sources/Mock/MockUserRepository.swift
@@ -65,8 +65,8 @@ public struct MockUserRepository: UserRepository {
 
     public func deleteInterestedConcert() async throws(UserError) {}
 
-    public func fetchInterestConcertToastNeedsToShow() async throws(UserError) -> Bool {
-        false
+    public func fetchInterestConcertCleanupPolicy() async throws(UserError) -> InterestConcertCleanupPolicy {
+        .none
     }
 
     public func markInterestConcertToastShown() async throws(UserError) {}

--- a/Projects/Data/UserData/Sources/Repository/UserRepositoryImpl.swift
+++ b/Projects/Data/UserData/Sources/Repository/UserRepositoryImpl.swift
@@ -132,23 +132,31 @@ struct UserRepositoryImpl: UserRepository {
         }
     }
 
-    func fetchInterestConcertToastNeedsToShow() async throws(UserError) -> Bool {
-       do {
-           let response: DTO.Response.FetchInterestConcertToast = try await homeService.request(.fetchInterestConcertToast)
-           return response.needsToShow
-       } catch {
-           let userError: UserError = errorMapper.mapToUserError(error)
-           throw userError
-       }
+    func fetchInterestConcertCleanupPolicy() async throws(UserError) -> InterestConcertCleanupPolicy {
+        do {
+            let response: DTO.Response.FetchInterestConcertToast = try await homeService.request(
+                .fetchInterestConcertToast
+            )
+            guard let policy = mapper.toDomain(from: response) else {
+                throw UserError.invalidResponse
+            }
+
+            return policy
+        } catch let error as UserError {
+            throw error
+        } catch {
+            let userError: UserError = errorMapper.mapToUserError(error)
+            throw userError
+        }
     }
 
     func markInterestConcertToastShown() async throws(UserError) {
-       do {
-           let _: DTO.Response.UpdateInterestConcertToast = try await homeService.request(.updateInterestConcertToast)
-       } catch {
-           let userError: UserError = errorMapper.mapToUserError(error)
-           throw userError
-       }
+        do {
+            let _: DTO.Response.UpdateInterestConcertToast = try await homeService.request(.updateInterestConcertToast)
+        } catch {
+            let userError: UserError = errorMapper.mapToUserError(error)
+            throw userError
+        }
     }
 }
 

--- a/Projects/Data/UserData/Tests/UserMapperTests.swift
+++ b/Projects/Data/UserData/Tests/UserMapperTests.swift
@@ -599,6 +599,62 @@ struct UserErrorMapperTests {
         }
     }
 
+    @Test("FetchInterestConcertToast는 needsToShow가 false이면 none 정책으로 변환해야 한다")
+    func fetchInterestConcertToast는_needsToShow가_false이면_none_정책으로_변환해야_한다() throws {
+        // Given
+        let sut = UserMapper()
+        let json = """
+        {
+            "needsToShow": false
+        }
+        """.data(using: .utf8)!
+        let dto = try JSONDecoder().decode(DTO.Response.FetchInterestConcertToast.self, from: json)
+
+        // When
+        let result = sut.toDomain(from: dto)
+
+        // Then
+        #expect(result == InterestConcertCleanupPolicy.none)
+    }
+
+    @Test("FetchInterestConcertToast는 type을 관심 콘서트 정리 정책으로 변환해야 한다")
+    func fetchInterestConcertToast는_type을_관심_콘서트_정리_정책으로_변환해야_한다() throws {
+        // Given
+        let sut = UserMapper()
+        let json = """
+        [
+            { "needsToShow": true, "type": "CANCELED" },
+            { "needsToShow": true, "type": "COMPLETED" },
+            { "needsToShow": true, "type": "BOTH" }
+        ]
+        """.data(using: .utf8)!
+        let dtoList = try JSONDecoder().decode([DTO.Response.FetchInterestConcertToast].self, from: json)
+
+        // When
+        let resultList = dtoList.map { sut.toDomain(from: $0) }
+
+        // Then
+        #expect(resultList == [.canceled, .completed, .both].map(Optional.some))
+    }
+
+    @Test("FetchInterestConcertToast는 needsToShow가 true인데 type이 없으면 변환하지 않아야 한다")
+    func fetchInterestConcertToast는_needsToShow가_true인데_type이_없으면_변환하지_않아야_한다() throws {
+        // Given
+        let sut = UserMapper()
+        let json = """
+        {
+            "needsToShow": true
+        }
+        """.data(using: .utf8)!
+        let dto = try JSONDecoder().decode(DTO.Response.FetchInterestConcertToast.self, from: json)
+
+        // When
+        let result = sut.toDomain(from: dto)
+
+        // Then
+        #expect(result == nil)
+    }
+
     @Test("인증 토큰 없음 에러를 unknown으로 변환해야 한다")
     func 인증_토큰_없음_에러를_unknown으로_변환해야_한다() {
         // Given

--- a/Projects/Domain/Sources/Entity/Concert/InterestConcert.swift
+++ b/Projects/Domain/Sources/Entity/Concert/InterestConcert.swift
@@ -77,3 +77,10 @@ public enum InterestConcertSort: Hashable {
     case concert
     case ticketing
 }
+
+public enum InterestConcertCleanupPolicy: CaseIterable, Equatable {
+    case none
+    case canceled
+    case completed
+    case both
+}

--- a/Projects/Domain/Sources/Repository/UserRepository.swift
+++ b/Projects/Domain/Sources/Repository/UserRepository.swift
@@ -18,6 +18,6 @@ public protocol UserRepository {
     @discardableResult
     func updateInterestedConcertList(_ concertIDList: [Int]) async throws(UserError) -> [Concert]
     func deleteInterestedConcert() async throws(UserError)
-    func fetchInterestConcertToastNeedsToShow() async throws(UserError) -> Bool
+    func fetchInterestConcertCleanupPolicy() async throws(UserError) -> InterestConcertCleanupPolicy
     func markInterestConcertToastShown() async throws(UserError)
 }

--- a/Projects/Domain/Tests/ConcertDomainModelTests.swift
+++ b/Projects/Domain/Tests/ConcertDomainModelTests.swift
@@ -92,6 +92,15 @@ struct ConcertDomainModelTests {
         #expect(filter.nextToken == nil)
     }
 
+    @Test("InterestConcertCleanupPolicy는 없음, 취소, 완료, 혼합 정책을 표현해야 한다")
+    func interestConcertCleanupPolicy는_없음_취소_완료_혼합_정책을_표현해야_한다() {
+        // When
+        let policyList = InterestConcertCleanupPolicy.allCases
+
+        // Then
+        #expect(policyList == [.none, .canceled, .completed, .both])
+    }
+
     @Test("ListResult는 관심 콘서트 목록과 다음 token을 보관해야 한다")
     func listResult는_관심_콘서트_목록과_다음_token을_보관해야_한다() {
         // Given

--- a/Projects/HomeFeature/Sources/Home/Store/HomeStore.swift
+++ b/Projects/HomeFeature/Sources/Home/Store/HomeStore.swift
@@ -40,7 +40,7 @@ enum HomeIntent {
     case _fetchUserResult(Result<User, Error>)
     case _fetchInterestConcertListResult(Result<[InterestConcert], Error>)
     case _fetchUnreadNotificationCountResult(Result<Int, Error>)
-    case _fetchInterestConcertToastResult(Result<Bool, Error>)
+    case _fetchInterestConcertToastResult(Result<InterestConcertCleanupPolicy, Error>)
     case _markInterestConcertToastShownResult(Result<Void, Error>)
     case _fetchConcertSectionDataResult(Result<(sectionList: [ConcertSection], recommendedConcertList: [Concert]?), Error>)
 }
@@ -129,15 +129,19 @@ final class HomeStore: ObservableObject {
 
         case ._fetchInterestConcertToastResult(let result):
             switch result {
-            case .success(true):
+            case .success(let policy):
+                guard let message = interestConcertCleanupMessage(for: policy) else {
+                    state.interestConcertToastMessage = ""
+                    return
+                }
                 guard state.errorMessage.isEmpty else {
                     state.interestConcertToastMessage = ""
                     return
                 }
 
-                state.interestConcertToastMessage = Constants.interestConcertToastMessage
+                state.interestConcertToastMessage = message
                 performMarkInterestConcertToastShown()
-            case .success(false), .failure:
+            case .failure:
                 state.interestConcertToastMessage = ""
             }
 
@@ -249,9 +253,9 @@ private extension HomeStore {
         }
     }
 
-    func fetchInterestConcertToastResult() async -> Result<Bool, Error> {
+    func fetchInterestConcertToastResult() async -> Result<InterestConcertCleanupPolicy, Error> {
         do {
-            return .success(try await userRepository.fetchInterestConcertToastNeedsToShow())
+            return .success(try await userRepository.fetchInterestConcertCleanupPolicy())
         } catch {
             return .failure(error)
         }
@@ -349,7 +353,22 @@ private extension HomeStore {
         state.interestConcertToastMessage = ""
     }
 
+    func interestConcertCleanupMessage(for policy: InterestConcertCleanupPolicy) -> String? {
+        switch policy {
+        case .none:
+            return nil
+        case .canceled:
+            return Constants.canceledInterestConcertToastMessage
+        case .completed:
+            return Constants.completedInterestConcertToastMessage
+        case .both:
+            return Constants.bothInterestConcertToastMessage
+        }
+    }
+
     enum Constants {
-        static let interestConcertToastMessage = "종료된 공연이 자동 정리됐어요"
+        static let canceledInterestConcertToastMessage = "취소된 공연이 자동 정리됐어요"
+        static let completedInterestConcertToastMessage = "종료된 공연이 자동 정리됐어요"
+        static let bothInterestConcertToastMessage = "종료·취소된 공연이 자동 정리됐어요"
     }
 }

--- a/Projects/HomeFeature/Tests/HomeStoreTests.swift
+++ b/Projects/HomeFeature/Tests/HomeStoreTests.swift
@@ -148,7 +148,7 @@ struct HomeStoreTests {
         // Given
         container.userRepository.userStub = makeMockUser(nickname: "홍길동")
         container.userRepository.interestConcertListStub = makeInterestConcertList(concertIDList: [123])
-        container.userRepository.interestConcertToastNeedsToShowStub = true
+        container.userRepository.interestConcertCleanupPolicyStub = .completed
         container.notificationRepository.unreadNotificationCountStub = 3
         container.concertRepository.homeSectionListStub = [makeMockSection(id: 1)]
 
@@ -159,16 +159,37 @@ struct HomeStoreTests {
         try await Task.sleep(nanoseconds: 200_000_000)
 
         // Then
-        #expect(container.userRepository.fetchInterestConcertToastNeedsToShowCallCount == 1)
+        #expect(container.userRepository.fetchInterestConcertCleanupPolicyCallCount == 1)
         #expect(sut.state.interestConcertToastMessage == "종료된 공연이 자동 정리됐어요")
         #expect(container.userRepository.markInterestConcertToastShownCallCount == 1)
+    }
+
+    @Test("관심 콘서트 정리 정책별 성공 메시지를 설정해야 한다")
+    func testInterestConcertCleanupPolicySetsMessage() async throws {
+        // Given
+        let sut = HomeStore()
+
+        // When & Then
+        sut.send(._fetchInterestConcertToastResult(.success(.canceled)))
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(sut.state.interestConcertToastMessage == "취소된 공연이 자동 정리됐어요")
+
+        sut.send(.onInterestConcertToastDisappear)
+        sut.send(._fetchInterestConcertToastResult(.success(.completed)))
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(sut.state.interestConcertToastMessage == "종료된 공연이 자동 정리됐어요")
+
+        sut.send(.onInterestConcertToastDisappear)
+        sut.send(._fetchInterestConcertToastResult(.success(.both)))
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(sut.state.interestConcertToastMessage == "취소·종료된 공연이 자동 정리됐어요")
     }
 
     @Test("onAppear 시 관심 콘서트 토스트 노출이 필요하지 않으면 성공 메시지와 노출 처리를 생략해야 한다")
     func testOnAppearSkipsInterestConcertToastWhenNotNeeded() async throws {
         // Given
         container.userRepository.userStub = makeMockUser(nickname: "홍길동")
-        container.userRepository.interestConcertToastNeedsToShowStub = false
+        container.userRepository.interestConcertCleanupPolicyStub = .none
         container.notificationRepository.unreadNotificationCountStub = 3
         container.concertRepository.homeSectionListStub = [makeMockSection(id: 1)]
 
@@ -179,7 +200,7 @@ struct HomeStoreTests {
         try await Task.sleep(nanoseconds: 200_000_000)
 
         // Then
-        #expect(container.userRepository.fetchInterestConcertToastNeedsToShowCallCount == 1)
+        #expect(container.userRepository.fetchInterestConcertCleanupPolicyCallCount == 1)
         #expect(sut.state.interestConcertToastMessage.isEmpty)
         #expect(container.userRepository.markInterestConcertToastShownCallCount == 0)
     }
@@ -189,7 +210,7 @@ struct HomeStoreTests {
         // Given
         container.userRepository.userStub = makeMockUser(nickname: "홍길동")
         container.userRepository.interestConcertListStub = makeInterestConcertList(concertIDList: [123])
-        container.userRepository.interestConcertToastNeedsToShowStub = true
+        container.userRepository.interestConcertCleanupPolicyStub = .completed
         container.notificationRepository.unreadNotificationCountStub = 3
         container.concertRepository.homeSectionListStub = [makeMockSection(id: 1)]
         container.concertRepository.fetchHomeConcertSectionListDelay = 300_000_000
@@ -203,14 +224,14 @@ struct HomeStoreTests {
         // Then
         #expect(container.concertRepository.fetchHomeConcertSectionListCallCount == 1)
         #expect(sut.state.concertSectionList.isEmpty)
-        #expect(container.userRepository.fetchInterestConcertToastNeedsToShowCallCount == 0)
+        #expect(container.userRepository.fetchInterestConcertCleanupPolicyCallCount == 0)
         #expect(sut.state.interestConcertToastMessage.isEmpty)
         #expect(container.userRepository.markInterestConcertToastShownCallCount == 0)
 
         try await Task.sleep(nanoseconds: 300_000_000)
 
         #expect(sut.state.concertSectionList.count == 1)
-        #expect(container.userRepository.fetchInterestConcertToastNeedsToShowCallCount == 1)
+        #expect(container.userRepository.fetchInterestConcertCleanupPolicyCallCount == 1)
         #expect(sut.state.interestConcertToastMessage == "종료된 공연이 자동 정리됐어요")
         #expect(container.userRepository.markInterestConcertToastShownCallCount == 1)
     }
@@ -220,7 +241,7 @@ struct HomeStoreTests {
         // Given
         container.userRepository.userStub = makeMockUser(nickname: "홍길동")
         container.userRepository.interestConcertListStub = makeInterestConcertList(concertIDList: [123])
-        container.userRepository.interestConcertToastNeedsToShowStub = true
+        container.userRepository.interestConcertCleanupPolicyStub = .completed
         container.notificationRepository.unreadNotificationCountStub = 3
         container.concertRepository.errorStub = .serverError
 
@@ -232,7 +253,7 @@ struct HomeStoreTests {
 
         // Then
         #expect(!sut.state.errorMessage.isEmpty)
-        #expect(container.userRepository.fetchInterestConcertToastNeedsToShowCallCount == 0)
+        #expect(container.userRepository.fetchInterestConcertCleanupPolicyCallCount == 0)
         #expect(sut.state.interestConcertToastMessage.isEmpty)
         #expect(container.userRepository.markInterestConcertToastShownCallCount == 0)
     }
@@ -266,7 +287,7 @@ struct HomeStoreTests {
         #expect(!sut.state.errorMessage.isEmpty)
 
         // When
-        sut.send(._fetchInterestConcertToastResult(.success(true)))
+        sut.send(._fetchInterestConcertToastResult(.success(.completed)))
         try await Task.sleep(nanoseconds: 100_000_000)
 
         // Then
@@ -278,7 +299,7 @@ struct HomeStoreTests {
     func testErrorClearsPendingInterestConcertToastMessage() async throws {
         // Given
         let sut = HomeStore()
-        sut.send(._fetchInterestConcertToastResult(.success(true)))
+        sut.send(._fetchInterestConcertToastResult(.success(.completed)))
         try await Task.sleep(nanoseconds: 100_000_000)
         #expect(!sut.state.interestConcertToastMessage.isEmpty)
 
@@ -297,7 +318,7 @@ struct HomeStoreTests {
         let sut = HomeStore()
 
         // When
-        sut.send(._fetchInterestConcertToastResult(.success(true)))
+        sut.send(._fetchInterestConcertToastResult(.success(.completed)))
         try await Task.sleep(nanoseconds: 100_000_000)
 
         // Then
@@ -310,7 +331,7 @@ struct HomeStoreTests {
     func testOnInterestConcertToastDisappearClearsMessage() async throws {
         // Given
         let sut = HomeStore()
-        sut.send(._fetchInterestConcertToastResult(.success(true)))
+        sut.send(._fetchInterestConcertToastResult(.success(.completed)))
         try await Task.sleep(nanoseconds: 100_000_000)
         #expect(!sut.state.interestConcertToastMessage.isEmpty)
 

--- a/Projects/HomeFeature/Tests/Mock/MockUserRepository.swift
+++ b/Projects/HomeFeature/Tests/Mock/MockUserRepository.swift
@@ -18,7 +18,7 @@ final class MockUserRepository: UserRepository {
     var fetchInterestedConcertListDelayQueue: [UInt64] = []
     var updatedConcertStub: Concert?
     var updatedConcertListStub: [Concert] = []
-    var interestConcertToastNeedsToShowStub: Bool = false
+    var interestConcertCleanupPolicyStub: InterestConcertCleanupPolicy = .none
     var errorStub: UserError?
     var fetchUserErrorStub: UserError?
     var fetchInterestedConcertListErrorStub: UserError?
@@ -37,7 +37,7 @@ final class MockUserRepository: UserRepository {
     var updateInterestedConcertIDList: [Int]?
     var deleteInterestedConcertCallCount: Int = 0
     var updateNicknameCallCount: Int = 0
-    var fetchInterestConcertToastNeedsToShowCallCount: Int = 0
+    var fetchInterestConcertCleanupPolicyCallCount: Int = 0
     var markInterestConcertToastShownCallCount: Int = 0
 
     func updateNickname(_ nickname: String) async throws(UserError) {
@@ -169,15 +169,15 @@ final class MockUserRepository: UserRepository {
         }
     }
 
-    func fetchInterestConcertToastNeedsToShow() async throws(UserError) -> Bool {
-        fetchInterestConcertToastNeedsToShowCallCount += 1
+    func fetchInterestConcertCleanupPolicy() async throws(UserError) -> InterestConcertCleanupPolicy {
+        fetchInterestConcertCleanupPolicyCallCount += 1
         if let error = fetchInterestConcertToastErrorStub {
             throw error
         }
         if let error = errorStub {
             throw error
         }
-        return interestConcertToastNeedsToShowStub
+        return interestConcertCleanupPolicyStub
     }
 
     func markInterestConcertToastShown() async throws(UserError) {

--- a/Projects/Shared/NicknameEditFeature/Tests/NicknameEditStoreTests.swift
+++ b/Projects/Shared/NicknameEditFeature/Tests/NicknameEditStoreTests.swift
@@ -126,8 +126,8 @@ final class MockUserRepository: UserRepository {
 
     func deleteInterestedConcert() async throws(UserError) {}
 
-    func fetchInterestConcertToastNeedsToShow() async throws(UserError) -> Bool {
-        false
+    func fetchInterestConcertCleanupPolicy() async throws(UserError) -> InterestConcertCleanupPolicy {
+        .none
     }
 
     func markInterestConcertToastShown() async throws(UserError) {}

--- a/docs/archives/LIVD-400-interest-concert-toast-type.md
+++ b/docs/archives/LIVD-400-interest-concert-toast-type.md
@@ -1,0 +1,56 @@
+# [LIVD-000] 관심 콘서트 정리 정책 반영
+
+## 배경
+- 관심 콘서트 토스트 조회 API가 `needsToShow`와 함께 `type`을 내려준다.
+- 현재 앱은 `needsToShow`만 DTO/Domain/Store에 반영하고 있어 취소/완료/혼합 상태별 정리 정책을 처리할 수 없다.
+- Domain 모델에 `Toast`라는 UI 표현을 노출하지 않고, 관심 콘서트 정리 결과를 정책으로 표현한다.
+
+## 목표
+- Network DTO에서 API 응답의 `type` 필드를 디코딩한다.
+- Domain 레이어에 관심 콘서트 정리 정책을 표현하는 모델을 추가한다.
+- Data 레이어에서 DTO를 Domain 정책 모델로 매핑한다.
+- Home Store/View 흐름에서 정책별 사용자 안내 메시지를 처리한다.
+
+## 작업 항목
+- [x] Network DTO와 디코딩 테스트 수정
+  - `FetchInterestConcertToast`에 `type` 필드를 추가하고 `CANCELED`, `COMPLETED`, `BOTH` 케이스를 검증한다.
+- [x] Domain 모델과 Repository 계약 수정
+  - `InterestConcertCleanupPolicy` enum을 추가하고, `UserRepository` 반환 타입을 Bool에서 정책 모델로 변경한다.
+- [x] Data 매핑과 Repository 구현 수정
+  - `UserMapper`에서 DTO 타입 문자열을 Domain 정책 enum으로 변환하고, `needsToShow == false`일 때 `.none`으로 정규화한다.
+- [x] Home Store 토스트 상태 처리 수정
+  - Store가 Domain 정책을 받아 타입별 메시지를 설정하도록 변경한다.
+- [x] 테스트 더블과 Home Store 테스트 수정
+  - Mock Repository와 기존 Home 테스트를 새 계약에 맞추고 정책별 메시지 테스트를 추가한다.
+- [x] 영향 범위 검증
+  - `LivithNetwork`, `Domain`, `UserData`, `HomeFeature` 관련 테스트를 실행한다.
+
+## 영향 범위
+- Network: `Projects/Core/LivithNetwork/Sources/DTO/HomeFeature/InterestConcertToast.swift`, `Projects/Core/LivithNetwork/Tests/HomeFeatureDTOTests.swift`
+- Domain: `Projects/Domain/Sources/Entity/Concert/*`, `Projects/Domain/Sources/Repository/UserRepository.swift`
+- Data: `Projects/Data/UserData/Sources/Mapper/UserMapper.swift`, `Projects/Data/UserData/Sources/Repository/UserRepositoryImpl.swift`, Mock/Tests
+- HomeFeature: `Projects/HomeFeature/Sources/Home/Store/HomeStore.swift`, `Projects/HomeFeature/Sources/Home/View/HomeView.swift`, Tests/Mocks
+- 기타 UserRepository mock 구현체
+
+## 기술 결정
+| 결정 사항 | 선택지 | 결정 | 근거 |
+|-----------|--------|------|------|
+| Domain 모델 형태 | Bool + Optional type / 정책 enum | `InterestConcertCleanupPolicy` enum | UI 표현인 Toast를 Domain에 노출하지 않고 정리 정책으로 의미를 표현하기 위함 |
+| 타입 enum 위치 | User Entity / Concert Entity | Concert Entity 하위 | 관심 콘서트 상태 정리 정책이므로 Concert 도메인에 더 가깝다 |
+| `needsToShow == false`의 type | nil 허용 / `.none` 정규화 | `.none` | PDF 예시에서 토스트가 없을 때 `type`이 내려오지 않으며, Domain에서는 조합 상태를 숨기기 위함 |
+| 타입별 메시지 위치 | Domain / Store Constants | HomeStore Constants | 문구는 화면 표현 정책이며 Domain 모델은 의미만 보관한다 |
+| 알 수 없는 type 처리 | invalidResponse / nil 변환 | `invalidResponse` | 서버 계약 변경 또는 오타를 조기에 감지하기 위함 |
+
+## 주의 사항
+- Domain 레이어는 외부 프레임워크 의존성을 추가하지 않는다.
+- DTO 타입을 HomeFeature로 노출하지 않는다.
+- Domain 모델 이름에는 `Toast` 대신 `Policy`를 사용한다.
+- 기존 에러 토스트가 관심 콘서트 성공 토스트보다 우선하는 흐름은 유지한다.
+- `needsToShow == false`이면 `type`이 없어도 `.none`으로 처리한다.
+- `needsToShow == true`인데 `type`이 없거나 유효하지 않으면 invalid response로 처리한다.
+
+## 검증 방법
+- `xcodebuild test -workspace Livith-iOS.xcworkspace -scheme LivithNetwork -destination 'platform=iOS Simulator,name=iPhone 17'`
+- `xcodebuild test -workspace Livith-iOS.xcworkspace -scheme Domain -destination 'platform=iOS Simulator,name=iPhone 17'`
+- `xcodebuild test -workspace Livith-iOS.xcworkspace -scheme UserData -destination 'platform=iOS Simulator,name=iPhone 17'`
+- `xcodebuild test -workspace Livith-iOS.xcworkspace -scheme HomeFeature -destination 'platform=iOS Simulator,name=iPhone 17'`


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 관심 콘서트 토스트 조회 응답의 `type`을 반영해, 관심 콘서트 정리 결과를 Domain 정책(`InterestConcertCleanupPolicy`)으로 처리하도록 변경했습니다.
- Home 화면은 정책에 따라 취소/종료/혼합 케이스별 안내 메시지를 노출합니다.

|    구현 내용    |   iPhone 16  |
| :-------------: | :----------: |
| 종료된 공연 정리 | <img src = "https://github.com/user-attachments/assets/a505f264-8f03-49bf-a465-f743542ec17d" width=250> |
| 취소된 공연 정리 | <img src = "https://github.com/user-attachments/assets/e57e5f78-343e-4cf5-97a5-2f1db0e362bc" width=250> |
| 모두 해당되는 경우 | <img src = "https://github.com/user-attachments/assets/00fe6263-98ca-48ed-b9e3-6c47a1a1d8ec" width=250> |


## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 관심 콘서트 정리 정책 처리 흐름
```mermaid
sequenceDiagram
    participant HomeView
    participant HomeStore
    participant UserRepository
    participant HomeService
    participant API
    participant UserMapper

    HomeView->>HomeStore: onAppear
    HomeStore->>UserRepository: fetchInterestConcertCleanupPolicy()
    UserRepository->>HomeService: request(.fetchInterestConcertToast)
    HomeService->>API: GET /users/interest-concerts/toast
    API-->>HomeService: needsToShow, type
    HomeService-->>UserRepository: FetchInterestConcertToast DTO
    UserRepository->>UserMapper: toDomain(dto)
    UserMapper-->>UserRepository: InterestConcertCleanupPolicy
    UserRepository-->>HomeStore: cleanup policy
    HomeStore->>HomeStore: policy별 메시지 변환
    HomeStore-->>HomeView: interestConcertToastMessage 갱신
```

### 정책 매핑
- `needsToShow == false` → `.none`
- `type == CANCELED` → `.canceled`
- `type == COMPLETED` → `.completed`
- `type == BOTH` → `.both`

## 🔗 연결된 이슈
- Resolved: LIVD-400
