### PR TITLE
[Fix] 관심 콘서트 카드 하단 문구 정책 수정

### DIFF
--- a/Projects/Shared/DisplaySupport/Sources/InterestConcertDisplayText.swift
+++ b/Projects/Shared/DisplaySupport/Sources/InterestConcertDisplayText.swift
@@ -72,20 +72,39 @@ public enum InterestConcertDisplayText {
             return "콘서트 진행중"
         }
 
-        if interestConcert.concert.daysLeft == 0 {
-            return "공연 진행 중"
+        let today = Calendar.current.startOfDay(for: Date())
+        if let startDate = interestConcert.concert.startDate,
+           let endDate = interestConcert.concert.endDate {
+            let startDay = Calendar.current.startOfDay(for: startDate)
+            let endDay = Calendar.current.startOfDay(for: endDate)
+            if startDay <= today && today <= endDay {
+                return "콘서트 진행중"
+            }
         }
 
         let schedule = interestConcert.ticketingSchedule
+
+        let upcomingDates = [
+            schedule.preSaleDate.map { (date: $0, isPreSale: true) },
+            schedule.generalSaleDate.map { (date: $0, isPreSale: false) }
+        ]
+        .compactMap { $0 }
+        .filter { $0.date >= today }
+
+        if let earliest = upcomingDates.min(by: { $0.date < $1.date }) {
+            let label = earliest.isPreSale ? "선예매 오픈" : "일반 예매 오픈"
+            return "\(label) · \(ticketingDate(earliest.date))"
+        }
+
         if let generalSaleDate = schedule.generalSaleDate {
             return "일반 예매 오픈 · \(ticketingDate(generalSaleDate))"
         }
 
-        guard let preSaleDate = schedule.preSaleDate else {
-            return unknownTicketingDate
+        if let preSaleDate = schedule.preSaleDate {
+            return "선예매 오픈 · \(ticketingDate(preSaleDate))"
         }
 
-        return "선예매 오픈 · \(ticketingDate(preSaleDate))"
+        return unknownTicketingDate
     }
 }
 

