### PR TITLE
[Fix] 관심 콘서트 규칙 보강

### DIFF
--- a/Projects/ConcertFeature/Sources/Store/ConcertStore.swift
+++ b/Projects/ConcertFeature/Sources/Store/ConcertStore.swift
@@ -205,7 +205,7 @@ private extension ConcertStore {
     }
 
     func formatDateRange(from concert: Concert) -> String {
-        ConcertDisplayText.dateRange(for: concert)
+        ConcertDisplayHelper.dateRange(for: concert)
     }
 
     func setInterestConcert() {

--- a/Projects/ConcertFeature/Sources/View/ConcertView.swift
+++ b/Projects/ConcertFeature/Sources/View/ConcertView.swift
@@ -435,14 +435,14 @@ private extension ConcertView {
                 .resizable()
                 .frame(width: 24, height: 24)
 
-            Text(store.state.concert.map { ConcertDisplayText.venue(for: $0) } ?? "")
+            Text(store.state.concert.map { ConcertDisplayHelper.venue(for: $0) } ?? "")
                 .notosans(.body4Medium)
                 .foregroundStyle(Color.livithColor(.black30))
         }
     }
 
     var navigationTitle: String {
-        store.state.concert.map { ConcertDisplayText.title(for: $0) } ?? ""
+        store.state.concert.map { ConcertDisplayHelper.title(for: $0) } ?? ""
     }
 }
 

