### PR TITLE
[Hotfix] App Store 업로드 IAP precheck 오류 수정

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -56,6 +56,7 @@ platform :ios do
       upload_to_app_store(
         api_key: load_api_key,
         submit_for_review: false,
+        precheck_include_in_app_purchases: false,
         skip_metadata: true,
         skip_screenshots: true,
         force: true


### PR DESCRIPTION
# *PULL REQUEST*

## 📄 작업 내용
- App Store Connect API Key가 지원하지 않는 인앱결제 precheck를 배포 단계에서 제외했습니다.
- 기존 메타데이터 precheck와 앱 바이너리 업로드 동작은 유지합니다.

## 💻 주요 코드 설명
### Fastlane 운영 배포 설정
- `upload_to_app_store`에 `precheck_include_in_app_purchases: false`를 추가했습니다.

## 📚 참고자료
- https://docs.fastlane.tools/actions/appstore/
- https://docs.fastlane.tools/app-store-connect-api/

## 👀 기타 더 이야기해볼 점
- 긴급 배포 복구 작업으로 별도 Linear 이슈 없이 진행했습니다.
- 이번에도 안되면 개발 접겠습니다