--- a/Projects/Shared/DisplaySupport/Sources/InterestConcertDisplayText.swift
+++ b/Projects/Shared/DisplaySupport/Sources/InterestConcertDisplayText.swift
@@ -20,7 +20,7 @@ public enum InterestConcertDisplayText {
     public static func title(for interestConcert: InterestConcert) -> String {
         let concert = interestConcert.concert
 
-        guard let title = concert.title.nonEmpty else {
+        guard let title = concert.title, !title.isEmpty else {
             return "\(concert.artist) 내한 예정"
         }
 
@@ -28,7 +28,10 @@ public enum InterestConcertDisplayText {
     }
 
     public static func venue(for interestConcert: InterestConcert) -> String {
-        return interestConcert.concert.venue.nonEmpty ?? unknownVenue
+        guard let venue = interestConcert.concert.venue, !venue.isEmpty else {
+            return unknownVenue
+        }
+        return venue
     }
 
     public static func dateRange(for interestConcert: InterestConcert) -> String {
@@ -72,14 +75,8 @@ public enum InterestConcertDisplayText {
             return "콘서트 진행중"
         }
 
-        let today = Calendar.current.startOfDay(for: Date())
-        if let startDate = interestConcert.concert.startDate,
-           let endDate = interestConcert.concert.endDate {
-            let startDay = Calendar.current.startOfDay(for: startDate)
-            let endDay = Calendar.current.startOfDay(for: endDate)
-            if startDay <= today && today <= endDay {
-                return "콘서트 진행중"
-            }
+        if isCurrentlyOngoing(interestConcert.concert) {
+            return "콘서트 진행중"
         }
 
         let schedule = interestConcert.ticketingSchedule
@@ -109,17 +106,20 @@ public enum InterestConcertDisplayText {
 }
 
 private extension InterestConcertDisplayText {
+    static var today: Date {
+        Calendar.current.startOfDay(for: Date())
+    }
+
+    static func isCurrentlyOngoing(_ concert: Concert) -> Bool {
+        guard let startDate = concert.startDate, let endDate = concert.endDate else {
+            return false
+        }
+        let startDay = Calendar.current.startOfDay(for: startDate)
+        let endDay = Calendar.current.startOfDay(for: endDate)
+        return startDay <= today && today <= endDay
+    }
+
     static func ticketingDate(_ date: Date) -> String {
         return DateFormatterService.string(from: date, type: .koreanDateTime)
-    }
-}
-
-private extension Optional where Wrapped == String {
-    var nonEmpty: String? {
-        guard let value = self?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        return value
     }
 }

--- a/Projects/Shared/DisplaySupport/Tests/InterestConcertDisplayTextTests.swift
+++ b/Projects/Shared/DisplaySupport/Tests/InterestConcertDisplayTextTests.swift
@@ -123,16 +123,19 @@ struct InterestConcertDisplayTextTests {
         #expect(badge == "공연 D-DAY")
     }
 
-    @Test("D-day가 0이면 하단 문구는 공연 진행 중을 표시해야 한다")
-    func dday가_0이면_하단_문구는_공연_진행_중을_표시해야_한다() {
+    @Test("공연 기간이 오늘을 포함하면 하단 문구는 콘서트 진행중을 표시해야 한다")
+    func 공연_기간이_오늘을_포함하면_하단_문구는_콘서트_진행중을_표시해야_한다() {
         // Given
-        let interestConcert = makeInterestConcert(daysLeft: 0, preSaleDate: ticketingDate, generalSaleDate: ticketingDate)
+        let today = Calendar.current.startOfDay(for: Date())
+        let yesterDay = Calendar.current.date(byAdding: .day, value: -1, to: today)!
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: today)!
+        let interestConcert = makeInterestConcert(status: .upcoming, startDate: yesterDay, endDate: tomorrow, preSaleDate: pastTicketingDate, generalSaleDate: pastTicketingDate)
 
         // When
         let bottom = InterestConcertDisplayText.bottom(for: interestConcert)
 
         // Then
-        #expect(bottom == "공연 진행 중")
+        #expect(bottom == "콘서트 진행중")
     }
 
     @Test("진행중 공연이면 하단 문구는 콘서트 진행중을 표시해야 한다")
@@ -147,10 +150,13 @@ struct InterestConcertDisplayTextTests {
         #expect(bottom == "콘서트 진행중")
     }
 
-    @Test("예정 공연의 D-day가 0이면 하단 문구는 콘서트 진행중을 표시하지 않아야 한다")
-    func 예정_공연의_dday가_0이면_하단_문구는_콘서트_진행중을_표시하지_않아야_한다() {
+    @Test("공연 기간이 미래이면 하단 문구는 콘서트 진행중을 표시하지 않아야 한다")
+    func 공연_기간이_미래이면_하단_문구는_콘서트_진행중을_표시하지_않아야_한다() {
         // Given
-        let interestConcert = makeInterestConcert(status: .upcoming, daysLeft: 0)
+        let today = Calendar.current.startOfDay(for: Date())
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: today)!
+        let nextDay = Calendar.current.date(byAdding: .day, value: 2, to: today)!
+        let interestConcert = makeInterestConcert(status: .upcoming, startDate: tomorrow, endDate: nextDay, preSaleDate: nil, generalSaleDate: nil)
 
         // When
         let bottom = InterestConcertDisplayText.bottom(for: interestConcert)
@@ -159,8 +165,8 @@ struct InterestConcertDisplayTextTests {
         #expect(bottom != "콘서트 진행중")
     }
 
-    @Test("선예매와 일반 예매 일정이 모두 있으면 하단 문구는 일반 예매 오픈 문구를 우선 표시해야 한다")
-    func 선예매와_일반_예매_일정이_모두_있으면_하단_문구는_일반_예매_오픈_문구를_우선_표시해야_한다() {
+    @Test("선예매와 일반 예매 일정이 모두 있으면 하단 문구는 더 이른 날짜를 우선 표시해야 한다")
+    func 선예매와_일반_예매_일정이_모두_있으면_하단_문구는_더_이른_날짜를_우선_표시해야_한다() {
         // Given
         let interestConcert = makeInterestConcert(preSaleDate: ticketingDate, generalSaleDate: laterTicketingDate)
 
@@ -168,7 +174,7 @@ struct InterestConcertDisplayTextTests {
         let bottom = InterestConcertDisplayText.bottom(for: interestConcert)
 
         // Then
-        #expect(bottom == "일반 예매 오픈 · 8/11(월) 2:20AM")
+        #expect(bottom == "선예매 오픈 · 8/22(토) 5:30PM")
     }
 
     @Test("선예매 일정만 있으면 하단 문구는 선예매 오픈 문구를 표시해야 한다")
@@ -180,7 +186,7 @@ struct InterestConcertDisplayTextTests {
         let bottom = InterestConcertDisplayText.bottom(for: interestConcert)
 
         // Then
-        #expect(bottom == "선예매 오픈 · 8/10(일) 2:20AM")
+        #expect(bottom == "선예매 오픈 · 8/22(토) 5:30PM")
     }
 
     @Test("선예매 일정이 없고 일반 예매 일정이 있으면 하단 문구는 일반 예매 오픈 문구를 표시해야 한다")
@@ -192,7 +198,7 @@ struct InterestConcertDisplayTextTests {
         let bottom = InterestConcertDisplayText.bottom(for: interestConcert)
 
         // Then
-        #expect(bottom == "일반 예매 오픈 · 8/10(일) 2:20AM")
+        #expect(bottom == "일반 예매 오픈 · 8/22(토) 5:30PM")
     }
 
     @Test("예매 일정이 없으면 하단 문구는 예매 오픈 예정 문구를 표시해야 한다")
@@ -218,15 +224,43 @@ struct InterestConcertDisplayTextTests {
         // Then
         #expect(bottom == "예매 오픈 예정")
     }
+
+    @Test("선예매 날짜가 지났고 일반 예매 날짜만 남아있으면 일반 예매 오픈 문구를 표시해야 한다")
+    func 선예매_날짜가_지났고_일반_예매_날짜만_남아있으면_일반_예매_오픈_문구를_표시해야_한다() {
+        // Given
+        let interestConcert = makeInterestConcert(preSaleDate: pastTicketingDate, generalSaleDate: ticketingDate)
+
+        // When
+        let bottom = InterestConcertDisplayText.bottom(for: interestConcert)
+
+        // Then
+        #expect(bottom == "일반 예매 오픈 · 8/22(토) 5:30PM")
+    }
+
+    @Test("두 예매 날짜가 모두 지났으면 하단 문구는 일반 예매 오픈 문구를 표시해야 한다")
+    func 두_예매_날짜가_모두_지났으면_하단_문구는_일반_예매_오픈_문구를_표시해야_한다() {
+        // Given
+        let interestConcert = makeInterestConcert(preSaleDate: pastTicketingDate, generalSaleDate: pastTicketingDate)
+
+        // When
+        let bottom = InterestConcertDisplayText.bottom(for: interestConcert)
+
+        // Then
+        #expect(bottom == "일반 예매 오픈 · 1/1(목) 9:00AM")
+    }
 }
 
 private extension InterestConcertDisplayTextTests {
+    var pastTicketingDate: Date {
+        Date(timeIntervalSince1970: 0)
+    }
+
     var ticketingDate: Date {
-        Date(timeIntervalSince1970: 1_754_760_000)
+        Date(timeIntervalSince1970: 1_787_387_400)
     }
 
     var laterTicketingDate: Date {
-        Date(timeIntervalSince1970: 1_754_846_400)
+        Date(timeIntervalSince1970: 1_787_473_800)
     }
 
     func makeInterestConcert(


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 선예매와 일반 예매 날짜가 모두 있을 때, 일반 예매를 무조건 우선하던 정책을 변경
- 현재 기준으로 아직 유효한 날짜 중 **가장 이른 날짜**를 우선 표시하도록 개선
- 두 예매 날짜가 모두 지난 경우 일반 예매를 표시하도록 변경
- 공연 기간 중에는 `startDate`/`endDate`를 기반으로 "콘서트 진행중" 표시 (기존: `daysLeft == 0` 기반)
- 문구 통일: "공연 진행 중" → "콘서트 진행중"


|    구현 내용    |   iPhone 16  |
| :-------------: | :----------: |
| 위켄드 스크린샷 | <img src = "https://github.com/user-attachments/assets/9c0f0122-8c5e-4130-9670-318f3a777a4f" width=250> |


## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### InterestConcertDisplayText.bottom(for:) 메서드 변경
#### 1. 공연 진행중 판단 (날짜 범위 기반)
```swift
let today = Calendar.current.startOfDay(for: Date())
if let startDate = interestConcert.concert.startDate,
   let endDate = interestConcert.concert.endDate {
    let startDay = Calendar.current.startOfDay(for: startDate)
    let endDay = Calendar.current.startOfDay(for: endDate)
    if startDay <= today && today <= endDay {
        return "콘서트 진행중"
    }
}
```

#### 2. 예매 날짜 비교 (가장 이른 날짜 우선)
```swift
let upcomingDates = [
    schedule.preSaleDate.map { (date: $0, isPreSale: true) },
    schedule.generalSaleDate.map { (date: $0, isPreSale: false) }
]
.compactMap { $0 }
.filter { $0.date >= today }

if let earliest = upcomingDates.min(by: { $0.date < $1.date }) {
    let label = earliest.isPreSale ? "선예매 오픈" : "일반 예매 오픈"
    return "\(label) · \(ticketingDate(earliest.date))"
}

// 미래 예매 일정이 없으면 지난 날짜 표시 (일반 예매 → 선예매 순서)
if let generalSaleDate = schedule.generalSaleDate {
    return "일반 예매 오픈 · \(ticketingDate(generalSaleDate))"
}
```


## 🔗 연결된 이슈
- Resolved: LIVD-407