--- a/Projects/HomeFeature/Sources/Home/View/Subview/ConcertContentSection/ConcertSectionView.swift
+++ b/Projects/HomeFeature/Sources/Home/View/Subview/ConcertContentSection/ConcertSectionView.swift
@@ -27,10 +27,10 @@ struct ConcertSectionView: View {
                     ForEach(concertSection.concertList) { concert in
                         LivithCard(
                             imageURL: concert.posterURL,
-                            title: ConcertDisplayText.title(for: concert),
-                            subtitle: ConcertDisplayText.dateRange(for: concert),
+                            title: ConcertDisplayHelper.title(for: concert),
+                            subtitle: ConcertDisplayHelper.dateRange(for: concert),
                             secondaryText: concert.artist,
-                            badge: .status(text: ConcertDisplayText.statusBadge(for: concert), remainDays: nil),
+                            badge: .status(text: ConcertDisplayHelper.statusBadge(for: concert), remainDays: nil),
                             onTap: { onConcertTap(concert) }
                         )
                     }

--- a/Projects/HomeFeature/Sources/Home/View/Subview/ConcertContentSection/RecommendedConcertGridView.swift
+++ b/Projects/HomeFeature/Sources/Home/View/Subview/ConcertContentSection/RecommendedConcertGridView.swift
@@ -59,10 +59,10 @@ private extension RecommendedConcertGridView {
     func concertCard(for concert: Concert) -> some View {
         LivithCard(
             imageURL: concert.posterURL,
-            title: ConcertDisplayText.title(for: concert),
-            subtitle: ConcertDisplayText.dateRange(for: concert),
+            title: ConcertDisplayHelper.title(for: concert),
+            subtitle: ConcertDisplayHelper.dateRange(for: concert),
             secondaryText: concert.artist,
-            badge: .status(text: ConcertDisplayText.statusBadge(for: concert), remainDays: nil),
+            badge: .status(text: ConcertDisplayHelper.statusBadge(for: concert), remainDays: nil),
             onTap: {
                 AmplitudeService.shared.trackEvent(tag: .click(.recommendedConcertCell))
                 coordinator?.showConcertDetail(concertID: concert.id)

--- a/Projects/HomeFeature/Sources/Home/View/Subview/ConcertContentSection/RecommendedConcertSectionView.swift
+++ b/Projects/HomeFeature/Sources/Home/View/Subview/ConcertContentSection/RecommendedConcertSectionView.swift
@@ -64,10 +64,10 @@ private extension RecommendedConcertSectionView {
                 ForEach(concertList.prefix(Constants.maxVisibleConcertCount)) { concert in
                     LivithCard(
                         imageURL: concert.posterURL,
-                        title: ConcertDisplayText.title(for: concert),
-                        subtitle: ConcertDisplayText.dateRange(for: concert),
+                        title: ConcertDisplayHelper.title(for: concert),
+                        subtitle: ConcertDisplayHelper.dateRange(for: concert),
                         secondaryText: concert.artist,
-                        badge: .status(text: ConcertDisplayText.statusBadge(for: concert), remainDays: nil),
+                        badge: .status(text: ConcertDisplayHelper.statusBadge(for: concert), remainDays: nil),
                         onTap: { onConcertTap(concert) }
                     )
                 }
@@ -169,7 +169,7 @@ private extension RecommendedConcertSectionView {
         title: "유지미님의\n취향이 담긴 콘서트",
         concertList: Concert.mockConcerts
     ) { concert in
-        print("\(ConcertDisplayText.title(for: concert)) 탭")
+        print("\(ConcertDisplayHelper.title(for: concert)) 탭")
     } onSeeAllTap: {
         print("전체보기 탭")
     }

--- a/Projects/HomeFeature/Sources/Home/View/Subview/InterestConcertSection/HomeInterestConcertSectionView.swift
+++ b/Projects/HomeFeature/Sources/Home/View/Subview/InterestConcertSection/HomeInterestConcertSectionView.swift
@@ -200,11 +200,11 @@ private extension HomeInterestConcertSectionView {
 
                 InterestConcertCardView(
                     posterURL: concert.posterURL,
-                    badgeText: InterestConcertDisplayText.badge(for: interestConcert),
-                    titleText: InterestConcertDisplayText.title(for: interestConcert),
-                    dateText: InterestConcertDisplayText.dateRange(for: interestConcert),
-                    locationText: InterestConcertDisplayText.venue(for: interestConcert),
-                    bottomText: InterestConcertDisplayText.bottom(for: interestConcert)
+                    badgeText: InterestConcertDisplayHelper.badge(for: interestConcert),
+                    titleText: InterestConcertDisplayHelper.title(for: interestConcert),
+                    dateText: InterestConcertDisplayHelper.dateRange(for: interestConcert),
+                    locationText: InterestConcertDisplayHelper.venue(for: interestConcert),
+                    bottomText: InterestConcertDisplayHelper.bottom(for: interestConcert)
                 )
                 .opacity(index == currentPage ? 1 : 0)
             }

--- a/Projects/HomeFeature/Sources/Interest/View/InterestConcertListView.swift
+++ b/Projects/HomeFeature/Sources/Interest/View/InterestConcertListView.swift
@@ -198,10 +198,10 @@ private extension InterestConcertListView {
 
         return LivithCard(
             imageURL: concert.posterURL,
-            title: ConcertDisplayText.title(for: concert),
-            subtitle: ConcertDisplayText.dateRange(for: concert),
+            title: ConcertDisplayHelper.title(for: concert),
+            subtitle: ConcertDisplayHelper.dateRange(for: concert),
             secondaryText: concert.artist,
-            badge: .status(text: ConcertDisplayText.statusBadge(for: concert), remainDays: nil),
+            badge: .status(text: ConcertDisplayHelper.statusBadge(for: concert), remainDays: nil),
             onTap: { coordinator?.showConcertDetail(concertID: concert.id) }
         )
         .transition(.opacity.combined(with: .scale(scale: 0.95)))

--- a/Projects/HomeFeature/Sources/Interest/View/Subview/InterestConcertSelectionBottomSectionView.swift
+++ b/Projects/HomeFeature/Sources/Interest/View/Subview/InterestConcertSelectionBottomSectionView.swift
@@ -52,7 +52,7 @@ private extension InterestConcertSelectionBottomSectionView {
         ScrollView(.horizontal, showsIndicators: false) {
             LazyHStack(spacing: 8) {
                 ForEach(selectedConcertList) { concert in
-                    RemovableChip(truncatedTitle(for: ConcertDisplayText.title(for: concert))) {
+                    RemovableChip(truncatedTitle(for: ConcertDisplayHelper.title(for: concert))) {
                         onRemoveSelectedConcert(concert.id)
                     }
                 }

--- a/Projects/HomeFeature/Sources/Interest/View/Subview/InterestConcertSelectionGridView.swift
+++ b/Projects/HomeFeature/Sources/Interest/View/Subview/InterestConcertSelectionGridView.swift
@@ -68,10 +68,10 @@ private extension InterestConcertSelectionGridView {
     func concertCard(for concert: Concert) -> some View {
         LivithCard(
             imageURL: concert.posterURL,
-            title: ConcertDisplayText.title(for: concert),
-            subtitle: ConcertDisplayText.dateRange(for: concert),
+            title: ConcertDisplayHelper.title(for: concert),
+            subtitle: ConcertDisplayHelper.dateRange(for: concert),
             secondaryText: concert.artist,
-            badge: .status(text: ConcertDisplayText.statusBadge(for: concert), remainDays: nil),
+            badge: .status(text: ConcertDisplayHelper.statusBadge(for: concert), remainDays: nil),
             isSelected: selectedConcertIDList.contains(concert.id),
             onTap: { onConcertTap(concert.id) }
         )

--- a/Projects/SearchFeature/Sources/Explore/View/ExploreView.swift
+++ b/Projects/SearchFeature/Sources/Explore/View/ExploreView.swift
@@ -221,10 +221,10 @@ private extension ExploreView {
                 ForEach(store.state.concertList, id: \.id) { concert in
                     LivithCard(
                         imageURL: concert.posterURL,
-                        title: ConcertDisplayText.title(for: concert),
+                        title: ConcertDisplayHelper.title(for: concert),
                         subtitle: concert.formattedStartDate,
                         secondaryText: concert.artist,
-                        badge: .status(text: ConcertDisplayText.statusBadge(for: concert), remainDays: nil),
+                        badge: .status(text: ConcertDisplayHelper.statusBadge(for: concert), remainDays: nil),
                         onTap: {
                             AmplitudeService.shared.trackEvent(tag: .click(.searchCell))
                             coordinator?.showConcertDetail(concertID: concert.id)

--- a/Projects/SearchFeature/Sources/Extension/Concert+Extension.swift
+++ b/Projects/SearchFeature/Sources/Extension/Concert+Extension.swift
@@ -13,6 +13,6 @@ import Domain
 
 extension Concert {
     var formattedStartDate: String {
-        ConcertDisplayText.dateRange(for: self)
+        ConcertDisplayHelper.dateRange(for: self)
     }
 }

--- a/Projects/SearchFeature/Sources/Search/View/SearchView.swift
+++ b/Projects/SearchFeature/Sources/Search/View/SearchView.swift
@@ -236,10 +236,10 @@ private extension SearchView {
         ForEach(store.state.searchedConcertList, id: \.id) { concert in
             LivithCard(
                 imageURL: concert.posterURL,
-                title: ConcertDisplayText.title(for: concert),
+                title: ConcertDisplayHelper.title(for: concert),
                 subtitle: concert.formattedStartDate,
                 secondaryText: concert.artist,
-                badge: .status(text: ConcertDisplayText.statusBadge(for: concert), remainDays: nil),
+                badge: .status(text: ConcertDisplayHelper.statusBadge(for: concert), remainDays: nil),
                 onTap: {
                     AmplitudeService.shared.trackEvent(tag: .click(.searchCell))
                     hideKeyboard()

--- a/Projects/Shared/DisplaySupport/Sources/ConcertDisplayHelper.swift
+++ b/Projects/Shared/DisplaySupport/Sources/ConcertDisplayHelper.swift
@@ -1,5 +1,5 @@
 //
-//  ConcertDisplayText.swift
+//  ConcertDisplayHelper.swift
 //  DisplaySupport
 //
 //  Created by 김진웅 on 4/29/26.
@@ -11,7 +11,7 @@ import Foundation
 import Domain
 import LivithFoundation
 
-public enum ConcertDisplayText {
+public enum ConcertDisplayHelper {
     public static let unknownVenue = "장소 공개 예정"
     public static let unknownDateRange = "추후 발표"
     public static let unknownDaysLeft = "공연 예정"

--- a/Projects/Shared/DisplaySupport/Sources/InterestConcertDisplayHelper.swift
+++ b/Projects/Shared/DisplaySupport/Sources/InterestConcertDisplayHelper.swift
@@ -48,20 +48,20 @@ public enum InterestConcertDisplayHelper {
     public static func badge(for interestConcert: InterestConcert) -> String {
         let concert = interestConcert.concert
 
-        guard concert.status != .ongoing else {
+        guard concert.status == .upcoming || concert.status == .ongoing else {
+            return concert.status.filterText
+        }
+
+        if isCurrentlyOngoing(concert) {
             return "공연 D-DAY"
         }
 
-        guard concert.status == .upcoming else {
-            return concert.status.filterText
+        if isEnded(concert) {
+            return "종료"
         }
 
         guard let daysLeft = concert.daysLeft else {
             return unknownDaysLeft
-        }
-
-        guard daysLeft != 0 else {
-            return "공연 D-DAY"
         }
 
         guard daysLeft > 0 else {
@@ -72,16 +72,16 @@ public enum InterestConcertDisplayHelper {
     }
 
     public static func bottom(for interestConcert: InterestConcert) -> String {
-        if interestConcert.concert.status == .ongoing {
-            return ongoingConcert
-        }
-
         if isCurrentlyOngoing(interestConcert.concert) {
             return ongoingConcert
         }
 
         if interestConcert.concert.daysLeft == 0 {
             return ongoingConcert
+        }
+
+        if isEnded(interestConcert.concert) {
+            return "콘서트 종료"
         }
 
         let schedule = interestConcert.ticketingSchedule
@@ -120,6 +120,16 @@ private extension InterestConcertDisplayHelper {
         let startDay = calendar.startOfDay(for: startDate)
         let endDay = calendar.startOfDay(for: endDate)
         return startDay <= today && today <= endDay
+    }
+
+    static func isEnded(_ concert: Concert) -> Bool {
+        guard let endDate = concert.endDate else {
+            return false
+        }
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let endDay = calendar.startOfDay(for: endDate)
+        return endDay < today
     }
 
     static func ticketingDate(_ date: Date) -> String {

--- a/Projects/Shared/DisplaySupport/Sources/InterestConcertDisplayHelper.swift
+++ b/Projects/Shared/DisplaySupport/Sources/InterestConcertDisplayHelper.swift
@@ -1,5 +1,5 @@
 //
-//  InterestConcertDisplayText.swift
+//  InterestConcertDisplayHelper.swift
 //  DisplaySupport
 //
 //  Created by 김진웅 on 4/30/26.
@@ -11,11 +11,12 @@ import Foundation
 import Domain
 import LivithFoundation
 
-public enum InterestConcertDisplayText {
+public enum InterestConcertDisplayHelper {
     public static let unknownVenue = "장소 공개 예정"
     public static let unknownDateRange = "추후 발표"
     public static let unknownDaysLeft = "공연 예정"
     public static let unknownTicketingDate = "예매 오픈 예정"
+    public static let ongoingConcert = "콘서트 진행중"
 
     public static func title(for interestConcert: InterestConcert) -> String {
         let concert = interestConcert.concert
@@ -72,11 +73,15 @@ public enum InterestConcertDisplayText {
 
     public static func bottom(for interestConcert: InterestConcert) -> String {
         if interestConcert.concert.status == .ongoing {
-            return "콘서트 진행중"
+            return ongoingConcert
         }
 
         if isCurrentlyOngoing(interestConcert.concert) {
-            return "콘서트 진행중"
+            return ongoingConcert
+        }
+
+        if interestConcert.concert.daysLeft == 0 {
+            return ongoingConcert
         }
 
         let schedule = interestConcert.ticketingSchedule
@@ -105,12 +110,16 @@ public enum InterestConcertDisplayText {
     }
 }
 
-private extension InterestConcertDisplayText {
+private extension InterestConcertDisplayHelper {
     static func isCurrentlyOngoing(_ concert: Concert) -> Bool {
         guard let startDate = concert.startDate, let endDate = concert.endDate else {
             return false
         }
-        return startDate <= .now && .now <= endDate
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let startDay = calendar.startOfDay(for: startDate)
+        let endDay = calendar.startOfDay(for: endDate)
+        return startDay <= today && today <= endDay
     }
 
     static func ticketingDate(_ date: Date) -> String {

--- a/Projects/Shared/DisplaySupport/Tests/ConcertDisplayHelperTests.swift
+++ b/Projects/Shared/DisplaySupport/Tests/ConcertDisplayHelperTests.swift
@@ -1,5 +1,5 @@
 //
-//  ConcertDisplayTextTests.swift
+//  ConcertDisplayHelperTests.swift
 //  DisplaySupportTests
 //
 //  Created by 김진웅 on 4/29/26.
@@ -13,14 +13,14 @@ import Domain
 
 import Testing
 
-struct ConcertDisplayTextTests {
+struct ConcertDisplayHelperTests {
     @Test("공연명이 없으면 아티스트 내한 예정 문구를 표시해야 한다")
     func 공연명이_없으면_아티스트_내한_예정_문구를_표시해야_한다() {
         // Given
         let concert = makeConcert(title: nil)
 
         // When
-        let title = ConcertDisplayText.title(for: concert)
+        let title = ConcertDisplayHelper.title(for: concert)
 
         // Then
         #expect(title == "Taylor Swift 내한 예정")
@@ -32,7 +32,7 @@ struct ConcertDisplayTextTests {
         let concert = makeConcert(title: "  ")
 
         // When
-        let title = ConcertDisplayText.title(for: concert)
+        let title = ConcertDisplayHelper.title(for: concert)
 
         // Then
         #expect(title == "Taylor Swift 내한 예정")
@@ -44,7 +44,7 @@ struct ConcertDisplayTextTests {
         let concert = makeConcert(venue: nil)
 
         // When
-        let venue = ConcertDisplayText.venue(for: concert)
+        let venue = ConcertDisplayHelper.venue(for: concert)
 
         // Then
         #expect(venue == "장소 공개 예정")
@@ -56,7 +56,7 @@ struct ConcertDisplayTextTests {
         let concert = makeConcert(venue: "  ")
 
         // When
-        let venue = ConcertDisplayText.venue(for: concert)
+        let venue = ConcertDisplayHelper.venue(for: concert)
 
         // Then
         #expect(venue == "장소 공개 예정")
@@ -68,7 +68,7 @@ struct ConcertDisplayTextTests {
         let concert = makeConcert(startDate: nil)
 
         // When
-        let dateRange = ConcertDisplayText.dateRange(for: concert)
+        let dateRange = ConcertDisplayHelper.dateRange(for: concert)
 
         // Then
         #expect(dateRange == "추후 발표")
@@ -80,7 +80,7 @@ struct ConcertDisplayTextTests {
         let concert = makeConcert(daysLeft: nil)
 
         // When
-        let daysLeft = ConcertDisplayText.daysLeft(for: concert)
+        let daysLeft = ConcertDisplayHelper.daysLeft(for: concert)
 
         // Then
         #expect(daysLeft == "공연 예정")
@@ -92,7 +92,7 @@ struct ConcertDisplayTextTests {
         let concert = makeConcert(daysLeft: nil)
 
         // When
-        let badge = ConcertDisplayText.statusBadge(for: concert)
+        let badge = ConcertDisplayHelper.statusBadge(for: concert)
 
         // Then
         #expect(badge == "공연 예정")
@@ -104,7 +104,7 @@ struct ConcertDisplayTextTests {
         let concert = makeConcert(daysLeft: 7)
 
         // When
-        let badge = ConcertDisplayText.statusBadge(for: concert)
+        let badge = ConcertDisplayHelper.statusBadge(for: concert)
 
         // Then
         #expect(badge == "D-7")
@@ -116,7 +116,7 @@ struct ConcertDisplayTextTests {
         let concert = makeConcert(status: .completed, daysLeft: nil)
 
         // When
-        let badge = ConcertDisplayText.statusBadge(for: concert)
+        let badge = ConcertDisplayHelper.statusBadge(for: concert)
 
         // Then
         #expect(badge == "종료")
@@ -128,7 +128,7 @@ struct ConcertDisplayTextTests {
         let concert = makeConcert(daysLeft: 0)
 
         // When
-        let daysLeft = ConcertDisplayText.daysLeft(for: concert)
+        let daysLeft = ConcertDisplayHelper.daysLeft(for: concert)
 
         // Then
         #expect(daysLeft == "진행중")
@@ -140,7 +140,7 @@ struct ConcertDisplayTextTests {
         let concert = makeConcert(status: .upcoming, daysLeft: 0)
 
         // When
-        let badge = ConcertDisplayText.statusBadge(for: concert)
+        let badge = ConcertDisplayHelper.statusBadge(for: concert)
 
         // Then
         #expect(badge == "진행중")
@@ -152,7 +152,7 @@ struct ConcertDisplayTextTests {
         let concert = makeConcert(daysLeft: 7)
 
         // When
-        let daysLeft = ConcertDisplayText.daysLeft(for: concert)
+        let daysLeft = ConcertDisplayHelper.daysLeft(for: concert)
 
         // Then
         #expect(daysLeft == "D-7")
@@ -161,14 +161,14 @@ struct ConcertDisplayTextTests {
     @Test("예매 일정이 없으면 예매 오픈 예정 문구를 표시해야 한다")
     func 예매_일정이_없으면_예매_오픈_예정_문구를_표시해야_한다() {
         // When
-        let ticketingDate = ConcertDisplayText.ticketingDate(nil)
+        let ticketingDate = ConcertDisplayHelper.ticketingDate(nil)
 
         // Then
         #expect(ticketingDate == "예매 오픈 예정")
     }
 }
 
-private extension ConcertDisplayTextTests {
+private extension ConcertDisplayHelperTests {
     func makeConcert(
         title: String? = "Taylor Swift | The Eras Tour",
         status: ConcertStatus = .upcoming,

--- a/Projects/Shared/DisplaySupport/Tests/InterestConcertDisplayHelperTests.swift
+++ b/Projects/Shared/DisplaySupport/Tests/InterestConcertDisplayHelperTests.swift
@@ -1,5 +1,5 @@
 //
-//  InterestConcertDisplayTextTests.swift
+//  InterestConcertDisplayHelperTests.swift
 //  DisplaySupportTests
 //
 //  Created by 김진웅 on 4/30/26.
@@ -14,14 +14,14 @@ import Domain
 import Testing
 
 @Suite("관심 콘서트 표시 문구")
-struct InterestConcertDisplayTextTests {
+struct InterestConcertDisplayHelperTests {
     @Test("공연명이 없으면 아티스트 내한 예정 문구를 표시해야 한다")
     func 공연명이_없으면_아티스트_내한_예정_문구를_표시해야_한다() {
         // Given
         let interestConcert = makeInterestConcert(title: nil)
 
         // When
-        let title = InterestConcertDisplayText.title(for: interestConcert)
+        let title = InterestConcertDisplayHelper.title(for: interestConcert)
 
         // Then
         #expect(title == "Taylor Swift 내한 예정")
@@ -33,7 +33,7 @@ struct InterestConcertDisplayTextTests {
         let interestConcert = makeInterestConcert(venue: nil)
 
         // When
-        let venue = InterestConcertDisplayText.venue(for: interestConcert)
+        let venue = InterestConcertDisplayHelper.venue(for: interestConcert)
 
         // Then
         #expect(venue == "장소 공개 예정")
@@ -45,7 +45,7 @@ struct InterestConcertDisplayTextTests {
         let interestConcert = makeInterestConcert(startDate: nil)
 
         // When
-        let dateRange = InterestConcertDisplayText.dateRange(for: interestConcert)
+        let dateRange = InterestConcertDisplayHelper.dateRange(for: interestConcert)
 
         // Then
         #expect(dateRange == "추후 발표")
@@ -57,7 +57,7 @@ struct InterestConcertDisplayTextTests {
         let interestConcert = makeInterestConcert(daysLeft: nil)
 
         // When
-        let badge = InterestConcertDisplayText.badge(for: interestConcert)
+        let badge = InterestConcertDisplayHelper.badge(for: interestConcert)
 
         // Then
         #expect(badge == "공연 예정")
@@ -69,7 +69,7 @@ struct InterestConcertDisplayTextTests {
         let interestConcert = makeInterestConcert(daysLeft: 0)
 
         // When
-        let badge = InterestConcertDisplayText.badge(for: interestConcert)
+        let badge = InterestConcertDisplayHelper.badge(for: interestConcert)
 
         // Then
         #expect(badge == "공연 D-DAY")
@@ -81,7 +81,7 @@ struct InterestConcertDisplayTextTests {
         let interestConcert = makeInterestConcert(daysLeft: 7)
 
         // When
-        let badge = InterestConcertDisplayText.badge(for: interestConcert)
+        let badge = InterestConcertDisplayHelper.badge(for: interestConcert)
 
         // Then
         #expect(badge == "공연 D-7")
@@ -93,7 +93,7 @@ struct InterestConcertDisplayTextTests {
         let interestConcert = makeInterestConcert(daysLeft: -1)
 
         // When
-        let badge = InterestConcertDisplayText.badge(for: interestConcert)
+        let badge = InterestConcertDisplayHelper.badge(for: interestConcert)
 
         // Then
         #expect(badge == "공연 예정")
@@ -105,7 +105,7 @@ struct InterestConcertDisplayTextTests {
         let interestConcert = makeInterestConcert(status: .canceled)
 
         // When
-        let badge = InterestConcertDisplayText.badge(for: interestConcert)
+        let badge = InterestConcertDisplayHelper.badge(for: interestConcert)
 
         // Then
         #expect(badge == "공연취소")
@@ -117,7 +117,7 @@ struct InterestConcertDisplayTextTests {
         let interestConcert = makeInterestConcert(status: .ongoing)
 
         // When
-        let badge = InterestConcertDisplayText.badge(for: interestConcert)
+        let badge = InterestConcertDisplayHelper.badge(for: interestConcert)
 
         // Then
         #expect(badge == "공연 D-DAY")
@@ -132,7 +132,7 @@ struct InterestConcertDisplayTextTests {
         let interestConcert = makeInterestConcert(status: .upcoming, startDate: startDate, endDate: endDate, preSaleDate: pastTicketingDate, generalSaleDate: pastTicketingDate)
 
         // When
-        let bottom = InterestConcertDisplayText.bottom(for: interestConcert)
+        let bottom = InterestConcertDisplayHelper.bottom(for: interestConcert)
 
         // Then
         #expect(bottom == "콘서트 진행중")
@@ -144,7 +144,7 @@ struct InterestConcertDisplayTextTests {
         let interestConcert = makeInterestConcert(status: .ongoing, daysLeft: nil)
 
         // When
-        let bottom = InterestConcertDisplayText.bottom(for: interestConcert)
+        let bottom = InterestConcertDisplayHelper.bottom(for: interestConcert)
 
         // Then
         #expect(bottom == "콘서트 진행중")
@@ -159,7 +159,7 @@ struct InterestConcertDisplayTextTests {
         let interestConcert = makeInterestConcert(status: .upcoming, startDate: startDate, endDate: endDate, preSaleDate: nil, generalSaleDate: nil)
 
         // When
-        let bottom = InterestConcertDisplayText.bottom(for: interestConcert)
+        let bottom = InterestConcertDisplayHelper.bottom(for: interestConcert)
 
         // Then
         #expect(bottom != "콘서트 진행중")
@@ -171,7 +171,7 @@ struct InterestConcertDisplayTextTests {
         let interestConcert = makeInterestConcert(preSaleDate: ticketingDate, generalSaleDate: laterTicketingDate)
 
         // When
-        let bottom = InterestConcertDisplayText.bottom(for: interestConcert)
+        let bottom = InterestConcertDisplayHelper.bottom(for: interestConcert)
 
         // Then
         #expect(bottom == "선예매 오픈 · 8/22(토) 5:30PM")
@@ -183,7 +183,7 @@ struct InterestConcertDisplayTextTests {
         let interestConcert = makeInterestConcert(preSaleDate: ticketingDate, generalSaleDate: nil)
 
         // When
-        let bottom = InterestConcertDisplayText.bottom(for: interestConcert)
+        let bottom = InterestConcertDisplayHelper.bottom(for: interestConcert)
 
         // Then
         #expect(bottom == "선예매 오픈 · 8/22(토) 5:30PM")
@@ -195,7 +195,7 @@ struct InterestConcertDisplayTextTests {
         let interestConcert = makeInterestConcert(preSaleDate: nil, generalSaleDate: ticketingDate)
 
         // When
-        let bottom = InterestConcertDisplayText.bottom(for: interestConcert)
+        let bottom = InterestConcertDisplayHelper.bottom(for: interestConcert)
 
         // Then
         #expect(bottom == "일반 예매 오픈 · 8/22(토) 5:30PM")
@@ -207,7 +207,7 @@ struct InterestConcertDisplayTextTests {
         let interestConcert = makeInterestConcert(preSaleDate: nil, generalSaleDate: nil)
 
         // When
-        let bottom = InterestConcertDisplayText.bottom(for: interestConcert)
+        let bottom = InterestConcertDisplayHelper.bottom(for: interestConcert)
 
         // Then
         #expect(bottom == "예매 오픈 예정")
@@ -219,10 +219,35 @@ struct InterestConcertDisplayTextTests {
         let interestConcert = makeInterestConcert(daysLeft: nil, preSaleDate: nil, generalSaleDate: nil)
 
         // When
-        let bottom = InterestConcertDisplayText.bottom(for: interestConcert)
+        let bottom = InterestConcertDisplayHelper.bottom(for: interestConcert)
 
         // Then
         #expect(bottom == "예매 오픈 예정")
+    }
+
+    @Test("startDate/endDate가 없고 D-DAY이면 하단 문구는 콘서트 진행중을 표시해야 한다")
+    func startDate_endDate_없고_dday이면_하단_콘서트_진행중() {
+        // Given
+        let interestConcert = makeInterestConcert(daysLeft: 0, startDate: nil, endDate: nil, preSaleDate: nil, generalSaleDate: nil)
+
+        // When
+        let bottom = InterestConcertDisplayHelper.bottom(for: interestConcert)
+
+        // Then
+        #expect(bottom == "콘서트 진행중")
+    }
+
+    @Test("당일 0시 공연이면 하단 문구는 콘서트 진행중을 표시해야 한다")
+    func 당일_0시_공연이면_하단_콘서트_진행중() {
+        // Given
+        let now = Date()
+        let interestConcert = makeInterestConcert(daysLeft: 0, startDate: now, endDate: now, preSaleDate: nil, generalSaleDate: nil)
+
+        // When
+        let bottom = InterestConcertDisplayHelper.bottom(for: interestConcert)
+
+        // Then
+        #expect(bottom == "콘서트 진행중")
     }
 
     @Test("선예매 날짜가 지났고 일반 예매 날짜만 남아있으면 일반 예매 오픈 문구를 표시해야 한다")
@@ -231,7 +256,7 @@ struct InterestConcertDisplayTextTests {
         let interestConcert = makeInterestConcert(preSaleDate: pastTicketingDate, generalSaleDate: ticketingDate)
 
         // When
-        let bottom = InterestConcertDisplayText.bottom(for: interestConcert)
+        let bottom = InterestConcertDisplayHelper.bottom(for: interestConcert)
 
         // Then
         #expect(bottom == "일반 예매 오픈 · 8/22(토) 5:30PM")
@@ -243,14 +268,14 @@ struct InterestConcertDisplayTextTests {
         let interestConcert = makeInterestConcert(preSaleDate: pastTicketingDate, generalSaleDate: pastTicketingDate)
 
         // When
-        let bottom = InterestConcertDisplayText.bottom(for: interestConcert)
+        let bottom = InterestConcertDisplayHelper.bottom(for: interestConcert)
 
         // Then
         #expect(bottom == "일반 예매 오픈 · 1/1(목) 9:00AM")
     }
 }
 
-private extension InterestConcertDisplayTextTests {
+private extension InterestConcertDisplayHelperTests {
     var pastTicketingDate: Date {
         Date(timeIntervalSince1970: 0)
     }

--- a/Projects/Shared/DisplaySupport/Tests/InterestConcertDisplayHelperTests.swift
+++ b/Projects/Shared/DisplaySupport/Tests/InterestConcertDisplayHelperTests.swift
@@ -63,10 +63,11 @@ struct InterestConcertDisplayHelperTests {
         #expect(badge == "공연 예정")
     }
 
-    @Test("D-day가 0이면 배지는 공연 D-DAY 문구를 표시해야 한다")
-    func dday가_0이면_배지는_공연_dday_문구를_표시해야_한다() {
+    @Test("D-day가 0이고 공연 기간이면 배지는 공연 D-DAY 문구를 표시해야 한다")
+    func dday가_0이고_공연_기간이면_배지는_공연_dday_문구를_표시해야_한다() {
         // Given
-        let interestConcert = makeInterestConcert(daysLeft: 0)
+        let now = Date()
+        let interestConcert = makeInterestConcert(daysLeft: 0, startDate: now, endDate: now)
 
         // When
         let badge = InterestConcertDisplayHelper.badge(for: interestConcert)
@@ -114,7 +115,8 @@ struct InterestConcertDisplayHelperTests {
     @Test("진행중 공연이면 배지는 공연 D-DAY 문구를 표시해야 한다")
     func 진행중_공연이면_배지는_공연_dday_문구를_표시해야_한다() {
         // Given
-        let interestConcert = makeInterestConcert(status: .ongoing)
+        let now = Date()
+        let interestConcert = makeInterestConcert(status: .ongoing, startDate: now, endDate: now)
 
         // When
         let badge = InterestConcertDisplayHelper.badge(for: interestConcert)
@@ -141,7 +143,8 @@ struct InterestConcertDisplayHelperTests {
     @Test("진행중 공연이면 하단 문구는 콘서트 진행중을 표시해야 한다")
     func 진행중_공연이면_하단_문구는_콘서트_진행중을_표시해야_한다() {
         // Given
-        let interestConcert = makeInterestConcert(status: .ongoing, daysLeft: nil)
+        let now = Date()
+        let interestConcert = makeInterestConcert(status: .ongoing, daysLeft: nil, startDate: now, endDate: now)
 
         // When
         let bottom = InterestConcertDisplayHelper.bottom(for: interestConcert)
@@ -273,6 +276,34 @@ struct InterestConcertDisplayHelperTests {
         // Then
         #expect(bottom == "일반 예매 오픈 · 1/1(목) 9:00AM")
     }
+
+    @Test("종료된 공연이면 배지는 종료 문구를 표시해야 한다")
+    func 종료된_공연이면_배지는_종료_문구를_표시해야_한다() {
+        // Given
+        let now = Date()
+        let yesterday = now.addingTimeInterval(-86400)
+        let interestConcert = makeInterestConcert(startDate: yesterday, endDate: yesterday, preSaleDate: nil, generalSaleDate: nil)
+
+        // When
+        let badge = InterestConcertDisplayHelper.badge(for: interestConcert)
+
+        // Then
+        #expect(badge == "종료")
+    }
+
+    @Test("종료된 공연이면 하단 문구는 콘서트 종료를 표시해야 한다")
+    func 종료된_공연이면_하단_문구는_콘서트_종료를_표시해야_한다() {
+        // Given
+        let now = Date()
+        let yesterday = now.addingTimeInterval(-86400)
+        let interestConcert = makeInterestConcert(startDate: yesterday, endDate: yesterday, preSaleDate: nil, generalSaleDate: nil)
+
+        // When
+        let bottom = InterestConcertDisplayHelper.bottom(for: interestConcert)
+
+        // Then
+        #expect(bottom == "콘서트 종료")
+    }
 }
 
 private extension InterestConcertDisplayHelperTests {
@@ -292,8 +323,8 @@ private extension InterestConcertDisplayHelperTests {
         title: String? = "Taylor Swift | The Eras Tour",
         status: ConcertStatus = .upcoming,
         daysLeft: Int? = 10,
-        startDate: Date? = Date(timeIntervalSince1970: 1_754_760_000),
-        endDate: Date? = Date(timeIntervalSince1970: 1_754_760_000),
+        startDate: Date? = Date(timeIntervalSinceNow: 86400 * 30),
+        endDate: Date? = Date(timeIntervalSinceNow: 86400 * 30),
         venue: String? = "고척스카이돔",
         preSaleDate: Date? = nil,
         generalSaleDate: Date? = nil


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 예매 일정이 없는 관심 콘서트에서 콘서트 당일임에도 하단에 '예매 오픈 예정'이 표시되는 문제를 해결했습니다.
- 이미 종료된 콘서트가 서버로부터 주어져도 '종료'를 표시하도록 방어 로직을 추가했습니다.
- `DisplayText`를 `DisplayHelper`으로 네이밍을 수정했습니다.

|    구현 내용    |   iPhone 16   |
| :-------------: | :----------: |
| 문제상황 1. 콘서트 종료 | <img src = "https://github.com/user-attachments/assets/fa1cd7c2-ad80-440c-a195-79f8aa80b9bf" width=250> |
| 문제상황 2. 콘서트 당일 | <img src = "https://github.com/user-attachments/assets/bef91882-41ba-4f32-b187-9b9d708f20e9" width=250> |
| 종료된 콘서트 | <img src = "https://github.com/user-attachments/assets/6ded25f2-ba54-41a4-ab1b-321644fac5ad" width=250> |
| 콘서트 당일 | <img src = "https://github.com/user-attachments/assets/d4f27567-2942-4915-9426-ea4ecc46553d" width=250> |


## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 구체적인 문제 원인
`InterestConcertDisplayHelper`가 콘서트 진행 상태를 `status` 필드와 `daysLeft`에만 의존해 판단하고 있었습니다. 

그러나:
1. `startDate`/`endDate`가 동일한 날짜일 때, endDate가 `00:00:00`이면 시간 비교(`<= .now`)로는 당일을 제대로 판단하지 못했습니다.
2. 서버에서 `status: UPCOMING`으로 내려주지만 실제 날짜는 이미 지난 경우에도 "공연 예정" / "예매 오픈 예정"으로 표시되었습니다.

### 해결 방법
1. 날짜(일) 단위 비교 도입 — `isCurrentlyOngoing`을 `Calendar.startOfDay`를 사용해 시간이 아닌 날짜 단위로 비교하도록 변경했습니다.
2. `daysLeft == 0` fallback — `startDate`/`endDate`가 `nil`이어서 기간 판단이 불가한 경우, `daysLeft == 0`이면 D-DAY로 간주해 "콘서트 진행중"을 반환합니다.
3. `isEnded` 방어 로직 — `endDate < today`인 경우 배지는 "종료", 하단은 "콘서트 종료"를 표시합니다.
4. `badge` / `bottom`에서 `status` 의존 제거 — `status == .ongoing` 체크를 제거하고 날짜 비교로 통일했습니다.
5. "콘서트 진행중" 상수화 — `ongoingConcert` 상수로 추출했습니다.

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
~서버를 믿지 말자..~

## 🔗 연결된 이슈
- Resolved: LIVD-412
