### PR TITLE
[Refactor] 자동 로그인 로직 개선

### DIFF
--- a/Projects/App/Sources/View/AppRootView.swift
+++ b/Projects/App/Sources/View/AppRootView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 import LivithDesignSystem
 import Domain
 import LoginFeature
+import Persistence
 import DIContainer
 import LivithNetwork
 
@@ -65,6 +66,12 @@ private extension AppRootView {
         guard currentRoute == .launch else { return }
         
         Task {
+            guard fetchLocalUser() != nil else {
+                try? await tokenService.removeToken()
+                await MainActor.run { transition(to: .login) }
+                return
+            }
+            
             do {
                 try await tokenService.refresh()
                 _ = try? await userRepository.fetchUser()
@@ -73,6 +80,10 @@ private extension AppRootView {
                 await MainActor.run { transition(to: .login) }
             }
         }
+    }
+    
+    func fetchLocalUser() -> User? {
+        try? UserDefaultsStorage().fetch(for: .currentUser)
     }
     
     func transition(to route: AppRoute) {

--- a/Projects/App/Sources/View/AppRootView.swift
+++ b/Projects/App/Sources/View/AppRootView.swift
@@ -11,8 +11,8 @@ import SwiftUI
 import LivithDesignSystem
 import Domain
 import LoginFeature
-import Persistence
 import DIContainer
+import LivithNetwork
 
 struct AppRootView: View {
     @State private var currentRoute: AppRoute = .launch
@@ -20,6 +20,7 @@ struct AppRootView: View {
     @State private var showWelcomeSheet: Bool = false
     
     @Injected private var userRepository: UserRepository
+    @Injected private var tokenService: TokenService
     
     var body: some View {
         contentView
@@ -61,33 +62,22 @@ private extension AppRootView {
     }
     
     func handleOnAppear() {
-        if currentRoute != .launch { return }
+        guard currentRoute == .launch else { return }
         
-        let targetRoute: AppRoute
-        do {
-            let _: User = try UserDefaultsStorage().fetch(for: .currentUser)
-            targetRoute = .main
-
-            preloadUser()
-        } catch {
-            targetRoute = .login
-        }
-
         Task {
-            try? await Task.sleep(nanoseconds: UInt64(Constants.startupDelay * 1_000_000_000))
-            await MainActor.run { transition(to: targetRoute) }
+            do {
+                try await tokenService.refresh()
+                _ = try? await userRepository.fetchUser()
+                await MainActor.run { transition(to: .main) }
+            } catch {
+                await MainActor.run { transition(to: .login) }
+            }
         }
     }
     
     func transition(to route: AppRoute) {
         withAnimation(.easeInOut(duration: Constants.animationDuration)) {
             currentRoute = route
-        }
-    }
-    
-    func preloadUser() {
-        Task {
-            _ = try? await userRepository.fetchUser()
         }
     }
 }
@@ -97,6 +87,5 @@ private extension AppRootView {
 private extension AppRootView {
     enum Constants {
         static let animationDuration = 0.5
-        static let startupDelay: TimeInterval = 3.0
     }
 }

--- a/Projects/Core/LivithNetwork/Sources/Token/Token.swift
+++ b/Projects/Core/LivithNetwork/Sources/Token/Token.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 struct Token: Equatable {
-    static let refreshTokenExpirationInterval: TimeInterval = 3 * 24 * 60 * 60
+    static let refreshTokenExpirationInterval: TimeInterval = 10 * 24 * 60 * 60
     
     let accessToken: String
     let refreshToken: String

--- a/Projects/Core/LivithNetwork/Sources/Token/Token.swift
+++ b/Projects/Core/LivithNetwork/Sources/Token/Token.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 struct Token: Equatable {
-    static let refreshTokenExpirationInterval: TimeInterval = 10 * 24 * 60 * 60
+    static let refreshTokenExpirationInterval: TimeInterval = 14 * 24 * 60 * 60
     
     let accessToken: String
     let refreshToken: String


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 앱 실행 시 자동 로그인 로직을 UserDefaults 기반 User 데이터 확인에서 `tokenService.refresh()` 기반으로 개선
- 리프레시 토큰 로컬 만료 시간을 3일 -> 10일로 조정 (백엔드의 14일 대비 4일 보수적)
- 앱 재설치 시 Keychain에 남아있는 이전 토큰으로 인한 자동 로그인 방지 처리

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 자동 로그인 판단
```swift
func handleOnAppear() {
    guard currentRoute == .launch else { return }
    
    Task {
        // 1차: UserDefaults로 재설치 여부 판단
        // (앱 삭제 시 UserDefaults는 사라지고 Keychain은 남음)
        guard fetchLocalUser() != nil else {
            try? await tokenService.removeToken()  // Keychain 잔여물 정리
            await MainActor.run { transition(to: .login) }
            return
        }
        
        // 2차: refresh token 유효성 검증 (로컬 만료 + 서버 검증)
        do {
            try await tokenService.refresh()
            // refresh 성공 시 TokenService 내부에서 새 토큰 저장 완료
            _ = try? await userRepository.fetchUser()  // User 데이터 최신화
            await MainActor.run { transition(to: .main) }
        } catch {
            // refresh 실패 시 TokenService 내부에서
            // handleRefreshTokenExpired() → 토큰 삭제 + reloginRequired 발송
            await MainActor.run { transition(to: .login) }
        }
    }
}

func fetchLocalUser() -> User? {
    try? UserDefaultsStorage().fetch(for: .currentUser)
}
```

### 리프레시 토큰 만료 시간 조정
```swift
// 변경 전: 3일
static let refreshTokenExpirationInterval: TimeInterval = 3 * 24 * 60 * 60

// 변경 후: 10일 (백엔드 14일 대비 4일 먼저 만료)
static let refreshTokenExpirationInterval: TimeInterval = 10 * 24 * 60 * 60
```

### 시나리오별 동작

| 상황 | `currentUser` (UserDefaults) | `refresh()` | 결과 |
|---|---|---|---|
| 진짜 최초 설치 | ❌ 없음 | 호출 안 함 | 로그인 화면 |
| 앱 재설치 | ❌ 없음 | 호출 안 함 + Keychain 정리 | 로그인 화면 |
| 일반 실행 (토큰 유효) | ✅ 있음 | 성공 | 메인 화면 |
| 일반 실행 (10일 초과) | ✅ 있음 | 실패 (로컬 만료) | 로그인 화면 |


## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 자동 로그인 확인: 앱 최초 실행 → 로그인 → 앱 종료 → 재실행 시 메인 화면 진입 여부 확인
- 재설치 시 자동 로그인이 되지 않는 것 확인
- 10일 경과 후 재실행 시 로그인 화면으로 전환되는 것 확인
- 추후 `LivithNetworking` 모듈 마이그레이션 시 `import LivithNetwork`를 `import LivithNetworking`으로 교체하고 `TokenService` → `TokenManager` 사용으로 변경 예정

## 🔗 연결된 이슈
- Resolved: LIVD-421
