### PR TITLE
[Refactor] DebugNetworkPlugin 출력 형식 구조화 및 민감 정보 마스킹

### DIFF
--- a/Projects/App/Sources/LivithApp+InjectDependency.swift
+++ b/Projects/App/Sources/LivithApp+InjectDependency.swift
@@ -60,7 +60,7 @@ private extension LivithApp {
         }
 
         let config = NetworkConfig(baseURL: baseURL)
-        let (client, tokenManager) = NetworkClientBuilder.build(
+        let (client, tokenManager) = NetworkingFactory.build(
             config: config,
             onAuthenticationExpired: onAuthenticationExpired
         )

--- a/Projects/LivithNetworking/Sources/API/HomeAPI.swift
+++ b/Projects/LivithNetworking/Sources/API/HomeAPI.swift
@@ -34,7 +34,8 @@ public enum HomeAPI {
             path: "/users/interest-concerts",
             method: .get,
             task: .query(queryItems),
-            authentication: .required
+            authentication: .required,
+            cache: .enabled
         )
     }
 

--- a/Projects/LivithNetworking/Sources/Foundation/Client/NetworkingFactory.swift
+++ b/Projects/LivithNetworking/Sources/Foundation/Client/NetworkingFactory.swift
@@ -1,5 +1,5 @@
 //
-//  NetworkClientBuilder.swift
+//  NetworkingFactory.swift
 //  LivithNetworking
 //
 //  Created by 김진웅 on 5/27/26.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum NetworkClientBuilder {
