### PR TITLE
[Feat] 스플래시 최소 표시 시간 보장

### DIFF
--- a/Projects/App/Sources/View/AppRootView.swift
+++ b/Projects/App/Sources/View/AppRootView.swift
@@ -66,19 +66,29 @@ private extension AppRootView {
         guard currentRoute == .launch else { return }
         
         Task {
-            guard fetchLocalUser() != nil else {
-                try? await tokenManager.remove()
-                await MainActor.run { transition(to: .login) }
-                return
-            }
-            
-            do {
-                try await tokenManager.refresh()
-                _ = try? await userRepository.fetchUser()
-                await MainActor.run { transition(to: .main) }
-            } catch {
-                await MainActor.run { transition(to: .login) }
-            }
+            async let minimumDisplay: Void = sleepMinimumDisplayDuration()
+            let nextRoute = await resolveLaunchRoute()
+            await minimumDisplay
+            await MainActor.run { transition(to: nextRoute) }
+        }
+    }
+    
+    func sleepMinimumDisplayDuration() async {
+        try? await Task.sleep(for: .seconds(Constants.minimumDisplayDuration))
+    }
+    
+    func resolveLaunchRoute() async -> AppRoute {
+        guard fetchLocalUser() != nil else {
+            try? await tokenManager.remove()
+            return .login
+        }
+        
+        do {
+            try await tokenManager.refresh()
+            _ = try? await userRepository.fetchUser()
+            return .main
+        } catch {
+            return .login
         }
     }
     
@@ -97,6 +107,7 @@ private extension AppRootView {
 
 private extension AppRootView {
     enum Constants {
+        static let minimumDisplayDuration = 1
         static let animationDuration = 0.5
     }
 }


### PR DESCRIPTION
# *PULL REQUEST*

## 📄 작업 내용
- 스플래시가 너무 짧게 깜빡이지 않도록, 최소 1초와 세션 판정이 모두 끝난 뒤에만 로그인/메인으로 전환합니다.
- 세션 판정이 1초보다 오래 걸리면 끝날 때까지 스플래시를 유지합니다. 타임아웃은 넣지 않았습니다.

## 💻 주요 코드 설명
### AppRootView 부트스트랩
- `async let`으로 최소 표시 대기와 `resolveLaunchRoute()`를 동시에 실행합니다.
- 기존 분기(로컬 유저 없음 → 로그인, 토큰 갱신 성공 → 메인, 실패 → 로그인)는 그대로 유지합니다.
- 전환 애니메이션 0.5초는 변경하지 않았습니다.

## 🔗 연결된 이슈
- Resolved: LIVD-479