+public enum NetworkingFactory {
     public static func build(
         config: NetworkConfig,
         onAuthenticationExpired: @Sendable @escaping () -> Void = {}
@@ -26,10 +26,16 @@ public enum NetworkClientBuilder {
             onRefreshTokenExpired: onAuthenticationExpired
         )
 
+        #if DEBUG
+        let plugins: [any NetworkPlugin] = [DebugNetworkPlugin()]
+        #else
+        let plugins: [any NetworkPlugin] = []
+        #endif
+
         let client = NetworkClient(
             config: config,
             interceptor: AuthInterceptor(tokenManager: tokenManager),
-            plugins: [DebugNetworkPlugin()]
+            plugins: plugins
         )
 
         return (client: client, tokenManager: tokenManager)

--- a/Projects/LivithNetworking/Sources/Foundation/Plugin/DebugNetworkPlugin.swift
+++ b/Projects/LivithNetworking/Sources/Foundation/Plugin/DebugNetworkPlugin.swift
@@ -8,12 +8,61 @@
 
 import Foundation
 
+// MARK: - BodyDisplayMode
+
+/// DebugNetworkPlugin이 Body를 출력하는 방식을 제어합니다.
+///
+/// ```swift
+/// // 전체 출력 (기본값)
+/// DebugNetworkPlugin(bodyDisplayMode: .full)
+///
+/// // 최대 200자까지만 출력하고 나머지는 생략
+/// DebugNetworkPlugin(bodyDisplayMode: .truncated(200))
+///
+/// // Body를 출력하지 않음 (헤더와 상태 코드만 확인할 때 유용)
+/// DebugNetworkPlugin(bodyDisplayMode: .omitted)
+/// ```
+public enum BodyDisplayMode: Sendable {
+    /// Body 전문을 출력합니다.
+    case full
+    /// Body를 지정된 글자 수(maxLength)까지만 출력하고 나머지는 `...(truncated)`로 생략합니다.
+    case truncated(maxLength: Int)
+    /// Body를 출력하지 않습니다. `(omitted)`로 표시됩니다.
+    case omitted
+}
+
+// MARK: - DebugNetworkPlugin
+
+/// 네트워크 요청/응답을 구조화된 박스 프레임으로 출력하는 디버그 플러그인입니다.
+///
+/// REQUEST, RESPONSE, ERROR 블록으로 구분하여 출력하며,
+/// 토큰, 이메일 등 민감 정보는 자동으로 `***` 마스킹됩니다.
+///
+/// ```swift
+/// // 기본 사용
+/// NetworkClient(plugins: [DebugNetworkPlugin()])
+///
+/// // Body 길이 제한 + 커스텀 출력
+/// NetworkClient(plugins: [
+///     DebugNetworkPlugin(
+///         bodyDisplayMode: .truncated(300),
+///         output: { NSLog("[LivithNetworking] %@", $0) }
+///     )
+/// ])
+/// ```
 public struct DebugNetworkPlugin: NetworkPlugin {
+    private let bodyDisplayMode: BodyDisplayMode
     private let output: @Sendable (String) -> Void
 
+    /// DebugNetworkPlugin을 생성합니다.
+    /// - Parameters:
+    ///   - bodyDisplayMode: Body 출력 모드. 기본값은 `.truncated(1000)` (최대 1000자).
+    ///   - output: 로그를 출력할 클로저. 기본값은 `print`.
     public init(
+        bodyDisplayMode: BodyDisplayMode = .truncated(maxLength: 1000),
         output: @escaping @Sendable (String) -> Void = { print($0) }
     ) {
+        self.bodyDisplayMode = bodyDisplayMode
         self.output = output
     }
 
@@ -21,7 +70,15 @@ public struct DebugNetworkPlugin: NetworkPlugin {
         _ request: URLRequest,
         endpoint: NetworkEndpoint
     ) async {
-        output("[요청] \(request.httpMethod ?? "-") \(sanitizedURLString(from: request.url))")
+        var lines: [String] = []
+        lines.append(Self.separator)
+        lines.append("🌐 REQUEST")
+        lines.append("  Method:  \(request.httpMethod ?? "-")")
+        lines.append("  URL:     \(sanitizedURLString(from: request.url))")
+        lines.append("  Headers: \(formatHeaders(request.allHTTPHeaderFields))")
+        lines.append("  Body:    \(formatBody(request.httpBody))")
+        lines.append(Self.separator)
+        output(lines.joined(separator: "\n"))
     }
 
     public func didReceive(
@@ -31,21 +88,112 @@ public struct DebugNetworkPlugin: NetworkPlugin {
     ) async {
         switch result {
         case .success(let response):
-            let status = response.response.statusCode
-            let emoji = (200..<300).contains(status) ? "✅" : "⚠️"
-            output("[\(emoji) \(status)] \(request.httpMethod ?? "-") \(sanitizedURLString(from: request.url))")
+            var lines: [String] = []
+            lines.append(Self.separator)
+            lines.append("📥 RESPONSE")
+            lines.append("  Status:  \(response.response.statusCode) \(statusDescription(response.response.statusCode))")
+            lines.append("  URL:     \(sanitizedURLString(from: request.url))")
+            lines.append("  Body:    \(formatBody(response.data))")
+            lines.append(Self.separator)
+            output(lines.joined(separator: "\n"))
         case .failure(let error):
-            output("[❌ \(errorSummary(error))] \(request.httpMethod ?? "-") \(sanitizedURLString(from: request.url))")
+            var lines: [String] = []
+            lines.append(Self.separator)
+            lines.append("❌ ERROR")
+            lines.append("  Reason:  \(errorSummary(error))")
+            lines.append("  URL:     \(sanitizedURLString(from: request.url))")
+            lines.append(Self.separator)
+            output(lines.joined(separator: "\n"))
         }
     }
 }
 
+// MARK: - Helpers
+
 private extension DebugNetworkPlugin {
+    static let sensitiveKeys: Set<String> = [
+        "accessToken", "refreshToken", "identityToken", "token",
+        "email", "providerID", "providerId"
+    ]
+
+    static let sensitiveHeaders: Set<String> = [
+        "Authorization", "Cookie"
+    ]
+
+    static let separator = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
     func sanitizedURLString(from url: URL?) -> String {
         guard let url else {
             return "-"
         }
         return url.path
+    }
+
+    func formatHeaders(_ headers: [String: String]?) -> String {
+        guard let headers, !headers.isEmpty else {
+            return "(none)"
+        }
+        let entries = headers
+            .map { key, value -> String in
+                let displayValue: String
+                if Self.sensitiveHeaders.contains(key) {
+                    if key.caseInsensitiveCompare("Authorization") == .orderedSame,
+                       value.hasPrefix("Bearer ")
+                    {
+                        displayValue = "Bearer ***"
+                    } else {
+                        displayValue = "***"
+                    }
+                } else {
+                    displayValue = value
+                }
+                return "\(key): \(displayValue)"
+            }
+            .sorted()
+        return "[\(entries.joined(separator: ", "))]"
+    }
+
+    func formatBody(_ data: Data?) -> String {
+        guard let data else {
+            return "(none)"
+        }
+        if case .omitted = bodyDisplayMode {
+            return "(omitted)"
+        }
+        guard let json = try? JSONSerialization.jsonObject(with: data) else {
+            return "(\(data.count) bytes)"
+        }
+        let masked = maskSensitiveValues(in: json)
+        guard let maskedData = try? JSONSerialization.data(
+            withJSONObject: masked,
+            options: [.sortedKeys]
+        ),
+              let string = String(data: maskedData, encoding: .utf8)
+        else {
+            return "(\(data.count) bytes)"
+        }
+        if case .truncated(let maxLength) = bodyDisplayMode, string.count > maxLength {
+            let index = string.index(string.startIndex, offsetBy: maxLength)
+            return "\(string[..<index])...(truncated)"
+        }
+        return string
+    }
+
+    func maskSensitiveValues(in json: Any) -> Any {
+        if let dict = json as? [String: Any] {
+            var result: [String: Any] = [:]
+            for (key, value) in dict {
+                if Self.sensitiveKeys.contains(key) {
+                    result[key] = "***"
+                } else {
+                    result[key] = maskSensitiveValues(in: value)
+                }
+            }
+            return result
+        } else if let array = json as? [Any] {
+            return array.map { maskSensitiveValues(in: $0) }
+        }
+        return json
     }
 
     func errorSummary(_ error: NetworkError) -> String {
@@ -82,6 +230,30 @@ private extension DebugNetworkPlugin {
             return "serverError(\(statusCode))"
         case .unknown:
             return "unknown"
+        }
+    }
+
+    func statusDescription(_ code: Int) -> String {
+        switch code {
+        case 200: return "OK"
+        case 201: return "Created"
+        case 204: return "No Content"
+        case 301: return "Moved Permanently"
+        case 302: return "Found"
+        case 304: return "Not Modified"
+        case 400: return "Bad Request"
+        case 401: return "Unauthorized"
+        case 403: return "Forbidden"
+        case 404: return "Not Found"
+        case 405: return "Method Not Allowed"
+        case 409: return "Conflict"
+        case 422: return "Unprocessable Entity"
+        case 429: return "Too Many Requests"
+        case 500: return "Internal Server Error"
+        case 502: return "Bad Gateway"
+        case 503: return "Service Unavailable"
+        case 504: return "Gateway Timeout"
+        default: return ""
         }
     }
 }

--- a/Projects/LivithNetworking/Tests/Plugin/DebugNetworkPluginTests.swift
+++ b/Projects/LivithNetworking/Tests/Plugin/DebugNetworkPluginTests.swift
@@ -116,8 +116,6 @@ struct DebugNetworkPluginTests {
         #expect(message.contains("***"))
     }
 
-    // MARK: - 새 출력 형식 (실패 예상)
-
     @Test("요청 로그는 REQUEST 블록 멀티라인 포맷으로 출력해야 한다")
     func 요청_로그는_REQUEST_블록_멀티라인_포맷으로_출력해야_한다() async throws {
         let recorder = OutputRecorder()

--- a/Projects/LivithNetworking/Tests/Plugin/DebugNetworkPluginTests.swift
+++ b/Projects/LivithNetworking/Tests/Plugin/DebugNetworkPluginTests.swift
@@ -26,7 +26,9 @@ struct DebugNetworkPluginTests {
         await sut.willSend(request, endpoint: endpoint)
 
         let message = try #require(recorder.messages().first)
-        #expect(message == "[요청] GET /concerts")
+        #expect(message.contains("🌐 REQUEST"))
+        #expect(message.contains("URL:     /concerts"))
+        #expect(!message.contains("token=secret"))
     }
 
     @Test("응답 로그는 status code와 path를 출력해야 한다")
@@ -46,12 +48,12 @@ struct DebugNetworkPluginTests {
         )
 
         let message = try #require(recorder.messages().first)
-        #expect(message.contains("204"))
+        #expect(message.contains("Status:  204"))
         #expect(message.contains("/concerts"))
     }
 
-    @Test("400번대 응답은 ⚠️로 출력해야 한다")
-    func client_error_응답은_경고_이모지로_출력해야_한다() async throws {
+    @Test("400번대 응답은 Bad Request로 표시해야 한다")
+    func client_error_응답은_Bad_Request로_표시해야_한다() async throws {
         let recorder = OutputRecorder()
         let sut = DebugNetworkPlugin { message in
             recorder.append(message)
@@ -67,7 +69,7 @@ struct DebugNetworkPluginTests {
         )
 
         let message = try #require(recorder.messages().first)
-        #expect(message.contains("⚠️"))
+        #expect(message.contains("Status:  400 Bad Request"))
     }
 
     @Test("실패 로그는 에러 요약을 출력해야 한다")
@@ -86,7 +88,9 @@ struct DebugNetworkPluginTests {
         )
 
         let message = try #require(recorder.messages().first)
-        #expect(message == "[❌ unknown] GET /concerts")
+        #expect(message.contains("❌ ERROR"))
+        #expect(message.contains("Reason:  unknown"))
+        #expect(message.contains("/concerts"))
     }
 
     @Test("디버그 로그는 header와 body 원문을 출력하지 않아야 한다")
@@ -105,7 +109,251 @@ struct DebugNetworkPluginTests {
         await sut.willSend(request, endpoint: endpoint)
 
         let message = try #require(recorder.messages().first)
-        #expect(message == "[요청] POST /concerts")
+        #expect(message.contains("🌐 REQUEST"))
+        #expect(!message.contains("secret-token"))
+        #expect(!message.contains("secret-cookie"))
+        #expect(!message.contains("secret-body"))
+        #expect(message.contains("***"))
+    }
+
+    // MARK: - 새 출력 형식 (실패 예상)
+
+    @Test("요청 로그는 REQUEST 블록 멀티라인 포맷으로 출력해야 한다")
+    func 요청_로그는_REQUEST_블록_멀티라인_포맷으로_출력해야_한다() async throws {
+        let recorder = OutputRecorder()
+        let sut = DebugNetworkPlugin { message in
+            recorder.append(message)
+        }
+        var request = URLRequest(url: try #require(URL(string: "https://api.example.com/concerts")))
+        request.httpMethod = "GET"
+        let endpoint = NetworkEndpoint(path: "/concerts", method: .get)
+
+        await sut.willSend(request, endpoint: endpoint)
+
+        let message = try #require(recorder.messages().first)
+        #expect(message.contains("🌐 REQUEST"))
+        #expect(message.contains("Method:  GET"))
+        #expect(message.contains("URL:     /concerts"))
+    }
+
+    @Test("성공 응답 로그는 RESPONSE 블록 멀티라인 포맷으로 출력해야 한다")
+    func 성공_응답_로그는_RESPONSE_블록_멀티라인_포맷으로_출력해야_한다() async throws {
+        let recorder = OutputRecorder()
+        let sut = DebugNetworkPlugin { message in
+            recorder.append(message)
+        }
+        let request = URLRequest(url: try #require(URL(string: "https://api.example.com/concerts")))
+        let response = try HTTPTestResponseFactory().response(statusCode: 200)
+        let endpoint = NetworkEndpoint(path: "/concerts", method: .get)
+
+        await sut.didReceive(
+            .success(NetworkPluginResponse(data: Data(), response: response)),
+            request: request,
+            endpoint: endpoint
+        )
+
+        let message = try #require(recorder.messages().first)
+        #expect(message.contains("📥 RESPONSE"))
+        #expect(message.contains("Status:  200 OK"))
+        #expect(message.contains("URL:     /concerts"))
+    }
+
+    @Test("실패 로그는 ERROR 블록 멀티라인 포맷으로 출력해야 한다")
+    func 실패_로그는_ERROR_블록_멀티라인_포맷으로_출력해야_한다() async throws {
+        let recorder = OutputRecorder()
+        let sut = DebugNetworkPlugin { message in
+            recorder.append(message)
+        }
+        let request = URLRequest(url: try #require(URL(string: "https://api.example.com/concerts")))
+        let endpoint = NetworkEndpoint(path: "/concerts", method: .get)
+
+        await sut.didReceive(
+            .failure(.timeout(SecretError())),
+            request: request,
+            endpoint: endpoint
+        )
+
+        let message = try #require(recorder.messages().first)
+        #expect(message.contains("❌ ERROR"))
+        #expect(message.contains("Reason:  timeout"))
+        #expect(message.contains("URL:     /concerts"))
+    }
+
+    @Test("요청 body가 없으면 (none)으로 출력해야 한다")
+    func 요청_body가_없으면_none으로_출력해야_한다() async throws {
+        let recorder = OutputRecorder()
+        let sut = DebugNetworkPlugin { message in
+            recorder.append(message)
+        }
+        let request = URLRequest(url: try #require(URL(string: "https://api.example.com/concerts")))
+        let endpoint = NetworkEndpoint(path: "/concerts", method: .get)
+
+        await sut.willSend(request, endpoint: endpoint)
+
+        let message = try #require(recorder.messages().first)
+        #expect(message.contains("Body:    (none)"))
+    }
+
+    @Test("JSON body의 민감 키 값은 ***로 마스킹해야 한다")
+    func JSON_body의_민감_키_값은_별표로_마스킹해야_한다() async throws {
+        let recorder = OutputRecorder()
+        let sut = DebugNetworkPlugin { message in
+            recorder.append(message)
+        }
+        var request = URLRequest(url: try #require(URL(string: "https://api.example.com/concerts")))
+        let body = """
+        {"email":"test@test.com","accessToken":"jwt-token-value","nickname":"진웅"}
+        """
+        request.httpBody = Data(body.utf8)
+        let endpoint = NetworkEndpoint(path: "/concerts", method: .post)
+
+        await sut.willSend(request, endpoint: endpoint)
+
+        let message = try #require(recorder.messages().first)
+        #expect(message.contains("\"email\":\"***\""))
+        #expect(message.contains("\"accessToken\":\"***\""))
+        #expect(!message.contains("jwt-token-value"))
+        #expect(!message.contains("test@test.com"))
+        #expect(message.contains("nickname"))
+    }
+
+    @Test("중첩 JSON 객체의 민감 키도 재귀적으로 마스킹해야 한다")
+    func 중첩_JSON_객체의_민감_키도_재귀적으로_마스킹해야_한다() async throws {
+        let recorder = OutputRecorder()
+        let sut = DebugNetworkPlugin { message in
+            recorder.append(message)
+        }
+        let response = try HTTPTestResponseFactory().response(statusCode: 200)
+        let body = """
+        {"user":{"email":"user@test.com","providerID":"pid-123"},"accessToken":"token-abc"}
+        """
+        let endpoint = NetworkEndpoint(path: "/login", method: .post)
+        let request = URLRequest(url: try #require(URL(string: "https://api.example.com/login")))
+
+        await sut.didReceive(
+            .success(NetworkPluginResponse(data: Data(body.utf8), response: response)),
+            request: request,
+            endpoint: endpoint
+        )
+
+        let message = try #require(recorder.messages().first)
+        #expect(message.contains("\"email\":\"***\""))
+        #expect(message.contains("\"providerID\":\"***\""))
+        #expect(message.contains("\"accessToken\":\"***\""))
+        #expect(!message.contains("user@test.com"))
+        #expect(!message.contains("pid-123"))
+        #expect(!message.contains("token-abc"))
+    }
+
+    @Test("Authorization 헤더 값은 ***로 마스킹해야 한다")
+    func Authorization_헤더_값은_별표로_마스킹해야_한다() async throws {
+        let recorder = OutputRecorder()
+        let sut = DebugNetworkPlugin { message in
+            recorder.append(message)
+        }
+        var request = URLRequest(url: try #require(URL(string: "https://api.example.com/concerts")))
+        request.setValue("Bearer secret-jwt-token", forHTTPHeaderField: "Authorization")
+        request.setValue("session-id-abc", forHTTPHeaderField: "Cookie")
+        let endpoint = NetworkEndpoint(path: "/concerts", method: .get)
+
+        await sut.willSend(request, endpoint: endpoint)
+
+        let message = try #require(recorder.messages().first)
+        #expect(message.contains("Authorization: Bearer ***"))
+        #expect(message.contains("Cookie: ***"))
+        #expect(!message.contains("secret-jwt-token"))
+        #expect(!message.contains("session-id-abc"))
+    }
+
+    @Test("민감 헤더가 없으면 Headers에 (none)을 출력해야 한다")
+    func 민감_헤더가_없으면_Headers에_none을_출력해야_한다() async throws {
+        let recorder = OutputRecorder()
+        let sut = DebugNetworkPlugin { message in
+            recorder.append(message)
+        }
+        let request = URLRequest(url: try #require(URL(string: "https://api.example.com/concerts")))
+        let endpoint = NetworkEndpoint(path: "/concerts", method: .get)
+
+        await sut.willSend(request, endpoint: endpoint)
+
+        let message = try #require(recorder.messages().first)
+        #expect(message.contains("Headers: (none)"))
+    }
+
+    @Test("비JSON body는 바이트 수로 출력해야 한다")
+    func 비JSON_body는_바이트_수로_출력해야_한다() async throws {
+        let recorder = OutputRecorder()
+        let sut = DebugNetworkPlugin { message in
+            recorder.append(message)
+        }
+        var request = URLRequest(url: try #require(URL(string: "https://api.example.com/upload")))
+        let bodyData = Data([0x00, 0x01, 0x02, 0x03])
+        request.httpBody = bodyData
+        let endpoint = NetworkEndpoint(path: "/upload", method: .post)
+
+        await sut.willSend(request, endpoint: endpoint)
+
+        let message = try #require(recorder.messages().first)
+        #expect(message.contains("(4 bytes)"))
+    }
+
+    // MARK: - BodyDisplayMode
+
+    @Test("bodyDisplayMode가 omitted일 때 Body는 (omitted)로 출력해야 한다")
+    func bodyDisplayMode가_omitted일_때_Body는_omitted로_출력해야_한다() async throws {
+        let recorder = OutputRecorder()
+        let sut = DebugNetworkPlugin(bodyDisplayMode: .omitted) { message in
+            recorder.append(message)
+        }
+        var request = URLRequest(url: try #require(URL(string: "https://api.example.com/concerts")))
+        request.httpBody = Data("{\"email\":\"test@test.com\"}".utf8)
+        let endpoint = NetworkEndpoint(path: "/concerts", method: .post)
+
+        await sut.willSend(request, endpoint: endpoint)
+
+        let message = try #require(recorder.messages().first)
+        #expect(message.contains("Body:    (omitted)"))
+        #expect(!message.contains("email"))
+    }
+
+    @Test("bodyDisplayMode가 truncated일 때 지정된 길이를 초과하면 생략해야 한다")
+    func bodyDisplayMode가_truncated일_때_지정된_길이를_초과하면_생략해야_한다() async throws {
+        let recorder = OutputRecorder()
+        let sut = DebugNetworkPlugin(bodyDisplayMode: .truncated(maxLength: 20)) { message in
+            recorder.append(message)
+        }
+        var request = URLRequest(url: try #require(URL(string: "https://api.example.com/concerts")))
+        let body = """
+        {"email":"test@test.com","nickname":"very-long-nickname"}
+        """
+        request.httpBody = Data(body.utf8)
+        let endpoint = NetworkEndpoint(path: "/concerts", method: .post)
+
+        await sut.willSend(request, endpoint: endpoint)
+
+        let message = try #require(recorder.messages().first)
+        #expect(message.contains("...(truncated)"))
+        #expect(!message.contains("very-long-nickname"))
+    }
+
+    @Test("bodyDisplayMode가 truncated일 때 길이 이내면 전문을 출력해야 한다")
+    func bodyDisplayMode가_truncated일_때_길이_이내면_전문을_출력해야_한다() async throws {
+        let recorder = OutputRecorder()
+        let sut = DebugNetworkPlugin(bodyDisplayMode: .truncated(maxLength: 200)) { message in
+            recorder.append(message)
+        }
+        var request = URLRequest(url: try #require(URL(string: "https://api.example.com/concerts")))
+        let body = """
+        {"email":"test@test.com"}
+        """
+        request.httpBody = Data(body.utf8)
+        let endpoint = NetworkEndpoint(path: "/concerts", method: .post)
+
+        await sut.willSend(request, endpoint: endpoint)
+
+        let message = try #require(recorder.messages().first)
+        #expect(message.contains("\"email\":\"***\""))
+        #expect(!message.contains("...(truncated)"))
     }
 }
 

--- a/docs/archives/LIVD-424-networking-plugin-debug-output.md
+++ b/docs/archives/LIVD-424-networking-plugin-debug-output.md
@@ -1,0 +1,105 @@
+# LIVD-424 DebugNetworkPlugin 출력 형식 변경
+
+## 배경
+- 현재 `DebugNetworkPlugin`은 한 줄 로그(`[✅ 200] GET /concerts`)만 출력한다.
+- 디버깅 시 응답 body, 헤더 정보 등 더 풍부한 정보가 필요해졌다.
+- 민감 정보(토큰, 이메일, providerID)가 로그에 노출되지 않도록 마스킹이 필요하다.
+
+## 목표
+- REQUEST / RESPONSE / ERROR 블록을 멀티라인 박스 프레임으로 구조화된 출력으로 변경한다.
+- URL은 path만 출력한다 (기존과 동일).
+- 요청 헤더(Authorization, Cookie)의 민감 값은 `***`로 마스킹한다.
+- 요청/응답 body는 JSON으로 포맷팅하고, 민감 키(`accessToken`, `refreshToken`, `identityToken`, `token`, `email`, `providerID`, `providerId`)의 값을 `***`로 마스킹한다.
+- HTTP status code는 설명(`200 OK`)과 함께 출력한다.
+- 오류 발생 시 `❌ ERROR` 블록으로 출력한다.
+
+## 작업 항목
+- [x] 1. 테스트: 새 출력 형식에 대한 실패 테스트 작성
+  - 요청 로그 멀티라인 포맷 검증 (🌐 REQUEST 블록, Method, URL path, Headers 마스킹, Body 마스킹)
+  - 성공 응답 로그 멀티라인 포맷 검증 (📥 RESPONSE 블록, Status 설명, Body 마스킹)
+  - 실패 응답 로그 멀티라인 포맷 검증 (❌ ERROR 블록, Reason)
+  - body 없는 케이스 `(none)` 처리 검증
+  - 비JSON body 처리 검증
+  - 중첩 JSON 마스킹 검증 (예: `{"user": {"email": "test@test.com"}}` → 내부까지 `***` 처리)
+  - 기존 테스트가 새 포맷에 맞게 업데이트
+
+- [x] 2. 구현: Body 포맷팅 및 마스킹
+  - JSON body 파싱 → `[String: Any]` 재귀 탐색 → 민감 키 값 `"***"` 치환 → pretty print
+  - 중첩 객체(`user.email`, `tempUser.email`) 및 배열 내 객체까지 재귀적으로 마스킹
+  - 비JSON body는 바이트 수만 출력
+  - body 없는 경우 `(none)` 출력
+
+- [x] 3. 구현: Header 마스킹
+  - `Authorization`, `Cookie` 값 `***` 처리
+
+- [x] 4. 구현: 새 출력 형식
+  - `willSend`: 🌐 REQUEST 블록 → Method, URL(path), Headers, Body
+  - `didReceive .success`: 📥 RESPONSE 블록 → Status, URL(path), Body
+  - `didReceive .failure`: ❌ ERROR 블록 → Reason, URL(path)
+
+- [x] 5. 검증: 전체 테스트 실행 및 통과 확인
+
+- [x] 6. 구현 리뷰: `impl-review` 스킬을 통해 계획 대비 산출물 검증
+  - 서브에이전트(fork)를 통해 계획 문서(`docs/plans/LIVD-424-networking-plugin-debug-output.md`) 대비 실제 코드 산출물을 리뷰
+  - Critical / Major 이슈 없음 — PASS
+  - 6개 차원(Spec Compliance, Simplicity, Correctness, Consistency, Quality, Fresh Perspective) 모두 통과
+
+## 영향 범위
+| 파일 | 변경 내용 |
+|------|-----------|
+| `Projects/LivithNetworking/Sources/Foundation/Plugin/DebugNetworkPlugin.swift` | 출력 형식 전면 재작성, body/header 포맷터 추가 |
+| `Projects/LivithNetworking/Tests/Plugin/DebugNetworkPluginTests.swift` | 기존 테스트 업데이트 + 새 포맷 검증 테스트 추가 |
+
+## 기술 결정
+
+| 결정 사항 | 선택지 | 결정 | 근거 |
+|-----------|--------|------|------|
+| URL 표시 범위 | path only vs full URL | path only | 민감 쿼리 파라미터 노출 방지, 기존 정책 유지 |
+| Body 마스킹 전략 | 키 기반 vs 휴리스틱 vs 하이브리드 | 키 기반 단독 | 프로젝트 민감 필드가 명확한 키 이름으로 제한됨, 오탐 0건 |
+| 마스킹 대상 키 | — | `accessToken`, `refreshToken`, `identityToken`, `token`, `email`, `providerID`, `providerId` | DTO 전체 분석 결과 |
+| Header 마스킹 대상 | — | `Authorization`, `Cookie` | 토큰/세션 정보 보호 |
+| 비JSON body 처리 | raw 출력 vs 바이트 수 | 바이트 수(`(N bytes)`) | binary body는 디버깅 가치 낮음 |
+| 소요 시간 표시 | 포함 vs 제외 | 제외 | 이번 작업 범위 아님 |
+| Status 코드 설명 | 숫자만 vs 설명 포함 | `200 OK` 형식 | 가독성 |
+
+## 주의 사항
+- body 마스킹은 JSON 파싱 실패 시 원본 body를 출력하지 않는다 (바이트 수만 표시).
+- `NetworkPlugin` 프로토콜 시그니처 변경 없음.
+- 보안 규칙(`docs/rules/security.md`): FCM Token, 인증 응답 원문 노출 없음 확인.
+
+## 출력 포맷 템플릿
+
+### REQUEST (willSend)
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🌐 REQUEST
+  Method:  GET
+  URL:     /concerts
+  Headers: [Authorization: Bearer ***]
+  Body:    {"email":"***","nickname":"진웅"}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### RESPONSE (didReceive .success)
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+📥 RESPONSE
+  Status:  200 OK
+  URL:     /concerts
+  Body:    {"accessToken":"***","user":{"email":"***"}}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### ERROR (didReceive .failure)
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+❌ ERROR
+  Reason:  timeout
+  URL:     /concerts
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+## 검증 방법
+- `xcodebuildmcp`의 `XcodeBuildMCP_test_sim` 도구를 사용하여 테스트 실행 및 통과 확인.
+- `XcodeBuildMCP_build_sim` 도구를 사용하여 빌드 성공 확인.
+- 사전 설정: `XcodeBuildMCP_session_set_defaults`로 scheme(`LivithNetworking`)과 시뮬레이터(`iPhone 16`)를 지정한다.


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- `DebugNetworkPlugin`의 출력 형식을 한 줄 로그에서 멀티라인 박스 프레임으로 구조화
- 요청/응답 body의 민감 정보(토큰, 이메일 등)를 자동 마스킹 (`***`)
- 요청 헤더(`Authorization`, `Cookie`) 값 마스킹
- `BodyDisplayMode` enum을 통해 body 출력 길이 제어 가능 (기본 `.truncated(1000)`)
- `#if DEBUG` 분기로 릴리즈 스킴에서 플러그인 사용 방지
- `NetworkClientBuilder` → `NetworkingFactory`로 네이밍 개선
- 관심 콘서트 조회 API 캐싱 처리


> **출력 예시**
> ```
> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
> 🌐 REQUEST
>   Method:  POST
>   URL:     /login
>   Headers: [Authorization: Bearer ***, Content-Type: application/json]
>   Body:    {"email":"***","identityToken":"***"}
> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
> 📥 RESPONSE
>   Status:  200 OK
>   URL:     /login
>   Body:    {"accessToken":"***","user":{"email":"***"}}
> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
> ```

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### `BodyDisplayMode` — body 출력 유연 제어
```swift
// 최대 1000자 (기본값)
NetworkClient(plugins: [DebugNetworkPlugin()])

// 전체 출력
NetworkClient(plugins: [DebugNetworkPlugin(bodyDisplayMode: .full)])

// Body 생략 (헤더·상태코드만 확인)
NetworkClient(plugins: [DebugNetworkPlugin(bodyDisplayMode: .omitted)])
```

### 민감 정보 마스킹
JSON body를 재귀 파싱하여 `accessToken`, `refreshToken`, `identityToken`, `token`, `email`, `providerID`, `providerId` 키의 값을 `***`로 치환합니다. 중첩 객체와 배열 내부까지 재귀적으로 마스킹합니다.

### 릴리즈 스킴 분기
```swift
// NetworkingFactory.swift
#if DEBUG
let plugins: [any NetworkPlugin] = [DebugNetworkPlugin()]
#else
let plugins: [any NetworkPlugin] = []
#endif
```

## 🔗 연결된 이슈
- Resolved: LIVD-424
